### PR TITLE
[Icon Updates] Update accordion chevron

### DIFF
--- a/src/shared-components/accordion/__snapshots__/test.js.snap
+++ b/src/shared-components/accordion/__snapshots__/test.js.snap
@@ -72,9 +72,9 @@ exports[`<Accordion /> renders disabled accordion 1`] = `
     >
       <svg
         fill="#332e54"
-        height={8}
+        height={16}
         rotate={0}
-        width={8}
+        width={16}
       />
     </div>
   </div>
@@ -158,9 +158,9 @@ exports[`<Accordion /> renders no border accordion 1`] = `
     >
       <svg
         fill="#332e54"
-        height={8}
+        height={16}
         rotate={0}
-        width={8}
+        width={16}
       />
     </div>
   </div>
@@ -245,9 +245,9 @@ exports[`<Accordion /> renders regular accordion 1`] = `
     >
       <svg
         fill="#332e54"
-        height={8}
+        height={16}
         rotate={0}
-        width={8}
+        width={16}
       />
     </div>
   </div>

--- a/src/shared-components/accordion/index.js
+++ b/src/shared-components/accordion/index.js
@@ -99,8 +99,8 @@ class Accordion extends React.Component {
           <ArrowWrapper rightAlign={rightAlignArrow}>
             <ChevronIcon
               rotate={isOpen ? 90 : 0}
-              width={8}
-              height={8}
+              width={16}
+              height={16}
               fill={COLORS.purple}
             />
           </ArrowWrapper>


### PR DESCRIPTION
Asana: https://app.asana.com/0/1156933028783725/1156933028783728/f

After the icon updates, the chevron in the Accordion component appeared too small. Per Elijah, bumping its size to 16x16.

<img width="447" alt="Screen Shot 2020-02-11 at 11 58 20 AM" src="https://user-images.githubusercontent.com/25893608/74273774-d2600d80-4cc5-11ea-8480-d006021c17a0.png">
