### PR TITLE
Update dropdown component max-height

### DIFF
--- a/docs/dropdown/main.md
+++ b/docs/dropdown/main.md
@@ -1,4 +1,5 @@
 # Dropdown
+
 ## Usage
 
 ```jsx
@@ -9,7 +10,7 @@ class DropdownExample extends React.Component {
     { value: 1, label: 'First option' },
     { value: 2, label: 'Second option (disabled)', disabled: true },
     { value: 3, label: 'Third option' },
-    { value: 4, label: 'Fourth option' }
+    { value: 4, label: 'Fourth option' },
   ];
 
   onChange = ({ value }) => {
@@ -41,6 +42,7 @@ class DropdownExample extends React.Component {
 | options   | array of objects | yes      | -        | The list of options (see proptypes below)             |
 | textAlign | string           | no       | 'left'   | Specifies text alignment - must be 'left' or 'center' |
 | onChange  | func             | no       | () => {} | The handler to be invoked on option change            |
+| maxHeight | string           | no       | `null`   | Specifies a maximum height of the expanded dropdown   |
 
 #### `options` Proptypes
 

--- a/docs/dropdown/main.md
+++ b/docs/dropdown/main.md
@@ -36,13 +36,13 @@ class DropdownExample extends React.Component {
 
 ### Proptypes
 
-| prop      | propType         | required | default  | description                                           |
-| --------- | ---------------- | -------- | -------- | ----------------------------------------------------- |
-| value     | any              | yes      | -        | The currently selected option. Can mount as `null`    |
-| options   | array of objects | yes      | -        | The list of options (see proptypes below)             |
-| textAlign | string           | no       | 'left'   | Specifies text alignment - must be 'left' or 'center' |
-| onChange  | func             | no       | () => {} | The handler to be invoked on option change            |
-| maxHeight | string           | no       | '250px'  | Specifies maximum height of the expanded dropdown     |
+| prop                      | propType         | required | default  | description                                           |
+| ------------------------- | ---------------- | -------- | -------- | ----------------------------------------------------- |
+| value                     | any              | yes      | -        | The currently selected option. Can mount as `null`    |
+| options                   | array of objects | yes      | -        | The list of options (see proptypes below)             |
+| textAlign                 | string           | no       | 'left'   | Specifies text alignment - must be 'left' or 'center' |
+| onChange                  | func             | no       | () => {} | The handler to be invoked on option change            |
+| optionsContainerMaxHeight | string           | no       | '250px'  | Specifies maximum height of the expanded dropdown     |
 
 #### `options` Proptypes
 

--- a/docs/dropdown/main.md
+++ b/docs/dropdown/main.md
@@ -42,7 +42,7 @@ class DropdownExample extends React.Component {
 | options   | array of objects | yes      | -        | The list of options (see proptypes below)             |
 | textAlign | string           | no       | 'left'   | Specifies text alignment - must be 'left' or 'center' |
 | onChange  | func             | no       | () => {} | The handler to be invoked on option change            |
-| maxHeight | string           | no       | `null`   | Specifies a maximum height of the expanded dropdown   |
+| maxHeight | string           | no       | '250px'  | Specifies maximum height of the expanded dropdown     |
 
 #### `options` Proptypes
 

--- a/src/shared-components/dropdown/desktopDropdown.js
+++ b/src/shared-components/dropdown/desktopDropdown.js
@@ -21,10 +21,22 @@ const DesktopDropdown = ({
   onOptionClick,
   onSelectClick,
   isOpen,
+  maxHeight,
 }) => (
-  <OffClickWrapper onOffClick={closeDropdown} css={css`width: 100%;`}>
+  <OffClickWrapper
+    onOffClick={closeDropdown}
+    css={css`
+      width: 100%;
+    `}
+  >
     <DropdownContainer textAlign={textAlign}>
-      <div id="select-input-box" onClick={onSelectClick}>
+      <div
+        id="select-input-box"
+        role="button"
+        onClick={onSelectClick}
+        onKeyDown={onSelectClick}
+        tabIndex="0"
+      >
         <div css={dropdownInputStyle({ textAlign })}>
           {currentOption && currentOption.label}
         </div>
@@ -33,9 +45,9 @@ const DesktopDropdown = ({
         </IconContainer>
       </div>
 
-      <DropdownOptionsContainer isOpen={isOpen}>
+      <DropdownOptionsContainer isOpen={isOpen} maxHeight={maxHeight}>
         {options.map(option => {
-          const { value: optionValue, disabled, label, ...rest } = option;
+          const { value: optionValue, disabled, ...rest } = option;
 
           return (
             <DropdownOption
@@ -44,11 +56,12 @@ const DesktopDropdown = ({
               selected={value === optionValue}
               disabled={disabled}
               onClick={onOptionClick}
+              // eslint-disable-next-line react/jsx-props-no-spreading
               {...rest}
             >
               {option.label}
             </DropdownOption>
-          )
+          );
         })}
       </DropdownOptionsContainer>
     </DropdownContainer>
@@ -60,10 +73,12 @@ DesktopDropdown.defaultProps = {
   options: [{ value: null, label: '' }],
   currentOption: { value: null, label: '' },
   textAlign: 'left',
-  closeDropdown() {},
-  onOptionClick() {},
-  onSelectClick() {},
+  /* eslint-disable  @typescript-eslint/no-empty-function */
+  closeDropdown: () => {},
+  onOptionClick: () => {},
+  onSelectClick: () => {},
   isOpen: false,
+  maxHeight: null,
 };
 
 DesktopDropdown.propTypes = {
@@ -75,7 +90,7 @@ DesktopDropdown.propTypes = {
       value: PropTypes.any,
       label: PropTypes.string,
       disabled: PropTypes.bool,
-    })
+    }),
   ),
   textAlign: PropTypes.oneOf(['left', 'center']),
   currentOption: PropTypes.shape({
@@ -88,6 +103,7 @@ DesktopDropdown.propTypes = {
   onOptionClick: PropTypes.func,
   onSelectClick: PropTypes.func,
   isOpen: PropTypes.bool,
+  maxHeight: PropTypes.string,
 };
 
 export default DesktopDropdown;

--- a/src/shared-components/dropdown/desktopDropdown.js
+++ b/src/shared-components/dropdown/desktopDropdown.js
@@ -78,7 +78,7 @@ DesktopDropdown.defaultProps = {
   onOptionClick: () => {},
   onSelectClick: () => {},
   isOpen: false,
-  maxHeight: null,
+  maxHeight: '250px',
 };
 
 DesktopDropdown.propTypes = {

--- a/src/shared-components/dropdown/desktopDropdown.js
+++ b/src/shared-components/dropdown/desktopDropdown.js
@@ -21,7 +21,7 @@ const DesktopDropdown = ({
   onOptionClick,
   onSelectClick,
   isOpen,
-  maxHeight,
+  optionsContainerMaxHeight,
 }) => (
   <OffClickWrapper
     onOffClick={closeDropdown}
@@ -45,9 +45,14 @@ const DesktopDropdown = ({
         </IconContainer>
       </div>
 
-      <DropdownOptionsContainer isOpen={isOpen} maxHeight={maxHeight}>
+      <DropdownOptionsContainer
+        isOpen={isOpen}
+        optionsContainerMaxHeight={optionsContainerMaxHeight}
+      >
         {options.map(option => {
-          const { value: optionValue, disabled, ...rest } = option;
+          const {
+            value: optionValue, disabled, label, ...rest 
+          } = option;
 
           return (
             <DropdownOption
@@ -59,7 +64,7 @@ const DesktopDropdown = ({
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...rest}
             >
-              {option.label}
+              {label}
             </DropdownOption>
           );
         })}
@@ -73,12 +78,10 @@ DesktopDropdown.defaultProps = {
   options: [{ value: null, label: '' }],
   currentOption: { value: null, label: '' },
   textAlign: 'left',
-  /* eslint-disable  @typescript-eslint/no-empty-function */
-  closeDropdown: () => {},
-  onOptionClick: () => {},
-  onSelectClick: () => {},
+  closeDropdown: () => undefined,
+  onOptionClick: () => undefined,
+  onSelectClick: () => undefined,
   isOpen: false,
-  maxHeight: '250px',
 };
 
 DesktopDropdown.propTypes = {
@@ -103,7 +106,7 @@ DesktopDropdown.propTypes = {
   onOptionClick: PropTypes.func,
   onSelectClick: PropTypes.func,
   isOpen: PropTypes.bool,
-  maxHeight: PropTypes.string,
+  optionsContainerMaxHeight: PropTypes.string.isRequired,
 };
 
 export default DesktopDropdown;

--- a/src/shared-components/dropdown/index.js
+++ b/src/shared-components/dropdown/index.js
@@ -7,7 +7,10 @@ import allowNullPropType from '../../utils/allowNullPropType';
 
 const defaultProps = {
   textAlign: 'left',
+  /* eslint-disable  @typescript-eslint/no-empty-function */
   onChange() {},
+  maxHeight: '',
+  value: null,
 };
 
 const propTypes = {
@@ -19,10 +22,11 @@ const propTypes = {
       value: PropTypes.any,
       label: PropTypes.string,
       disabled: PropTypes.bool,
-    })
+    }),
   ).isRequired,
   textAlign: PropTypes.oneOf(['left', 'center']),
   onChange: PropTypes.func,
+  maxHeight: PropTypes.string,
 };
 
 class Dropdown extends React.Component {
@@ -63,13 +67,14 @@ class Dropdown extends React.Component {
   closeDropdown = () => this.setState({ isOpen: false });
 
   render() {
-    const { value, options } = this.props;
+    const { value, options, maxHeight } = this.props;
     const { isOpen } = this.state;
 
     const touchSupported = 'ontouchstart' in document.documentElement;
 
     if (touchSupported) {
       return (
+        // eslint-disable-next-line react/jsx-props-no-spreading
         <MobileDropdown {...this.props} onSelectChange={this.onSelectChange} />
       );
     }
@@ -83,6 +88,8 @@ class Dropdown extends React.Component {
         closeDropdown={this.closeDropdown}
         onSelectClick={this.onSelectClick}
         currentOption={currentOption}
+        maxHeight={maxHeight}
+        // eslint-disable-next-line react/jsx-props-no-spreading
         {...this.props}
       />
     );

--- a/src/shared-components/dropdown/index.js
+++ b/src/shared-components/dropdown/index.js
@@ -9,7 +9,7 @@ const defaultProps = {
   textAlign: 'left',
   /* eslint-disable  @typescript-eslint/no-empty-function */
   onChange() {},
-  maxHeight: '',
+  maxHeight: null,
   value: null,
 };
 

--- a/src/shared-components/dropdown/index.js
+++ b/src/shared-components/dropdown/index.js
@@ -9,7 +9,7 @@ const defaultProps = {
   textAlign: 'left',
   /* eslint-disable  @typescript-eslint/no-empty-function */
   onChange() {},
-  maxHeight: null,
+  maxHeight: '250px',
   value: null,
 };
 

--- a/src/shared-components/dropdown/index.js
+++ b/src/shared-components/dropdown/index.js
@@ -7,10 +7,9 @@ import allowNullPropType from '../../utils/allowNullPropType';
 
 const defaultProps = {
   textAlign: 'left',
-  /* eslint-disable  @typescript-eslint/no-empty-function */
-  onChange() {},
-  maxHeight: '250px',
-  value: null,
+  onChange: () => undefined,
+  optionsContainerMaxHeight: '250px',
+  value: undefined,
 };
 
 const propTypes = {
@@ -26,7 +25,7 @@ const propTypes = {
   ).isRequired,
   textAlign: PropTypes.oneOf(['left', 'center']),
   onChange: PropTypes.func,
-  maxHeight: PropTypes.string,
+  optionsContainerMaxHeight: PropTypes.string,
 };
 
 class Dropdown extends React.Component {
@@ -67,7 +66,7 @@ class Dropdown extends React.Component {
   closeDropdown = () => this.setState({ isOpen: false });
 
   render() {
-    const { value, options, maxHeight } = this.props;
+    const { value, options, optionsContainerMaxHeight } = this.props;
     const { isOpen } = this.state;
 
     const touchSupported = 'ontouchstart' in document.documentElement;
@@ -88,7 +87,7 @@ class Dropdown extends React.Component {
         closeDropdown={this.closeDropdown}
         onSelectClick={this.onSelectClick}
         currentOption={currentOption}
-        maxHeight={maxHeight}
+        optionsContainerMaxHeight={optionsContainerMaxHeight}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...this.props}
       />

--- a/src/shared-components/dropdown/style.js
+++ b/src/shared-components/dropdown/style.js
@@ -9,7 +9,7 @@ import {
   TYPOGRAPHY_CONSTANTS,
 } from '../../constants';
 
-const optionsContainerMaxHeight = '250px';
+const optionsContainerMaxHeight = '206px';
 
 export const DropdownContainer = styled.div`
   position: relative;

