### PR TITLE
Use circle icon for selected radio buttons instead of a checkmark

### DIFF
--- a/src/shared-components/selectorButton/__snapshots__/test.js.snap
+++ b/src/shared-components/selectorButton/__snapshots__/test.js.snap
@@ -241,8 +241,8 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
     >
       <svg
         className="emotion-0"
-        height={16}
-        width={16}
+        height={8}
+        width={8}
       />
     </div>
     <div
@@ -861,8 +861,8 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
     >
       <svg
         className="emotion-0"
-        height={16}
-        width={16}
+        height={8}
+        width={8}
       />
     </div>
     <div
@@ -990,8 +990,8 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
     >
       <svg
         className="emotion-0"
-        height={16}
-        width={16}
+        height={8}
+        width={8}
       />
     </div>
     <div

--- a/src/shared-components/selectorButton/__snapshots__/test.js.snap
+++ b/src/shared-components/selectorButton/__snapshots__/test.js.snap
@@ -98,9 +98,11 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 }
 
 <div
+  aria-checked={true}
   className="emotion-9 emotion-10"
   onClick={[Function]}
   onKeyPress={[Function]}
+  role="checkbox"
   tabIndex="0"
 >
   <div
@@ -228,9 +230,11 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 }
 
 <div
+  aria-checked={true}
   className="emotion-9 emotion-10"
   onClick={[Function]}
   onKeyPress={[Function]}
+  role="radio"
   tabIndex="0"
 >
   <div
@@ -354,9 +358,11 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for check
 }
 
 <div
+  aria-checked={false}
   className="emotion-8 emotion-9"
   onClick={[Function]}
   onKeyPress={[Function]}
+  role="checkbox"
   tabIndex="0"
 >
   <div
@@ -479,9 +485,11 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for radio
 }
 
 <div
+  aria-checked={false}
   className="emotion-8 emotion-9"
   onClick={[Function]}
   onKeyPress={[Function]}
+  role="radio"
   tabIndex="0"
 >
   <div
@@ -604,9 +612,11 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for checkbox
 }
 
 <div
+  aria-checked={false}
   className="emotion-8 emotion-9"
   onClick={[Function]}
   onKeyPress={[Function]}
+  role="checkbox"
   tabIndex="0"
 >
   <div
@@ -724,9 +734,11 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for radio bu
 }
 
 <div
+  aria-checked={false}
   className="emotion-8 emotion-9"
   onClick={[Function]}
   onKeyPress={[Function]}
+  role="radio"
   tabIndex="0"
 >
   <div
@@ -848,9 +860,11 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
 }
 
 <div
+  aria-checked={true}
   className="emotion-9 emotion-10"
   onClick={[Function]}
   onKeyPress={[Function]}
+  role="radio"
   tabIndex="0"
 >
   <div
@@ -977,9 +991,11 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
 }
 
 <div
+  aria-checked={true}
   className="emotion-9 emotion-10"
   onClick={[Function]}
   onKeyPress={[Function]}
+  role="radio"
   tabIndex="0"
 >
   <div
@@ -1102,9 +1118,11 @@ exports[`<SelectorButton /> UI snapshots when children is a node 1`] = `
 }
 
 <div
+  aria-checked={false}
   className="emotion-8 emotion-9"
   onClick={[Function]}
   onKeyPress={[Function]}
+  role="radio"
   tabIndex="0"
 >
   <div
@@ -1214,9 +1232,11 @@ exports[`<SelectorButton /> UI snapshots when children is undefined 1`] = `
 }
 
 <div
+  aria-checked={false}
   className="emotion-6 emotion-7"
   onClick={[Function]}
   onKeyPress={[Function]}
+  role="radio"
   tabIndex="0"
 >
   <div
