### PR TITLE
Exclude deprecated SPACING constant from story

### DIFF
--- a/stories/constants/index.js
+++ b/stories/constants/index.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { withDocs } from 'storybook-readme';
 import { storiesOf } from '@storybook/react';
 import { css } from '@emotion/core';
-
 import * as CONSTANTS from 'src/constants';
 import { Typography } from 'src/shared-components';
+// eslint-disable-next-line import/extensions
 import ConstantsReadme from 'docs/constants.md';
 
 import renderConstantsMap from './renderConstantsMap';
@@ -14,6 +14,29 @@ import boxShadowsStory from './boxShadowsStory';
 const stories = storiesOf('CONSTANTS', module);
 
 const CONSTANTS_WITH_OWN_STORY = ['COLORS'];
+const DEPRECATED_CONSTANTS = ['SPACING'];
+
+const EXCLUDED_CONSTANTS = [
+  ...CONSTANTS_WITH_OWN_STORY,
+  ...DEPRECATED_CONSTANTS,
+];
+
+const EXCLUDED_CONSTANT_PROPERTIES = {
+  SPACER: ['base'],
+};
+
+const excludeProperties = (category, properties) => {
+  const excludedProperties = EXCLUDED_CONSTANT_PROPERTIES[category];
+
+  return Object.entries(properties).reduce((filtered, [key, value]) => {
+    if (!excludedProperties.includes(key)) {
+      // eslint-disable-next-line no-param-reassign
+      filtered[key] = value;
+    }
+
+    return filtered;
+  }, {});
+};
 
 stories.add(
   'Available Constants',
@@ -24,11 +47,15 @@ stories.add(
       `}
     >
       {Object.keys(CONSTANTS).map(category => {
-        if (CONSTANTS_WITH_OWN_STORY.includes(category)) {
+        if (EXCLUDED_CONSTANTS.includes(category)) {
           return null;
         }
 
-        const categoryConstant = CONSTANTS[category];
+        let categoryConstant = CONSTANTS[category];
+
+        if (EXCLUDED_CONSTANT_PROPERTIES[category]) {
+          categoryConstant = excludeProperties(category, categoryConstant);
+        }
 
         return (
           <div
@@ -43,7 +70,7 @@ stories.add(
         );
       })}
     </div>
-  ))
+  )),
 );
 
 stories.add('COLORS', colorsStory);


### PR DESCRIPTION
This excludes the deprecated `SPACING` constant from the story to avoid confusion.

I also filtered out the `base` property from `SPACER` since we should be only be using `medium`. I've seen some confusion over that.

I haven't looked if `SPACING` or `base` are still in use in the other repos (is/was `base` ever used?), this was just a quick patch so folks aren't using the wrong ones. Might be time to just pull them out completely.

<img width="351" alt="Screen Shot 2020-05-12 at 12 21 12 PM" src="https://user-images.githubusercontent.com/38407520/81737512-0d9ce480-944d-11ea-975a-c66466dab286.png">