--- a/src/shared-components/dropdown/style.js
+++ b/src/shared-components/dropdown/style.js
@@ -99,10 +99,10 @@ export const DropdownOptionsContainer = styled.ul`
   list-style: none;
   -webkit-overflow-scrolling: touch;
 
-  ${({ isOpen, maxHeight }) =>
+  ${({ isOpen, optionsContainerMaxHeight }) =>
     isOpen &&
     css`
-      max-height: ${maxHeight};
+      max-height: ${optionsContainerMaxHeight};
       border-bottom-width: 1px;
       transition: max-height ${ANIMATION.defaultTiming} ease-in-out;
     `};

--- a/src/shared-components/dropdown/style.js
+++ b/src/shared-components/dropdown/style.js
@@ -9,8 +9,6 @@ import {
   TYPOGRAPHY_CONSTANTS,
 } from '../../constants';
 
-const optionsContainerMaxHeight = '250px';
-
 export const DropdownContainer = styled.div`
   position: relative;
   width: 100%;
@@ -104,7 +102,7 @@ export const DropdownOptionsContainer = styled.ul`
   ${({ isOpen, maxHeight }) =>
     isOpen &&
     css`
-      max-height: ${maxHeight ? maxHeight : optionsContainerMaxHeight};
+      max-height: ${maxHeight};
       border-bottom-width: 1px;
       transition: max-height ${ANIMATION.defaultTiming} ease-in-out;
     `};

--- a/src/shared-components/dropdown/style.js
+++ b/src/shared-components/dropdown/style.js
@@ -9,7 +9,7 @@ import {
   TYPOGRAPHY_CONSTANTS,
 } from '../../constants';
 
-const optionsContainerMaxHeight = '206px';
+const optionsContainerMaxHeight = '250px';
 
 export const DropdownContainer = styled.div`
   position: relative;
