### PR TITLE
[Hotfix] - Programatically display prop fix

### DIFF
--- a/src/shared-components/tooltip/style.js
+++ b/src/shared-components/tooltip/style.js
@@ -104,7 +104,7 @@ export const TooltipBox = styled.div`
   z-index: 5;
   text-align: left;
   font-size: ${TYPOGRAPHY_CONSTANTS.fontSize.caption};
-  display: ${({ displayTooltip }) => (displayTooltip ? 'block' : 'block')};
+  display: ${({ displayTooltip }) => (displayTooltip ? 'block' : 'none')};
 `;
 
 export const TooltipContent = styled.div`


### PR DESCRIPTION
- I introduced this bug dont know how. Should be like before since I didn't work with the display prop, just reorder the props alphabetically 