### PR TITLE
[a11y] Add box-shadow outline to button focus state

### DIFF
--- a/src/shared-components/button/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/__snapshots__/test.tsx.snap
@@ -138,6 +138,7 @@ exports[`<Button /> UI snapshots renders with props 1`] = `
 .emotion-6:active,
 .emotion-6:focus {
   outline: none;
+  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
 }
 
 .emotion-6:visited,

--- a/src/shared-components/button/components/linkButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/linkButton/__snapshots__/test.tsx.snap
@@ -47,6 +47,7 @@ exports[`<LinkButton/> UI snapshots renders with props 1`] = `
 .emotion-4:active,
 .emotion-4:focus {
   outline: none;
+  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
 }
 
 .emotion-4:visited,

--- a/src/shared-components/button/components/roundButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/roundButton/__snapshots__/test.tsx.snap
@@ -163,6 +163,7 @@ exports[`<RoundButton /> UI snapshots renders with props 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
+  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
 }
 
 .emotion-2:visited,

--- a/src/shared-components/button/style.ts
+++ b/src/shared-components/button/style.ts
@@ -186,6 +186,7 @@ export const baseButtonStyles = ({
   &:active,
   &:focus {
     outline: none;
+    box-shadow: ${BOX_SHADOWS.focusSecondary};
   }
 
   ${parseTheme(disabled, buttonType, !!isLoading, buttonColor)};


### PR DESCRIPTION
### What & Why

Keyboard navigation without focus state indication is difficult--adding this style will make things easier. This will apply to *all* buttons. 

![boxshadow](https://user-images.githubusercontent.com/13544620/87715748-6e111080-c773-11ea-8e05-329225e7250c.gif)

I view this as a temporary solution--the outline on our primary buttons is very faint and not ideal, but it's a simple start. 
