### PR TITLE
Allow passing an empty array of messages to VerificationMessages

### DIFF
--- a/src/shared-components/verificationMessages/__snapshots__/test.js.snap
+++ b/src/shared-components/verificationMessages/__snapshots__/test.js.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<VerificationMessages /> UI snapshot renders content and children 1`] = `
+.emotion-6 {
+  list-style-type: none;
+  margin: 0;
+}
+
+.emotion-0 {
+  color: #706D87;
+  font-size: 0.875rem;
+  line-height: 1.71;
+  color: #BD200F;
+  line-height: 24px;
+}
+
+.emotion-0:last-of-type {
+  margin: 0 0 0.125rem 0;
+}
+
+<ul
+  className="emotion-6 emotion-7"
+>
+  <li
+    className="emotion-0 emotion-1"
+    style={
+      Object {
+        "maxHeight": "48px",
+        "opacity": "1",
+        "transitionDuration": "350ms",
+        "transitionProperty": "max-height, opacity",
+        "transitionTimingFunction": "ease-in-out",
+      }
+    }
+    type="error"
+  >
+    <strong>
+      Uh oh!
+    </strong>
+     This field is required
+  </li>
+  <li
+    className="emotion-0 emotion-1"
+    style={
+      Object {
+        "maxHeight": "48px",
+        "opacity": "1",
+        "transitionDuration": "350ms",
+        "transitionProperty": "max-height, opacity",
+        "transitionTimingFunction": "ease-in-out",
+      }
+    }
+    type="error"
+  >
+    <strong>
+      Uh oh!
+    </strong>
+     Must be at least 3 characters
+  </li>
+  <li
+    className="emotion-0 emotion-1"
+    style={
+      Object {
+        "maxHeight": "48px",
+        "opacity": "1",
+        "transitionDuration": "350ms",
+        "transitionProperty": "max-height, opacity",
+        "transitionTimingFunction": "ease-in-out",
+      }
+    }
+    type="error"
+  >
+    Must contain 1 number
+    , 
+    Must contain 1 symbol
+  </li>
+</ul>
+`;

--- a/src/shared-components/verificationMessages/index.js
+++ b/src/shared-components/verificationMessages/index.js
@@ -13,13 +13,17 @@ const VerificationMessages = ({ messages, centered, type }) => {
   return (
     <TransitionGroup component={centered ? CenteredMessageList : MessageList}>
       {showMessages &&
-        messageKeys.map(key => (
-          <HelperTransition key={key}>
-            <MessageItem type={type}>
-              {formatMessage(messages[key])}
-            </MessageItem>
-          </HelperTransition>
-        ))}
+        messageKeys
+          .filter(
+            key => !Array.isArray(messages[key]) || messages[key].length >= 1,
+          )
+          .map(key => (
+            <HelperTransition key={key}>
+              <MessageItem type={type}>
+                {formatMessage(messages[key])}
+              </MessageItem>
+            </HelperTransition>
+          ))}
     </TransitionGroup>
   );
 };

--- a/src/shared-components/verificationMessages/test.js
+++ b/src/shared-components/verificationMessages/test.js
@@ -35,7 +35,6 @@ describe('<VerificationMessages />', () => {
         required: [],
       };
       const wrapper = shallow(<VerificationMessages messages={messages} />);
-      console.log(wrapper.debug());
       expect(wrapper.html().indexOf('li') === -1).toBe(true);
     });
   });

--- a/src/shared-components/verificationMessages/test.js
+++ b/src/shared-components/verificationMessages/test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
+
+import VerificationMessages from './index';
+
+describe('<VerificationMessages />', () => {
+  describe('UI snapshot', () => {
+    it('renders content and children', () => {
+      const messages = {
+        required: (
+          <React.Fragment>
+            <strong>Uh oh!</strong> This field is required
+          </React.Fragment>
+        ),
+        maxLength: (
+          <React.Fragment>
+            <strong>Uh oh!</strong> Must be at least 3 characters
+          </React.Fragment>
+        ),
+        charactersRequired: ['Must contain 1 number', 'Must contain 1 symbol'],
+      };
+      const component = renderer.create(
+        <VerificationMessages messages={messages} />,
+      );
+
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  describe('when message value is an empty array', () => {
+    it('renders nothing', () => {
+      const messages = {
+        required: [],
+      };
+      const wrapper = shallow(<VerificationMessages messages={messages} />);
+      console.log(wrapper.debug());
+      expect(wrapper.html().indexOf('li') === -1).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Currently passing a `messages` prop with an empty array to `VerificationMessages` causes a TypeError, i.e.

```jsx
 <VerificationMessages messages={ { required: [] } } />
```

This PR adds a filter so we don't attempt to render empty arrays of messages.

See https://github.com/curology/PocketDerm/pull/8609#discussion_r404881354 for more info.