@@ -101,10 +101,10 @@ export const DropdownOptionsContainer = styled.ul`
   list-style: none;
   -webkit-overflow-scrolling: touch;
 
-  ${({ isOpen }) =>
+  ${({ isOpen, maxHeight }) =>
     isOpen &&
     css`
-      max-height: ${optionsContainerMaxHeight};
+      max-height: ${maxHeight ? maxHeight : optionsContainerMaxHeight};
       border-bottom-width: 1px;
       transition: max-height ${ANIMATION.defaultTiming} ease-in-out;
     `};


### PR DESCRIPTION
I noticed a bug where the dropdown max-height was rendering outside of its container, causing the last item to not be visible. 

Based on feedback, I added a `maxHeight` prop to the dropdown component to make it more flexible. 👍 

Before:
<img width="562" alt="Screen Shot 2020-07-01 at 5 44 37 PM" src="https://user-images.githubusercontent.com/4212012/86383953-877e6c80-bc4b-11ea-9f00-4af43e15eb02.png">

<img width="603" alt="Screen Shot 2020-07-02 at 10 07 03 AM" src="https://user-images.githubusercontent.com/4212012/86384319-cd3b3500-bc4b-11ea-99bb-0951ac151c2f.png">

After:
<img width="499" alt="Screen Shot 2020-07-02 at 9 42 58 AM" src="https://user-images.githubusercontent.com/4212012/86384003-8baa8a00-bc4b-11ea-8feb-db0be87a41b6.png">
