### PR TITLE
Update Components: Button, Chip and Tooltip

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -7,7 +7,7 @@ const UTIL_LOCATION = '../../utils/icons';
 // SVGs will not load properly if we do not remove the default rule before adding our own
 function removeDefaultStorybookSvgRule(config) {
   const defaultStorybookLoaderRule = config.module.rules.find(rule =>
-    rule.test.test('.svg')
+    rule.test.test('.svg'),
   );
 
   const ruleWithoutSvg = defaultStorybookLoaderRule.test
@@ -16,7 +16,7 @@ function removeDefaultStorybookSvgRule(config) {
 
   // Removes forward flashes from regexp string before creating new regexp from string
   defaultStorybookLoaderRule.test = new RegExp(
-    ruleWithoutSvg.substr(1, ruleWithoutSvg.length - 2)
+    ruleWithoutSvg.substr(1, ruleWithoutSvg.length - 2),
   );
 }
 
@@ -33,10 +33,6 @@ module.exports = webpackSettings => {
   };
 
   const customRules = [
-    {
-      test: /\.(png|jpe?g|gif)$/,
-      use: [{ loader: 'file-loader', options: {} }],
-    },
     {
       test: /\.svg$/,
       use: [
@@ -70,7 +66,7 @@ module.exports = webpackSettings => {
       allowAsyncCycles: false,
       // set the current working directory for displaying module paths
       cwd: process.cwd(),
-    })
+    }),
   );
 
   return config;

--- a/docs/callout.md
+++ b/docs/callout.md
@@ -21,7 +21,7 @@ import { NeckGlyph } from "radiance-ui/lib/icons";
 </Callout.Container>
 
 <Callout.Container>
-  <Callout icon={<NeckGlyph width={40} height={40} />}>
+  <Callout icon={<NeckGlyph width={48} height={48} />}>
     <strong>We recommend</strong> this bundle because you indicated
     concern about <strong>dry skin</strong> and{' '}
     <strong>body acne</strong>

--- a/docs/chip.md
+++ b/docs/chip.md
@@ -1,25 +1,25 @@
 # Chip
+
+Chips should be used in small spaces to add value to the elements they're nested in. (i.e. "Recommended" on product cards or showing an error on an element in a list.)
+
+These chips can be either Default, Success, or Error. The Secondary is an inverse of the primary chip and should be used on top of photos or illustrations.
+
 ## Usage
 
 ```jsx
 import { Chip } from 'radiance-ui';
 
-<Chip status="success" text="Success" />
+<Chip status="default" text="Default" />
 <Chip status="error" text="Error" />
-<Chip status="pending" text="Pending" />
-<Chip status="closed" text="Closed" />
+<Chip status="success" text="Success" />
+<Chip status="secondary" text="Secondary" />
 ```
 
 <!-- STORY -->
 
 ### Proptypes
-| prop     | propType           | required | default | description                                                                                                                  |
-|----------|--------------------|----------|---------|------------------------------------------------------------------------------------------------------------------------------|
-| text     | string             | yes      | -       | content of chip |
-| status   | string             | yes      | -       | must be one of: 'success', 'error', 'pending', 'closed' |
 
-### Notes
-The `<Chip />` component has variations that alert the user of a
-particular status with a combination of color and text. This component
-does not take any children. Rather, you will need to pass in the content
-of the chip as the `text` prop.
+| prop   | propType | required | default | description                                                |
+| ------ | -------- | -------- | ------- | ---------------------------------------------------------- |
+| text   | string   | yes      | -       | content of chip                                            |
+| status | string   | no       | default | must be one of: 'default', 'success', 'error', 'secondary' |

--- a/docs/tooltip.md
+++ b/docs/tooltip.md
@@ -14,6 +14,14 @@ import { Tooltip } from 'radiance-ui';
 </Tooltip>
 
 <Tooltip