@@ -1328,9 +1348,11 @@ exports[`<SelectorButton /> UI snapshots when is checkbox 1`] = `
 }
 
 <div
+  aria-checked={false}
   className="emotion-8 emotion-9"
   onClick={[Function]}
   onKeyPress={[Function]}
+  role="checkbox"
   tabIndex="0"
 >
   <div

--- a/src/shared-components/selectorButton/index.js
+++ b/src/shared-components/selectorButton/index.js
@@ -69,6 +69,8 @@ const SelectorButton = ({
       onKeyPress={onClick}
       tabIndex="0"
       selector={selector}
+      role={selector}
+      aria-checked={checked}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...rest}
     >

--- a/src/shared-components/selectorButton/index.js
+++ b/src/shared-components/selectorButton/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {css} from '@emotion/core';
+import { css } from '@emotion/core';
 
 import CheckmarkIcon from '../../svgs/icons/checkmark-icon.svg';
-import {COLORS} from '../../constants';
+import CircleSolidIcon from '../../svgs/icons/circle-solid-icon.svg';
+import { COLORS } from '../../constants';
 import {
   OuterContainer,
   Selector,
@@ -26,10 +27,12 @@ const propTypes = {
 };
 
 const defaultProps = {
-  onClick: () => {
-  },
+  onClick: undefined,
   type: 'primary',
   selector: 'radio',
+  icon: undefined,
+  children: undefined,
+  size: undefined,
 };
 
 const SelectorButton = ({
@@ -41,38 +44,52 @@ const SelectorButton = ({
   icon,
   size,
   ...rest
-}) => (
-  <OuterContainer
-    onClick={onClick}
-    onKeyPress={onClick}
-    tabIndex="0"
-    selector={selector}
-    {...rest}
-  >
-    <SelectorContainer>
-      <SelectorIcon>
-        {checked ?
-          <CheckmarkIcon
-            css={css`
-              color: ${COLORS.white};
-            `}
-            width={16}
-            height={16}
-          /> :
-          size === 'large' && icon
-        }
-      </SelectorIcon>
-      <Selector type={type} checked={checked} selector={selector} size={size}/>
-    </SelectorContainer>
+}) => {
+  const checkedIcon =
+    selector === 'radio' ? (
+      <CircleSolidIcon
+        css={css`
+          color: ${COLORS.white};
+        `}
+        width={8}
+        height={8}
+      />
+    ) : (
+      <CheckmarkIcon
+        css={css`
+          color: ${COLORS.white};
+        `}
+        width={16}
+        height={16}
+      />
+    );
+  return (
+    <OuterContainer
+      onClick={onClick}
+      onKeyPress={onClick}
+      tabIndex="0"
+      selector={selector}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...rest}
+    >
+      <SelectorContainer>
+        <SelectorIcon>
+          {checked ? checkedIcon : size === 'large' && icon}
+        </SelectorIcon>
+        <Selector
+          type={type}
+          checked={checked}
+          selector={selector}
+          size={size}
+        />
+      </SelectorContainer>
 
-    {children && (
-      <TextContainer>{children}</TextContainer>
-    )}
-  </OuterContainer>
-);
+      {children && <TextContainer>{children}</TextContainer>}
+    </OuterContainer>
+  );
+};
 
 SelectorButton.propTypes = propTypes;
 SelectorButton.defaultProps = defaultProps;
 
 export default SelectorButton;
-

--- a/src/shared-components/selectorButton/test.js
+++ b/src/shared-components/selectorButton/test.js
@@ -175,5 +175,20 @@ describe('<SelectorButton />', () => {
       wrapper.simulate('click');
       expect(spy).toHaveBeenCalled();
     });
+
+    it('Does nothing when no onClick is set', () => {
+      const wrapper = shallow(<SelectorButton checked={false} />);
+      // Just check that no exception is thrown
+      wrapper.simulate('click');
+      wrapper.simulate('keypress', { key: 'Enter' });
+    });
+
+    it('is invoked when enter is pressed', () => {
+      const spy = jest.fn();
+      const wrapper = shallow(<SelectorButton checked={false} onClick={spy} />);
+
+      wrapper.simulate('keypress', { key: 'Enter' });
+      expect(spy).toHaveBeenCalled();
+    });
   });
 });

--- a/src/svgs/icons/circle-solid-icon.svg
+++ b/src/svgs/icons/circle-solid-icon.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <title>Circle Solid Icon</title>
+    <circle cx="8" cy="8" r="7.4" stroke="currentColor" stroke-width="1.2" fill="currentColor"/>
+</svg>

--- a/src/svgs/icons/index.js
+++ b/src/svgs/icons/index.js
@@ -12,6 +12,7 @@ export { default as ChevronIcon } from './chevron-icon.svg';
 export { default as CircleCheckmarkIcon } from './circle-checkmark-icon.svg';
 export { default as CircleMinusIcon } from './circle-minus-icon.svg';
 export { default as CirclePlusIcon } from './circle-plus-icon.svg';
+export { default as CircleSolidIcon } from './circle-solid-icon.svg';
 export { default as ClipboardIcon } from './clipboard-icon.svg';
 export { default as ClockIcon } from './clock-icon.svg';
 export { default as CloudIcon } from './cloud-icon.svg';


### PR DESCRIPTION
A checkmark implies that the radio button can be unselected.  Radio
buttons cannot be unselected.  A white circle is a more consistent
pattern for radio buttons.

Checkboxes will still have a white checkmark.

Also, made some updates to pass the linter.

<img width="328" alt="Screen Shot 2020-05-29 at 10 55 50 AM" src="https://user-images.githubusercontent.com/7872259/83276582-d34a7b80-a19e-11ea-80f9-06b1bedcc450.png">
