### PR TITLE
[Hotfix] - Indicator display style

### DIFF
--- a/src/shared-components/indicator/__snapshots__/test.js.snap
+++ b/src/shared-components/indicator/__snapshots__/test.js.snap
@@ -9,11 +9,14 @@ exports[`<Indicator /> UI snapshots renders the correct css and text 1`] = `
   text-align: center;
   padding: 0 0.25rem;
   min-width: 16px;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
   box-sizing: border-box;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;

--- a/src/shared-components/indicator/style.js
+++ b/src/shared-components/indicator/style.js
@@ -12,8 +12,9 @@ export const IndicatorContainer = styled.div`
   text-align: center;
   padding: 0 ${SPACER.xsmall};
   min-width: 16px;
+  width: fit-content;
   box-sizing: border-box;
-  display: inline-flex;
+  display: flex;
   justify-content: center;
   align-items: center;
   border-radius: 8px;


### PR DESCRIPTION
- I made a change to display the Indicator same as Chips in this PR https://github.com/curology/radiance-ui/pull/204

- Reverting back to its original display mechanism since the Indicator is mostly used floating around and does not have to be displayed inline where it makes more sense with Chips

- Original mechanis is `width: content-fit` this is widely supported according to https://caniuse.com/#feat=mdn-css_properties_width_fit-content