### PR TITLE
[Accordion] Set decorative Thumbnail image alt text to empty string

### DIFF
--- a/src/shared-components/accordion/thumbnails/index.tsx
+++ b/src/shared-components/accordion/thumbnails/index.tsx
@@ -16,7 +16,7 @@ class Thumbnails extends React.Component<{ photoSrcs: string[] }> {
   };
 
   /**
-   * Thumbnail images set with empty alt text because they are decorative. Accordion
+   * Thumbnail images set with empty alt text because they are decorative.
    * Accessible Accordion functionality does not depend on these thumbnails.
    */
   renderThumbnails() {

--- a/src/shared-components/accordion/thumbnails/index.tsx
+++ b/src/shared-components/accordion/thumbnails/index.tsx
@@ -15,6 +15,10 @@ class Thumbnails extends React.Component<{ photoSrcs: string[] }> {
     photoSrcs: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
+  /**
+   * Thumbnail images set with empty alt text because they are decorative. Accordion
+   * Accessible Accordion functionality does not depend on these thumbnails.
+   */
   renderThumbnails() {
     const { photoSrcs } = this.props;
 
@@ -24,7 +28,7 @@ class Thumbnails extends React.Component<{ photoSrcs: string[] }> {
 
     const firstThumbnail = (
       <ImageContainer>
-        <ThumbnailImage src={photoSrcs[0]} />
+        <ThumbnailImage alt="" src={photoSrcs[0]} />
       </ImageContainer>
     );
 
@@ -33,7 +37,7 @@ class Thumbnails extends React.Component<{ photoSrcs: string[] }> {
     if (photoSrcs.length === 2) {
       secondThumbnail = (
         <ImageContainer>
-          <ThumbnailImage src={photoSrcs[1]} />
+          <ThumbnailImage alt="" src={photoSrcs[1]} />
         </ImageContainer>
       );
     } else if (photoSrcs.length > 2) {


### PR DESCRIPTION
### What & Why

We're enhancing the accessibility of our components. One item that came up in our audit was `Accordion.Thumbnail` images not having alt text. After some consideration I think that the thumbnail images are "decorative," especially in contrast to the other elements of the Accordion component, which require fully accessible functionality, rendering any pertinent alt text, at best, duplicative of the image (with also redundant alt text) contained in that aforementioned functionality.

This PR suppresses the error by setting an empty string. This is a small change, in any case, and this decision is not final, so it is subject to change with future changes/enhancements. 