### PR TITLE
[Alerts] use dontTrucateText flag

### DIFF
--- a/docs/alert.md
+++ b/docs/alert.md
@@ -8,7 +8,7 @@ We should avoid using alerts to show flow-level success states (i.e. Cancellatio
 
 Alerts contain some visual marker, an icon `16px` or avatar `32px`
 
-Alerts should have a **bolded** portion of the text that helps inform the user what the alert is about. The text should be short and preferably not extend more than 2 lines. Ellipses (...) will be used to truncate past 2 lines by default. Truncate functionality can be turned off via the prop `truncateText`.
+Alerts should have a **bolded** portion of the text that helps inform the user what the alert is about. The text should be short and preferably not extend more than 2 lines. Ellipses (...) will be used to truncate past 2 lines by default. Truncate text functionality can be turned off via the prop `dontTruncateText`.
 
 Alerts can contain a CTA section. These should be reserved for really important actions. These alerts persists until an action is taken.
 
@@ -56,7 +56,7 @@ import { Alert } from 'radiance-ui';
     }
     duration="sticky"
     avatarSrc={avatarImageSrc}
-    truncateText={false}
+    dontTruncateText
   />
   <Alert
     content={
@@ -76,15 +76,15 @@ import { Alert } from 'radiance-ui';
 
 ### Proptypes
 
-| prop         | propType         | required | default | description                                                                                                             |
-| ------------ | ---------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
-| avatarSrc    | string           | no       | -       | to display a 32x32 small avatar instead of an icon                                                                      |
-| content      | node             | yes      | -       | content of the alert                                                                                                    |
-| ctaContent   | node             | no       | -       | content of the CTA section. The handler can be provided in the `onExit` prop                                            |
-| duration     | number or string | no       | 3       | can be the string `sticky` for the alert to persist or a number in seconds before the alert is automatically dismissed  |
-| truncateText | bool             | no       | true    | truncates text after 2 lines                                                                                            |
-| type         | string           | no       | default | must be one of: 'success', 'error', 'default'                                                                           |
-| onExit       | func             | no       | ()->{}  | function to be called on dismissal of the alert. The function will receive all of the component's props as the argument |
+| prop             | propType         | required | default | description                                                                                                             |
+| ---------------- | ---------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| avatarSrc        | string           | no       | -       | to display a 32x32 small avatar instead of an icon                                                                      |
+| content          | node             | yes      | -       | content of the alert                                                                                                    |
+| ctaContent       | node             | no       | -       | content of the CTA section. The handler can be provided in the `onExit` prop                                            |
+| duration         | number or string | no       | 3       | can be the string `sticky` for the alert to persist or a number in seconds before the alert is automatically dismissed  |
+| dontTruncateText | bool             | no       | false   | prevents text truncate after 2 lines                                                                                    |
+| type             | string           | no       | default | must be one of: 'success', 'error', 'default'                                                                           |
+| onExit           | func             | no       | ()->{}  | function to be called on dismissal of the alert. The function will receive all of the component's props as the argument |
 
 ### Notes
 

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -8,7 +8,7 @@ We should avoid using alerts to show flow-level success states (i.e. Cancellatio
 
 Alerts contain some visual marker, an icon `16px` or avatar `32px`
 
-Alerts should have a **bolded** portion of the text that helps inform the user what the alert is about. The text should be short and preferably not extend more than 2 lines. Ellipses (...) will be used to truncate past 2 lines by default. Truncate text functionality can be turned off via the prop `dontTruncateText`.
+Alerts should have a **bolded** portion of the text that helps inform the user what the alert is about. The text should be short and preferably not extend more than 2 lines. Ellipses (...) will be used to truncate past 2 lines by default. Truncate text functionality can be turned off via the prop `preventTextTruncating`.
 
 Alerts can contain a CTA section. These should be reserved for really important actions. These alerts persists until an action is taken.
 
@@ -56,7 +56,7 @@ import { Alert } from 'radiance-ui';
     }
     duration="sticky"
     avatarSrc={avatarImageSrc}
-    dontTruncateText
+    preventTextTruncating
   />
   <Alert
     content={
@@ -76,15 +76,15 @@ import { Alert } from 'radiance-ui';
 
 ### Proptypes
 
-| prop             | propType         | required | default | description                                                                                                             |
-| ---------------- | ---------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
-| avatarSrc        | string           | no       | -       | to display a 32x32 small avatar instead of an icon                                                                      |
-| content          | node             | yes      | -       | content of the alert                                                                                                    |
-| ctaContent       | node             | no       | -       | content of the CTA section. The handler can be provided in the `onExit` prop                                            |
-| duration         | number or string | no       | 3       | can be the string `sticky` for the alert to persist or a number in seconds before the alert is automatically dismissed  |
-| dontTruncateText | bool             | no       | false   | prevents text truncate after 2 lines                                                                                    |
-| type             | string           | no       | default | must be one of: 'success', 'error', 'default'                                                                           |
-| onExit           | func             | no       | ()->{}  | function to be called on dismissal of the alert. The function will receive all of the component's props as the argument |
+| prop                  | propType         | required | default | description                                                                                                             |
+| --------------------- | ---------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| avatarSrc             | string           | no       | -       | to display a 32x32 small avatar instead of an icon                                                                      |
+| content               | node             | yes      | -       | content of the alert                                                                                                    |
+| ctaContent            | node             | no       | -       | content of the CTA section. The handler can be provided in the `onExit` prop                                            |
+| duration              | number or string | no       | 3       | can be the string `sticky` for the alert to persist or a number in seconds before the alert is automatically dismissed  |
+| preventTextTruncating | bool             | no       | false   | prevents text truncate after 2 lines                                                                                    |
+| type                  | string           | no       | default | must be one of: 'success', 'error', 'default'                                                                           |
+| onExit                | func             | no       | ()->{}  | function to be called on dismissal of the alert. The function will receive all of the component's props as the argument |
 
 ### Notes
 

--- a/src/shared-components/alert/index.js
+++ b/src/shared-components/alert/index.js
@@ -35,7 +35,7 @@ class Alert extends React.Component {
     content: PropTypes.node.isRequired,
     ctaContent: PropTypes.node,
     duration: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    dontTruncateText: PropTypes.bool,
+    preventTextTruncating: PropTypes.bool,
     type: PropTypes.oneOf(['success', 'error', 'default']),
     onExit: PropTypes.func,
   };
@@ -44,7 +44,7 @@ class Alert extends React.Component {
     avatarSrc: '',
     ctaContent: null,
     duration: 3,
-    dontTruncateText: false,
+    preventTextTruncating: false,
     type: 'default',
     onExit: () => undefined,
   };
@@ -60,10 +60,10 @@ class Alert extends React.Component {
   };
 
   componentDidMount() {
-    const { duration, ctaContent, dontTruncateText } = this.props;
+    const { duration, ctaContent, preventTextTruncating } = this.props;
 
     // Truncate text logic
-    if (!dontTruncateText) {
+    if (!preventTextTruncating) {
       const contentElement = this.contentText.current;
       const wordsArray = contentElement.innerHTML.split(' ');
       while (contentElement.scrollHeight > contentElement.offsetHeight) {
@@ -112,7 +112,7 @@ class Alert extends React.Component {
       avatarSrc,
       content,
       ctaContent,
-      dontTruncateText,
+      preventTextTruncating,
       type,
       // need to destructure onExit to avoid passing as AlertContainer attribute with ...rest
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -143,7 +143,7 @@ class Alert extends React.Component {
             )}
           </IconContainer>
           <ContentContainer
-            dontTruncateText={dontTruncateText}
+            preventTextTruncating={preventTextTruncating}
             ref={this.contentText}
           >
             {content}

--- a/src/shared-components/alert/index.js
+++ b/src/shared-components/alert/index.js
@@ -35,7 +35,7 @@ class Alert extends React.Component {
     content: PropTypes.node.isRequired,
     ctaContent: PropTypes.node,
     duration: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    truncateText: PropTypes.bool,
+    dontTruncateText: PropTypes.bool,
     type: PropTypes.oneOf(['success', 'error', 'default']),
     onExit: PropTypes.func,
   };
@@ -44,7 +44,7 @@ class Alert extends React.Component {
     avatarSrc: '',
     ctaContent: null,
     duration: 3,
-    truncateText: true,
+    dontTruncateText: false,
     type: 'default',
     onExit: () => undefined,
   };
@@ -60,10 +60,10 @@ class Alert extends React.Component {
   };
 
   componentDidMount() {
-    const { duration, ctaContent, truncateText } = this.props;
+    const { duration, ctaContent, dontTruncateText } = this.props;
 
     // Truncate text logic
-    if (truncateText) {
+    if (!dontTruncateText) {
       const contentElement = this.contentText.current;
       const wordsArray = contentElement.innerHTML.split(' ');
       while (contentElement.scrollHeight > contentElement.offsetHeight) {
@@ -112,7 +112,7 @@ class Alert extends React.Component {
       avatarSrc,
       content,
       ctaContent,
-      truncateText,
+      dontTruncateText,
       type,
       // need to destructure onExit to avoid passing as AlertContainer attribute with ...rest
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -142,7 +142,10 @@ class Alert extends React.Component {
               <Icon fill={COLORS.white} />
             )}
           </IconContainer>
-          <ContentContainer truncateText={truncateText} ref={this.contentText}>
+          <ContentContainer
+            dontTruncateText={dontTruncateText}
+            ref={this.contentText}
+          >
             {content}
           </ContentContainer>
         </MainContainer>

--- a/src/shared-components/alert/style.js
+++ b/src/shared-components/alert/style.js
@@ -96,7 +96,8 @@ export const MainContainer = styled.div`
 
 export const ContentContainer = styled.div`
   margin: -3px 0 0 ${SPACER.medium};
-  max-height: ${({ dontTruncateText }) => (dontTruncateText ? 'none' : '48px')};
+  max-height: ${({ preventTextTruncating }) =>
+    preventTextTruncating ? 'none' : '48px'};
 `;
 
 export const CtaContent = styled.div`

--- a/src/shared-components/alert/style.js
+++ b/src/shared-components/alert/style.js
@@ -96,7 +96,7 @@ export const MainContainer = styled.div`
 
 export const ContentContainer = styled.div`
   margin: -3px 0 0 ${SPACER.medium};
-  max-height: ${({ truncateText }) => (truncateText ? '48px' : 'none')};
+  max-height: ${({ dontTruncateText }) => (dontTruncateText ? 'none' : '48px')};
 `;
 
 export const CtaContent = styled.div`

--- a/src/shared-components/alert/test.tsx
+++ b/src/shared-components/alert/test.tsx
@@ -3,7 +3,7 @@ import TestRenderer from 'react-test-renderer';
 
 import Alert from './index';
 
-// Note on truncateText prop test: this cannot be tested because element scrollHeight and offsetHeight are not simulated correctly
+// Note on dontTruncateText prop test: this cannot be tested because element scrollHeight and offsetHeight are not simulated correctly
 
 const alertText = 'Your email address was updated successfully!';
 

--- a/src/shared-components/alert/test.tsx
+++ b/src/shared-components/alert/test.tsx
@@ -3,7 +3,7 @@ import TestRenderer from 'react-test-renderer';
 
 import Alert from './index';
 
-// Note on dontTruncateText prop test: this cannot be tested because element scrollHeight and offsetHeight are not simulated correctly
+// Note on preventTextTruncating prop test: this cannot be tested because element scrollHeight and offsetHeight are not simulated correctly
 
 const alertText = 'Your email address was updated successfully!';
 

--- a/stories/alert/index.js
+++ b/stories/alert/index.js
@@ -55,7 +55,7 @@ stories.add(
           }
           duration="sticky"
           avatarSrc={avatarImageSrc}
-          dontTruncateText
+          preventTextTruncating
         />
         <Alert
           content={

--- a/stories/alert/index.js
+++ b/stories/alert/index.js
@@ -55,7 +55,7 @@ stories.add(
           }
           duration="sticky"
           avatarSrc={avatarImageSrc}
-          truncateText={false}
+          dontTruncateText
         />
         <Alert
           content={


### PR DESCRIPTION
- To be more consistent whit our other flags usage it is best to place flags as true when you want to override some default behaviour so I changed the way we check the flag.

When you want full text scenario:

Before `<Alert truncateText={false} ...`

After `<Alert dontTrucateText ....`

This has no impact in Curology since the flag is not being used yet, I was motivated to do this because of the messy code I was doing in https://github.com/curology/PocketDerm/pull/8978 with truncateText={false}