### PR TITLE
[Hotfix] - SVG styles leaking outside Field component

### DIFF
--- a/src/shared-components/field/__snapshots__/test.js.snap
+++ b/src/shared-components/field/__snapshots__/test.js.snap
@@ -22,7 +22,7 @@ exports[`<Field /> UI Snapshot renders with label and labelFor 1`] = `
   position: relative;
 }
 
-.emotion-6 svg {
+.emotion-6 svg.radiance-field-input-icon {
   opacity: 0;
   position: absolute;
   top: 20px;
@@ -107,6 +107,7 @@ exports[`<Field /> UI Snapshot renders with label and labelFor 1`] = `
     className="emotion-6 emotion-7"
   >
     <svg
+      className="radiance-field-input-icon"
       fill="#BD200F"
     />
     <input
@@ -142,7 +143,7 @@ exports[`<Field /> UI Snapshot renders with label prop 1`] = `
   position: relative;
 }
 
-.emotion-6 svg {
+.emotion-6 svg.radiance-field-input-icon {
   opacity: 0;
   position: absolute;
   top: 20px;
@@ -227,6 +228,7 @@ exports[`<Field /> UI Snapshot renders with label prop 1`] = `
     className="emotion-6 emotion-7"
   >
     <svg
+      className="radiance-field-input-icon"
       fill="#BD200F"
     />
     <input

--- a/src/shared-components/field/index.js
+++ b/src/shared-components/field/index.js
@@ -57,9 +57,12 @@ class Field extends React.Component {
     const showMessages = messagesKeys.length > 0;
     const MessageIcon =
       messagesType === 'success' ? (
-        <CheckmarkIcon fill={COLORS.success} />
+        <CheckmarkIcon
+          fill={COLORS.success}
+          className="radiance-field-input-icon"
+        />
       ) : (
-        <ErrorIcon fill={COLORS.error} />
+        <ErrorIcon fill={COLORS.error} className="radiance-field-input-icon" />
       );
 
     return (

--- a/src/shared-components/field/style.js
+++ b/src/shared-components/field/style.js
@@ -81,7 +81,7 @@ export const Textarea = styled.textarea`
 `;
 
 const applyMessagesStyles = messagesType => css`
-  svg {
+  svg.radiance-field-input-icon {
     opacity: 1;
   }
 
@@ -101,7 +101,7 @@ const applyMessagesStyles = messagesType => css`
 export const InputContainer = styled.div`
   position: relative;
 
-  svg {
+  svg.radiance-field-input-icon {
     opacity: 0;
     position: absolute;
     top: 20px;


### PR DESCRIPTION
- I removed the SVG className selector in the previous [PR](https://github.com/curology/radiance-ui/pull/208/files) because I wasn't sure we needed it. I now remeber I specifically added that class a year ago while redesigning the field component for the first time and the reason was (is) to avoid leaking the styles to nested SVGs (see screenshot Checkbox icon is not showing due to this bug):

This PR restore the className selector to style only the SVG we want to target.

<img width="427" alt="Screen Shot 2020-03-23 at 16 17 36" src="https://user-images.githubusercontent.com/11194969/77354770-1eb95700-6d22-11ea-9d5d-b71857380074.png">