+  hasRestrictedWidth
+  content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec efficitur enim diam, eget fringilla neque efficitur eu. Praesent et ornare risus. Aenean in orci posuere, convallis nulla a, posuere dolor."
+>
+  Hover or Click here to trigger the Tooltip. This tooltip have a
+  restricted width.
+</Tooltip>
+
+<Tooltip
   arrowAlign="left"
   content={
     <span>
@@ -36,18 +44,19 @@ import { Tooltip } from 'radiance-ui';
 
 ### Proptypes
 
-| prop              | propType | required | default  | description                                                                            |
-| ----------------- | -------- | -------- | -------- | -------------------------------------------------------------------------------------- |
-| alignRightPercent | number   | no       | -        | adjust position using %                                                                |
-| alignTopPercent   | number   | no       | -        | adjust position using %                                                                |
-| arrowAlign        | string   | no       | 'middle' | must be one of: 'left', 'middle', 'right'                                              |
-| children          | node     | yes      | -        | content of the trigger element displayed on page                                       |
-| content           | node     | yes      | ''       | content of the tooltip                                                                 |
-| nudgeLeft         | number   | no       | 0        | adjust position using px                                                               |
-| nudgeRight        | number   | no       | 0        | adjust position using px                                                               |
-| nudgeTop          | number   | no       | 0        | adjust position using px                                                               |
-| nudgeBottom       | number   | no       | 0        | adjust position using px                                                               |
-| position          | string   | no       | 'top'    | must be one of: 'top', 'bottom'                                                        |
-| defaultOpen       | bool     | no       | false    | show the tooltip without the need of the trigger                                       |
-| display           | bool     | no       | true     | programatically control the tooltip to never show (false) or function as normal (true) |
-| isSmall           | bool     | no       | false    | small tooltip with very little padding                                                 |
+| prop               | propType | required | default  | description                                                                            |
+| ------------------ | -------- | -------- | -------- | -------------------------------------------------------------------------------------- |
+| alignRightPercent  | number   | no       | -        | adjust position using %                                                                |
+| alignTopPercent    | number   | no       | -        | adjust position using %                                                                |
+| arrowAlign         | string   | no       | 'middle' | must be one of: 'left', 'middle', 'right'                                              |
+| children           | node     | yes      | -        | content of the trigger element displayed on page                                       |
+| content            | node     | yes      | ''       | content of the tooltip                                                                 |
+| defaultOpen        | bool     | no       | false    | show the tooltip without the need of the trigger                                       |
+| display            | bool     | no       | true     | programatically control the tooltip to never show (false) or function as normal (true) |
+| hasRestrictedWidth | bool     | no       | false    | makes the tooltip have a maximun width of 327px                                        |
+| isSmall            | bool     | no       | false    | small tooltip with very little padding                                                 |
+| nudgeLeft          | number   | no       | 0        | adjust position using px                                                               |
+| nudgeRight         | number   | no       | 0        | adjust position using px                                                               |
+| nudgeTop           | number   | no       | 0        | adjust position using px                                                               |
+| nudgeBottom        | number   | no       | 0        | adjust position using px                                                               |
+| position           | string   | no       | 'top'    | must be one of: 'top', 'bottom'                                                        |

--- a/docs/tooltip.md
+++ b/docs/tooltip.md
@@ -1,4 +1,9 @@
 # Tooltip
+
+Tooltips provide additional context to elements or give patients hints about new features or updates.
+
+They can be triggered from an icon or another component (such as a navigation link)
+
 ## Usage
 
 ```jsx
@@ -7,22 +12,42 @@ import { Tooltip } from 'radiance-ui';
 <Tooltip content="Tooltip Content goes here">
   Hover or Click here to trigger the Tooltip with default values
 </Tooltip>
+
+<Tooltip
+  arrowAlign="left"
+  content={
+    <span>
+      <strong>Did you know?</strong>
+      <br />
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Sapiente,
+      dolore! Esse at, aliquid.
+    </span>
+  }
+>
+  Hover here to trigger the tooltip.
+</Tooltip>
+
+<Tooltip content={<strong>3 new</strong>} isSmall arrowAlign="middle">
+  Hover here to trigger the small tooltip.
+</Tooltip>
 ```
 
 <!-- STORY -->
 
 ### Proptypes
-| prop                  | propType         | required | default   | description                                                                                                                  
-|-----------------------|------------------|----------|-----------|------------------------------------------------------------------------------------------------------------------------------|
-| alignRightPercent     | number           | no      | -         | adjust position using % |
-| alignTopPercent       | number           | no      | -         | adjust position using % |
-| arrowAlign            | string           | no      | 'middle'  | must be one of: 'left', 'middle', 'right' |
-| children              | node             | yes     | -         | content of the trigger element displayed on page |
-| content               | node             | yes     | ''        | content of the tooltip |
-| nudgeLeft             | number           | no      | 0         | adjust position using px |
-| nudgeRight            | number           | no      | 0         | adjust position using px |
-| nudgeTop              | number           | no      | 0         | adjust position using px |
-| nudgeBottom           | number           | no      | 0         | adjust position using px |
-| position              | string           | no      | 'top'     | must be one of: 'top', 'bottom' |
-| defaultOpen           | bool             | no      | false     | show the tooltip without the need of the trigger  |
-| display               | bool             | no      | true      | programatically control the tooltip to never show (false) or function as normal (true) |
+
+| prop              | propType | required | default  | description                                                                            |
+| ----------------- | -------- | -------- | -------- | -------------------------------------------------------------------------------------- |
+| alignRightPercent | number   | no       | -        | adjust position using %                                                                |
+| alignTopPercent   | number   | no       | -        | adjust position using %                                                                |
+| arrowAlign        | string   | no       | 'middle' | must be one of: 'left', 'middle', 'right'                                              |
+| children          | node     | yes      | -        | content of the trigger element displayed on page                                       |
+| content           | node     | yes      | ''       | content of the tooltip                                                                 |
+| nudgeLeft         | number   | no       | 0        | adjust position using px                                                               |
+| nudgeRight        | number   | no       | 0        | adjust position using px                                                               |
+| nudgeTop          | number   | no       | 0        | adjust position using px                                                               |
+| nudgeBottom       | number   | no       | 0        | adjust position using px                                                               |
+| position          | string   | no       | 'top'    | must be one of: 'top', 'bottom'                                                        |
+| defaultOpen       | bool     | no       | false    | show the tooltip without the need of the trigger                                       |
+| display           | bool     | no       | true     | programatically control the tooltip to never show (false) or function as normal (true) |
+| isSmall           | bool     | no       | false    | small tooltip with very little padding                                                 |

--- a/src/shared-components/button/__snapshots__/test.js.snap
+++ b/src/shared-components/button/__snapshots__/test.js.snap
@@ -104,7 +104,7 @@ exports[`<Button /> UI snapshots renders with props 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  border-radius: 0;
+  border-radius: 0.25rem;
   border-style: solid;
   border-width: 1px;
   cursor: pointer;

--- a/src/shared-components/button/components/linkButton/__snapshots__/test.js.snap
+++ b/src/shared-components/button/components/linkButton/__snapshots__/test.js.snap
@@ -14,7 +14,7 @@ exports[`<LinkButton/> UI snapshots renders with props 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  border-radius: 0;
+  border-radius: 0.25rem;
   border-style: solid;
   border-width: 1px;
   cursor: pointer;

--- a/src/shared-components/button/components/roundButton/__snapshots__/test.js.snap
+++ b/src/shared-components/button/components/roundButton/__snapshots__/test.js.snap
@@ -122,7 +122,7 @@ exports[`<RoundButton /> UI snapshots renders with props 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  border-radius: 0;
+  border-radius: 0.25rem;
   border-style: solid;
   border-width: 1px;
   cursor: pointer;

--- a/src/shared-components/button/style.js
+++ b/src/shared-components/button/style.js
@@ -122,7 +122,7 @@ export const baseButtonStyles = ({
 }) => css`
   ${TYPOGRAPHY_STYLE.button};
   appearance: none;
-  border-radius: 0;
+  border-radius: ${SPACER.xsmall};
   border-style: solid;
   border-width: 1px;
   cursor: pointer;

--- a/src/shared-components/chip/__snapshots__/test.js.snap
+++ b/src/shared-components/chip/__snapshots__/test.js.snap
@@ -6,24 +6,29 @@ exports[`<Chip /> UI snapshots renders the correct css and text 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border-radius: 1rem;
-  border: 1px solid;
+  border-radius: 0.25rem;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
   height: 1.5rem;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  min-width: 2rem;
-  background-color: #EAF1EB;
-  border-color: #DFE9E0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0 0.5rem;
+  background-color: #2B6E33;
 }
 
 .emotion-2 .emotion-1 {
-  color: #2B6E33;
+  color: #ffffff;
 }
 
 .emotion-0 {
@@ -31,20 +36,8 @@ exports[`<Chip /> UI snapshots renders the correct css and text 1`] = `
   font-size: 0.75rem;
   line-height: 1.67;
   font-weight: bold;
-  -webkit-letter-spacing: 1px;
-  -moz-letter-spacing: 1px;
-  -ms-letter-spacing: 1px;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.5px;
-  -moz-letter-spacing: 0.5px;
-  -ms-letter-spacing: 0.5px;
-  letter-spacing: 0.5px;
-  font-size: 10px;
-  line-height: 1;
-  padding: 0.5rem 12px;
   position: relative;
-  top: 0.5px;
+  top: 1px;
 }
 
 <div

--- a/src/shared-components/chip/index.js
+++ b/src/shared-components/chip/index.js
@@ -10,8 +10,12 @@ const Chip = ({ status, text }) => (
 );
 
 Chip.propTypes = {
-  status: PropTypes.oneOf(['pending', 'success', 'error', 'closed']).isRequired,
+  status: PropTypes.oneOf(['default', 'success', 'error', 'secondary']),
   text: PropTypes.string.isRequired,
+};
+
+Chip.defaultProps = {
+  status: 'default',
 };
 
 export default Chip;

--- a/src/shared-components/chip/style.js
+++ b/src/shared-components/chip/style.js
@@ -2,73 +2,66 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { COLORS, SPACER } from '../../constants';
+import { COLORS, SPACER, TYPOGRAPHY_CONSTANTS } from '../../constants';
 
-/* eslint-disable */
 export const ChipText = styled.span`
-  ${TYPOGRAPHY_STYLE.button};
-  letter-spacing: 0.5px;
-  font-size: 10px;
-  line-height: 1;
-  padding: ${SPACER.small} 12px;
+  ${TYPOGRAPHY_STYLE.label};
+  font-weight: ${TYPOGRAPHY_CONSTANTS.fontWeight.bold};
   position: relative;
-  top: 0.5px;
-`;
-/* eslint-enable */
-
-const closedStyle = css`
-  background-color: ${COLORS.defaultBackground};
-  border-color: ${COLORS.defaultBorder};
-  ${ChipText} {
-    color: ${COLORS.default};
-  }
+  top: 1px;
 `;
 
-const errorStyle = css`
-  background-color: ${COLORS.errorBackground};
-  border-color: ${COLORS.errorBorder};
+const defaultStyle = css`
+  background-color: ${COLORS.purple10};
   ${ChipText} {
-    color: ${COLORS.error};
-  }
-`;
-
-const pendingStyle = css`
-  background-color: ${COLORS.infoBackground};
-  border-color: ${COLORS.infoBorder};
-  ${ChipText} {
-    color: ${COLORS.info};
+    color: ${COLORS.primary};
   }
 `;
 
 const successStyle = css`
-  background-color: ${COLORS.successBackground};
-  border-color: ${COLORS.successBorder};
+  background-color: ${COLORS.success};
   ${ChipText} {
-    color: ${COLORS.success};
+    color: ${COLORS.white};
+  }
+`;
+
+const errorStyle = css`
+  background-color: ${COLORS.error};
+  ${ChipText} {
+    color: ${COLORS.white};
+  }
+`;
+
+const secondaryStyle = css`
+  background-color: ${COLORS.white};
+  ${ChipText} {
+    color: ${COLORS.primary};
   }
 `;
 
 export const ChipStyles = styled.div`
   align-items: center;
-  border-radius: ${SPACER.medium};
-  border: 1px solid;
+  border-radius: ${SPACER.xsmall};
   display: inline-flex;
   height: ${SPACER.large};
+  flex-flow: row nowrap;
   justify-content: center;
-  min-width: ${SPACER.xlarge};
+  align-items: center;
+  padding: 0 ${SPACER.small};
 
   ${({ status }) => {
     switch (status) {
-      case 'pending':
-        return pendingStyle;
-      case 'error':
-        return errorStyle;
+      case 'default':
+        return defaultStyle;
       case 'success':
         return successStyle;
-      case 'closed':
-        return closedStyle;
+      case 'error':
+        return errorStyle;
+      case 'secondary':
+        return secondaryStyle;
+      // support for old pending and closed status will have default styles
       default:
-        break;
+        return defaultStyle;
     }
   }};
 `;

--- a/src/shared-components/indicator/__snapshots__/test.js.snap
+++ b/src/shared-components/indicator/__snapshots__/test.js.snap
@@ -9,14 +9,11 @@ exports[`<Indicator /> UI snapshots renders the correct css and text 1`] = `
   text-align: center;
   padding: 0 0.25rem;
   min-width: 16px;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
   box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;

--- a/src/shared-components/indicator/style.js
+++ b/src/shared-components/indicator/style.js
@@ -12,9 +12,8 @@ export const IndicatorContainer = styled.div`
   text-align: center;
   padding: 0 ${SPACER.xsmall};
   min-width: 16px;
-  width: fit-content;
   box-sizing: border-box;
-  display: flex;
+  display: inline-flex;
   justify-content: center;
   align-items: center;
   border-radius: 8px;

--- a/src/shared-components/tooltip/__snapshots__/test.js.snap
+++ b/src/shared-components/tooltip/__snapshots__/test.js.snap
@@ -43,17 +43,16 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
 }
 
 .emotion-2::after {
-  top: -10px;
-  border-left: 12px solid transparent;
-  border-right: 12px solid transparent;
-  border-bottom: 12px solid #332e54;
+  top: -8px;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-bottom: 8px solid #332e54;
   left: 50%;
-  margin-left: -10px;
+  margin-left: -8px;
   width: 0;
   height: 0;
   content: '';
   position: absolute;
-  margin-top: 3px;
   z-index: 4;
 }
 

--- a/src/shared-components/tooltip/__snapshots__/test.js.snap
+++ b/src/shared-components/tooltip/__snapshots__/test.js.snap
@@ -17,6 +17,7 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
 }
 
 .emotion-6 {
+  max-width: none;
   top: 120%;
   background: #332e54;
   box-shadow: 0px 8px 24px rgba(51,46,84,0.05);

--- a/src/shared-components/tooltip/__snapshots__/test.js.snap
+++ b/src/shared-components/tooltip/__snapshots__/test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
-.emotion-4 {
+.emotion-8 {
   position: relative;
   -webkit-align-items: left;
   -webkit-box-align: left;
@@ -16,7 +16,7 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
   cursor: pointer;
 }
 
-.emotion-2 {
+.emotion-6 {
   top: 120%;
   background: #332e54;
   box-shadow: 0px 8px 24px rgba(51,46,84,0.05);
@@ -42,23 +42,25 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
   display: block;
 }
 
-.emotion-2::after {
-  top: -8px;
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-bottom: 8px solid #332e54;
-  left: 50%;
-  margin-left: -8px;
-  width: 0;
-  height: 0;
-  content: '';
+.emotion-2 {
+  z-index: 5;
+  position: relative;
+}
+
+.emotion-4 {
   position: absolute;
   z-index: 4;
+  top: -8px;
+  -webkit-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  transform: rotate(180deg);
+  left: 50%;
+  margin-left: -10px;
 }
 
 <div>
   <div
-    className="emotion-4 emotion-5"
+    className="emotion-8 emotion-9"
   >
     <div
       className="emotion-0 emotion-1"
@@ -69,10 +71,23 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
       Tooltip Trigger
     </div>
     <div
-      className="emotion-2 emotion-3"
+      className="emotion-6 emotion-7"
       open={false}
     >
-      Tooltip Content
+      <div
+        className="emotion-2 emotion-3"
+      >
+        Tooltip Content
+      </div>
+      <div
+        className="emotion-4 emotion-5"
+      >
+        <svg
+          fill="#332e54"
+          height={16}
+          width={16}
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/src/shared-components/tooltip/__snapshots__/test.js.snap
+++ b/src/shared-components/tooltip/__snapshots__/test.js.snap
@@ -18,13 +18,13 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
 
 .emotion-2 {
   top: 120%;
-  background: #ffffff;
-  border: 1px solid #ededf0;
-  box-shadow: 0 12px 20px 0 rgba(51,46,84,0.05);
-  color: #706D87;
+  background: #332e54;
+  box-shadow: 0px 8px 24px rgba(51,46,84,0.05);
+  border-radius: 0.5rem;
+  color: #ffffff;
   min-width: 100px;
   opacity: 0;
-  padding: 11px 1rem;
+  padding: 1rem;
   pointer-events: none;
   position: absolute;
   -webkit-transform: translateY(-8px);
@@ -44,20 +44,17 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
 
 .emotion-2::after {
   top: -10px;
-  -webkit-transform: rotate(-60deg) skewX(-30deg) scale(1,0.866);
-  -ms-transform: rotate(-60deg) skewX(-30deg) scale(1,0.866);
-  transform: rotate(-60deg) skewX(-30deg) scale(1,0.866);
-  left: 45%;
-  background: #ffffff;
-  border-top-right-radius: 20%;
-  border-color: #ededf0;
-  border-style: solid;
-  border-width: 1px 1px 0 0;
+  border-left: 12px solid transparent;
+  border-right: 12px solid transparent;
+  border-bottom: 12px solid #332e54;
+  left: 50%;
+  margin-left: -10px;
+  width: 0;
+  height: 0;
   content: '';
-  height: 12px;
   position: absolute;
-  width: 12px;
   margin-top: 3px;
+  z-index: 4;
 }
 
 <div>

--- a/src/shared-components/tooltip/arrow.svg
+++ b/src/shared-components/tooltip/arrow.svg
@@ -1,0 +1,1 @@
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 46.29 32.92"><defs><style>.cls-1{fill:#332e54;}</style></defs><title>arrow2</title><path class="cls-1" d="M27.8,39.8a4.63,4.63,0,0,1-7.85,0L.73,9.05H47Z" transform="translate(-0.73 -9.05)"/></svg>

--- a/src/shared-components/tooltip/chevron-icon.svg
+++ b/src/shared-components/tooltip/chevron-icon.svg
@@ -1,4 +1,0 @@
-<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <title>Chevron Icon</title>
-  <path d="M6.87999 12.88L6 12L9.55 8.44L6 4.88L6.87999 4L11.32 8.44L6.87999 12.88Z" fill="currentColor"/>
-</svg>

--- a/src/shared-components/tooltip/chevron-icon.svg
+++ b/src/shared-components/tooltip/chevron-icon.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Chevron Icon</title>
+  <path d="M6.87999 12.88L6 12L9.55 8.44L6 4.88L6.87999 4L11.32 8.44L6.87999 12.88Z" fill="currentColor"/>
+</svg>

--- a/src/shared-components/tooltip/index.js
+++ b/src/shared-components/tooltip/index.js
@@ -3,7 +3,15 @@ import PropTypes from 'prop-types';
 import { Global } from '@emotion/core';
 
 import OffClickWrapper from '../offClickWrapper';
-import { MainContainer, Trigger, TooltipBox } from './style';
+import {
+  MainContainer,
+  Trigger,
+  TooltipBox,
+  TooltipContent,
+  ArrowImageContainer,
+} from './style';
+import ChevronIcon from './chevron-icon.svg';
+import { COLORS } from '../../constants';
 
 const propTypes = {
   alignRightPercent: PropTypes.number,
@@ -120,7 +128,10 @@ class Tooltip extends React.Component {
             position={position}
             isSmall={isSmall}
           >
-            {content}
+            <TooltipContent>{content}</TooltipContent>
+            <ArrowImageContainer arrowAlign={arrowAlign} position={position}>
+              <ChevronIcon width={16} height={16} fill={COLORS.primary} />
+            </ArrowImageContainer>
           </TooltipBox>
         </MainContainer>
       </OffClickWrapper>

--- a/src/shared-components/tooltip/index.js
+++ b/src/shared-components/tooltip/index.js
@@ -10,7 +10,7 @@ import {
   TooltipContent,
   ArrowImageContainer,
 } from './style';
-import ChevronIcon from './chevron-icon.svg';
+import Arrow from './arrow.svg';
 import { COLORS } from '../../constants';
 
 const propTypes = {
@@ -130,7 +130,7 @@ class Tooltip extends React.Component {
           >
             <TooltipContent>{content}</TooltipContent>
             <ArrowImageContainer arrowAlign={arrowAlign} position={position}>
-              <ChevronIcon width={16} height={16} fill={COLORS.primary} />
+              <Arrow width={16} height={16} fill={COLORS.primary} />
             </ArrowImageContainer>
           </TooltipBox>
         </MainContainer>

--- a/src/shared-components/tooltip/index.js
+++ b/src/shared-components/tooltip/index.js
@@ -21,6 +21,7 @@ const propTypes = {
   position: PropTypes.oneOf(['top', 'bottom']),
   defaultOpen: PropTypes.bool,
   display: PropTypes.bool,
+  isSmall: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -33,6 +34,7 @@ const defaultProps = {
   position: 'top',
   defaultOpen: false,
   display: true,
+  isSmall: false,
 };
 
 class Tooltip extends React.Component {
@@ -84,6 +86,7 @@ class Tooltip extends React.Component {
       nudgeRight,
       nudgeTop,
       position,
+      isSmall,
     } = this.props;
     const open = defaultOpen || clicked || hovered;
 
@@ -115,6 +118,7 @@ class Tooltip extends React.Component {
             open={open}
             displayTooltip={display}
             position={position}
+            isSmall={isSmall}
           >
             {content}
           </TooltipBox>

--- a/src/shared-components/tooltip/index.js
+++ b/src/shared-components/tooltip/index.js
@@ -22,27 +22,29 @@ const propTypes = {
     PropTypes.node,
   ]).isRequired,
   content: PropTypes.node,
+  defaultOpen: PropTypes.bool,
+  display: PropTypes.bool,
+  hasRestrictedWidth: PropTypes.bool,
+  isSmall: PropTypes.bool,
   nudgeLeft: PropTypes.number,
   nudgeRight: PropTypes.number,
   nudgeTop: PropTypes.number,
   nudgeBottom: PropTypes.number,
   position: PropTypes.oneOf(['top', 'bottom']),
-  defaultOpen: PropTypes.bool,
-  display: PropTypes.bool,
-  isSmall: PropTypes.bool,
 };
 
 const defaultProps = {
   arrowAlign: 'middle',
   content: '',
+  defaultOpen: false,
+  display: true,
+  hasRestrictedWidth: false,
+  isSmall: false,
   nudgeLeft: 0,
   nudgeRight: 0,
   nudgeTop: 0,
   nudgeBottom: 0,
   position: 'top',
-  defaultOpen: false,
-  display: true,
-  isSmall: false,
 };
 
 class Tooltip extends React.Component {
@@ -89,12 +91,13 @@ class Tooltip extends React.Component {
       content,
       defaultOpen,
       display,
+      hasRestrictedWidth,
+      isSmall,
       nudgeBottom,
       nudgeLeft,
       nudgeRight,
       nudgeTop,
       position,
-      isSmall,
     } = this.props;
     const open = defaultOpen || clicked || hovered;
 
@@ -119,14 +122,15 @@ class Tooltip extends React.Component {
             alignRightPercent={alignRightPercent}
             alignTopPercent={alignTopPercent}
             arrowAlign={arrowAlign}
+            displayTooltip={display}
+            hasRestrictedWidth={hasRestrictedWidth}
+            isSmall={isSmall}
             nudgeLeft={nudgeLeft}
             nudgeRight={nudgeRight}
             nudgeTop={nudgeTop}
             nudgeBottom={nudgeBottom}
             open={open}
-            displayTooltip={display}
             position={position}
-            isSmall={isSmall}
           >
             <TooltipContent>{content}</TooltipContent>
             <ArrowImageContainer arrowAlign={arrowAlign} position={position}>

--- a/src/shared-components/tooltip/style.js
+++ b/src/shared-components/tooltip/style.js
@@ -90,7 +90,8 @@ export const TooltipBox = styled.div`
   color: ${COLORS.white};
   min-width: ${({ isSmall }) => (isSmall ? '0px' : '100px')};
   opacity: ${({ open }) => (open ? '1' : '0')};
-  padding: ${({ isSmall }) => (isSmall ? `0px 8px` : SPACER.medium)};
+  padding: ${({ isSmall }) =>
+    isSmall ? `${SPACER.x2small} ${SPACER.small}` : SPACER.medium};
   pointer-events: none;
   position: absolute;
   transform: ${({ open }) => (open ? 'translateY(0)' : 'translateY(-8px)')};
@@ -107,17 +108,17 @@ export const TooltipBox = styled.div`
       switch (position) {
         case 'bottom':
           return css`
-            top: -10px;
-            border-left: 12px solid transparent;
-            border-right: 12px solid transparent;
-            border-bottom: 12px solid ${COLORS.primary};
+            top: -8px;
+            border-left: 8px solid transparent;
+            border-right: 8px solid transparent;
+            border-bottom: 8px solid ${COLORS.primary};
           `;
         case 'top':
           return css`
-            bottom: -7px;
-            border-left: 12px solid transparent;
-            border-right: 12px solid transparent;
-            border-top: 12px solid ${COLORS.primary};
+            bottom: -8px;
+            border-left: 8px solid transparent;
+            border-right: 8px solid transparent;
+            border-top: 8px solid ${COLORS.primary};
           `;
         default:
           break;
@@ -137,7 +138,7 @@ export const TooltipBox = styled.div`
         case 'middle':
           return css`
             left: 50%;
-            margin-left: -10px;
+            margin-left: -8px;
           `;
         default:
           break;
@@ -148,7 +149,6 @@ export const TooltipBox = styled.div`
     height: 0;
     content: '';
     position: absolute;
-    margin-top: 3px;
     z-index: 4;
   }
 `;

--- a/src/shared-components/tooltip/style.js
+++ b/src/shared-components/tooltip/style.js
@@ -14,6 +14,9 @@ export const Trigger = styled.div`
 `;
 
 export const TooltipBox = styled.div`
+  max-width: ${({ hasRestrictedWidth }) =>
+    hasRestrictedWidth ? '327px' : 'none'};
+
   ${({ position }) => {
     switch (position) {
       case 'bottom':

--- a/src/shared-components/tooltip/style.js
+++ b/src/shared-components/tooltip/style.js
@@ -89,7 +89,7 @@ export const TooltipBox = styled.div`
 
   background: ${COLORS.primary};
   box-shadow: 0px 8px 24px rgba(51, 46, 84, 0.05);
-  border-radius: ${SPACER.small};
+  border-radius: ${({ isSmall }) => (isSmall ? SPACER.xsmall : SPACER.small)};
   color: ${COLORS.white};
   min-width: ${({ isSmall }) => (isSmall ? '0px' : '100px')};
   opacity: ${({ open }) => (open ? '1' : '0')};

--- a/src/shared-components/tooltip/style.js
+++ b/src/shared-components/tooltip/style.js
@@ -118,6 +118,7 @@ export const ArrowImageContainer = styled.div`
       case 'bottom':
         return css`
           top: -8px;
+          transform: rotate(180deg);
         `;
       case 'top':
         return css`

--- a/src/shared-components/tooltip/style.js
+++ b/src/shared-components/tooltip/style.js
@@ -1,12 +1,7 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
-import {
-  COLORS,
-  SPACER,
-  BOX_SHADOWS,
-  TYPOGRAPHY_CONSTANTS,
-} from '../../constants';
+import { COLORS, SPACER, TYPOGRAPHY_CONSTANTS } from '../../constants';
 
 export const MainContainer = styled.div`
   position: relative;
@@ -89,13 +84,13 @@ export const TooltipBox = styled.div`
       bottom: auto;
     `};
 
-  background: ${COLORS.white};
-  border: 1px solid ${COLORS.border};
-  box-shadow: ${BOX_SHADOWS.message};
-  color: ${COLORS.purpleTint2};
-  min-width: 100px;
+  background: ${COLORS.primary};
+  box-shadow: 0px 8px 24px rgba(51, 46, 84, 0.05);
+  border-radius: ${SPACER.small};
+  color: ${COLORS.white};
+  min-width: ${({ isSmall }) => (isSmall ? '0px' : '100px')};
   opacity: ${({ open }) => (open ? '1' : '0')};
-  padding: 11px ${SPACER.medium};
+  padding: ${({ isSmall }) => (isSmall ? `0px 8px` : SPACER.medium)};
   pointer-events: none;
   position: absolute;
   transform: ${({ open }) => (open ? 'translateY(0)' : 'translateY(-8px)')};
@@ -105,7 +100,7 @@ export const TooltipBox = styled.div`
   z-index: 5;
   text-align: left;
   font-size: ${TYPOGRAPHY_CONSTANTS.fontSize.caption};
-  display: ${({ displayTooltip }) => (displayTooltip ? 'block' : 'none')};
+  display: ${({ displayTooltip }) => (displayTooltip ? 'block' : 'block')};
 
   &::after {
     ${({ position }) => {
@@ -113,12 +108,16 @@ export const TooltipBox = styled.div`
         case 'bottom':
           return css`
             top: -10px;
-            transform: rotate(-60deg) skewX(-30deg) scale(1, 0.866);
+            border-left: 12px solid transparent;
+            border-right: 12px solid transparent;
+            border-bottom: 12px solid ${COLORS.primary};
           `;
         case 'top':
           return css`
             bottom: -7px;
-            transform: rotate(-240deg) skewX(-30deg) scale(1, 0.866);
+            border-left: 12px solid transparent;
+            border-right: 12px solid transparent;
+            border-top: 12px solid ${COLORS.primary};
           `;
         default:
           break;
@@ -137,22 +136,19 @@ export const TooltipBox = styled.div`
           `;
         case 'middle':
           return css`
-            left: 45%;
+            left: 50%;
+            margin-left: -10px;
           `;
         default:
           break;
       }
     }};
 
-    background: ${COLORS.white};
-    border-top-right-radius: 20%;
-    border-color: ${COLORS.border};
-    border-style: solid;
-    border-width: 1px 1px 0 0;
+    width: 0;
+    height: 0;
     content: '';
-    height: 12px;
     position: absolute;
-    width: 12px;
     margin-top: 3px;
+    z-index: 4;
   }
 `;

--- a/src/shared-components/tooltip/style.js
+++ b/src/shared-components/tooltip/style.js
@@ -102,53 +102,49 @@ export const TooltipBox = styled.div`
   text-align: left;
   font-size: ${TYPOGRAPHY_CONSTANTS.fontSize.caption};
   display: ${({ displayTooltip }) => (displayTooltip ? 'block' : 'block')};
+`;
 
-  &::after {
-    ${({ position }) => {
-      switch (position) {
-        case 'bottom':
-          return css`
-            top: -8px;
-            border-left: 8px solid transparent;
-            border-right: 8px solid transparent;
-            border-bottom: 8px solid ${COLORS.primary};
-          `;
-        case 'top':
-          return css`
-            bottom: -8px;
-            border-left: 8px solid transparent;
-            border-right: 8px solid transparent;
-            border-top: 8px solid ${COLORS.primary};
-          `;
-        default:
-          break;
-      }
-    }};
+export const TooltipContent = styled.div`
+  z-index: 5;
+  position: relative;
+`;
 
-    ${({ arrowAlign }) => {
-      switch (arrowAlign) {
-        case 'left':
-          return css`
-            left: 10.25%;
-          `;
-        case 'right':
-          return css`
-            right: 10.25%;
-          `;
-        case 'middle':
-          return css`
-            left: 50%;
-            margin-left: -8px;
-          `;
-        default:
-          break;
-      }
-    }};
+export const ArrowImageContainer = styled.div`
+  position: absolute;
+  z-index: 4;
 
-    width: 0;
-    height: 0;
-    content: '';
-    position: absolute;
-    z-index: 4;
-  }
+  ${({ position }) => {
+    switch (position) {
+      case 'bottom':
+        return css`
+          top: -8px;
+        `;
+      case 'top':
+        return css`
+          bottom: -8px;
+        `;
+      default:
+        break;
+    }
+  }};
+
+  ${({ arrowAlign }) => {
+    switch (arrowAlign) {
+      case 'left':
+        return css`
+          left: 10.25%;
+        `;
+      case 'right':
+        return css`
+          right: 10.25%;
+        `;
+      case 'middle':
+        return css`
+          left: 50%;
+          margin-left: -10px;
+        `;
+      default:
+        break;
+    }
+  }};
 `;

--- a/stories/chip/index.js
+++ b/stories/chip/index.js
@@ -3,8 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { withDocs } from 'storybook-readme';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { css } from '@emotion/core';
-
-import ChipReadme from 'docs/chip.md';
+import ChipReadme from 'docs/chip';
 import { Chip, Typography } from 'src/shared-components';
 import { SPACER } from 'src/constants';
 
@@ -21,10 +20,16 @@ stories.add(
           text-align: left;
         `}
       >
-        <Chip status="success" text="Success" />
+        <Chip status="default" text="Default" />
+        <br />
+        <br />
         <Chip status="error" text="Error" />
-        <Chip status="pending" text="Pending" />
-        <Chip status="closed" text="Closed" />
+        <br />
+        <br />
+        <Chip status="success" text="Success" />
+        <br />
+        <br />
+        <Chip status="secondary" text="Secondary" />
         <Typography.Heading
           css={css`
             padding: ${SPACER.large} 0 ${SPACER.medium};
@@ -35,12 +40,12 @@ stories.add(
         <Chip
           status={select(
             'status',
-            ['success', 'error', 'pending', 'closed'],
-            'error'
+            ['default', 'success', 'error', 'secondary'],
+            'default',
           )}
-          text={text('text', 'WHOOPS!')}
+          text={text('text', 'Chip')}
         />
       </div>
     </React.Fragment>
-  ))
+  )),
 );

--- a/stories/tooltip/index.js
+++ b/stories/tooltip/index.js
@@ -19,7 +19,7 @@ const MainContainer = styled.div`
 `;
 
 const TooltipContainer = styled.div`
-  max-width: 300px;
+  max-width: 400px;
 `;
 
 const TriggerContainer = styled.div`
@@ -45,10 +45,18 @@ stories.add(
         Hover or Click here to trigger the Tooltip with default values
       </Tooltip>
       <br />
+      <Tooltip
+        hasRestrictedWidth
+        content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec efficitur enim diam, eget fringilla neque efficitur eu. Praesent et ornare risus. Aenean in orci posuere, convallis nulla a, posuere dolor."
+      >
+        Hover or Click here to trigger the Tooltip. This tooltip have a
+        restricted width.
+      </Tooltip>
+      <br />
       <Typography.Title>With custom content</Typography.Title>
       <div
         css={css`
-          max-width: 328px;
+          max-width: auto;
         `}
       >
         <Tooltip
@@ -87,18 +95,19 @@ stories.add(
 
       <TooltipContainer>
         <Tooltip
-          position={select('Position', positionOptions, 'bottom')}
+          alignRightPercent={number('alignRightPercent', 0)}
+          alignTopPercent={number('alignTopPercent', 0)}
           arrowAlign={select('arrowAlign', arrowAlignOptions, 'right')}
           content={text('Content', 'This is the tooltip text')}
-          alignTopPercent={number('alignTopPercent', 0)}
-          alignRightPercent={number('alignRightPercent', 0)}
+          defaultOpen={boolean('defaultOpen', false)}
+          display={boolean('display', true)}
+          hasRestrictedWidth={boolean('hasRestrictedWidth', false)}
+          isSmall={boolean('isSmall', false)}
           nudgeRight={number('nudgeRight', 0)}
           nudgeLeft={number('nudgeLeft', 0)}
           nudgeTop={number('nudgeTop', 0)}
           nudgeBottom={number('nudgeBottom', 0)}
-          defaultOpen={boolean('defaultOpen', false)}
-          display={boolean('display', true)}
-          isSmall={boolean('isSmall', false)}
+          position={select('Position', positionOptions, 'bottom')}
         >
           <TriggerContainer>Trigger element</TriggerContainer>
         </Tooltip>

--- a/stories/tooltip/index.js
+++ b/stories/tooltip/index.js
@@ -10,8 +10,7 @@ import {
 } from '@storybook/addon-knobs';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
-
-import TooltipReadme from 'docs/tooltip.md';
+import TooltipReadme from 'docs/tooltip';
 import { Tooltip, Typography } from 'src/shared-components';
 import { SPACER, COLORS } from 'src/constants';
 
@@ -41,10 +40,42 @@ stories.add(
   'Usage',
   withDocs(TooltipReadme, () => (
     <MainContainer>
-      <Typography.Heading>Example:</Typography.Heading>
+      <Typography.Heading>Examples:</Typography.Heading>
       <Tooltip content="Tooltip Content goes here">
         Hover or Click here to trigger the Tooltip with default values
       </Tooltip>
+      <br />
+      <Typography.Title>With custom content</Typography.Title>
+      <div
+        css={css`
+          max-width: 328px;
+        `}
+      >
+        <Tooltip
+          arrowAlign="left"
+          content={
+            <span>
+              <strong>Did you know?</strong>
+              <br />
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Sapiente,
+              dolore! Esse at, aliquid.
+            </span>
+          }
+        >
+          Hover here to trigger the tooltip.
+        </Tooltip>
+      </div>
+      <br />
+      <Typography.Title>Small tooltip</Typography.Title>
+      <div
+        css={css`
+          max-width: 328px;
+        `}
+      >
+        <Tooltip content={<strong>3 new</strong>} isSmall arrowAlign="middle">
+          Hover here to trigger the small tooltip.
+        </Tooltip>
+      </div>
 
       <Typography.Heading
         css={css`
@@ -67,10 +98,11 @@ stories.add(
           nudgeBottom={number('nudgeBottom', 0)}
           defaultOpen={boolean('defaultOpen', false)}
           display={boolean('display', true)}
+          isSmall={boolean('isSmall', false)}
         >
           <TriggerContainer>Trigger element</TriggerContainer>
         </Tooltip>
       </TooltipContainer>
     </MainContainer>
-  ))
+  )),
 );


### PR DESCRIPTION
- **Buttons:** Update all buttons to have border radius: 4px.
- **Chip:** new styles, added default and secondary status. deprecated pending and closed status, but they will fallback to default styles if someone provides an incorrect status
-  **Tooltip:** update styles. Fixed arrow center positioning (now the arrow wont get in way of letters and is perfect centered). New `isSmall` prop for smaller tooltips.

### Other minor fixes 
- Callout: fixed doc to use 48x48 glyph
- Indicator: refactored to use same technique as chip using `display: inline-text` instead of `width:content-fit`
- Edit Storybook build (webpack config) that makes images broken. Compare Avatar component in PROD the images are all broken, this fixes that.

### Preview link
https://curology-radiance-pr-204.herokuapp.com/