### PR TITLE
[a11y] Add aria-disabled to disabled usage

### DIFF
--- a/src/shared-components/accordion/__snapshots__/test.tsx.snap
+++ b/src/shared-components/accordion/__snapshots__/test.tsx.snap
@@ -52,6 +52,7 @@ exports[`<Accordion /> renders disabled accordion 1`] = `
 }
 
 <div
+  aria-disabled={true}
   className="emotion-8 emotion-9"
   disabled={true}
 >
@@ -138,6 +139,7 @@ exports[`<Accordion /> renders no border accordion 1`] = `
 }
 
 <div
+  aria-disabled={false}
   className="emotion-8 emotion-9"
   disabled={false}
 >
@@ -225,6 +227,7 @@ exports[`<Accordion /> renders regular accordion 1`] = `
 }
 
 <div
+  aria-disabled={false}
   className="emotion-8 emotion-9"
   disabled={false}
 >

--- a/src/shared-components/accordion/index.tsx
+++ b/src/shared-components/accordion/index.tsx
@@ -104,7 +104,12 @@ class Accordion extends React.Component<
     } = this.props;
 
     return (
-      <AccordionBox isOpen={isOpen} noBorder={!!noBorder} disabled={!!disabled}>
+      <AccordionBox
+        isOpen={isOpen}
+        noBorder={!!noBorder}
+        disabled={!!disabled}
+        aria-disabled={!!disabled}
+      >
         <TitleWrapper
           onClick={(event): void => {
             if (!disabled) {

--- a/src/shared-components/button/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/__snapshots__/test.tsx.snap
@@ -231,6 +231,7 @@ exports[`<Button /> UI snapshots renders with props 1`] = `
 }
 
 <button
+  aria-disabled={true}
   className="emotion-6 emotion-7"
   disabled={true}
   onClick={[Function]}
@@ -247,6 +248,7 @@ exports[`<Button /> UI snapshots renders with props 1`] = `
     </span>
   </div>
   <div
+    aria-disabled={true}
     className=" emotion-4 emotion-5"
     disabled={true}
   >

--- a/src/shared-components/button/components/linkButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/linkButton/__snapshots__/test.tsx.snap
@@ -99,6 +99,7 @@ exports[`<LinkButton/> UI snapshots renders with props 1`] = `
 }
 
 <a
+  aria-disabled={false}
   className="emotion-4"
   disabled={false}
   href="#"

--- a/src/shared-components/button/components/linkButton/index.tsx
+++ b/src/shared-components/button/components/linkButton/index.tsx
@@ -63,6 +63,7 @@ const Link = ({
         textColor,
       })}
       disabled={disabled}
+      aria-disabled={disabled}
       onClick={!disabled ? onClick : () => false}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...rest}

--- a/src/shared-components/button/components/roundButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/roundButton/__snapshots__/test.tsx.snap
@@ -238,6 +238,7 @@ exports[`<RoundButton /> UI snapshots renders with props 1`] = `
   className="emotion-5 emotion-6"
 >
   <button
+    aria-disabled={true}
     className="emotion-2 emotion-3"
     disabled={true}
     onClick={[Function]}
@@ -245,6 +246,7 @@ exports[`<RoundButton /> UI snapshots renders with props 1`] = `
   >
     <svg />
     <div
+      aria-disabled={true}
       className="emotion-0 emotion-1"
       disabled={true}
     >

--- a/src/shared-components/button/components/roundButton/index.tsx
+++ b/src/shared-components/button/components/roundButton/index.tsx
@@ -77,6 +77,7 @@ const RoundButton = ({
     <RoundButtonWrapper>
       <RoundButtonBase
         onClick={!disabled && !isLoading ? onClick : () => false}
+        aria-disabled={disabled}
         disabled={disabled}
         buttonType={buttonType}
         buttonColor={buttonColor}

--- a/src/shared-components/button/components/textButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/textButton/__snapshots__/test.tsx.snap
@@ -51,6 +51,7 @@ exports[`<TextButton /> UI snapshots renders with disabled prop 1`] = `
 }
 
 <button
+  aria-disabled={true}
   className="emotion-2 emotion-3"
   disabled={true}
   onClick={[Function]}
@@ -114,6 +115,7 @@ exports[`<TextButton /> UI snapshots renders without any props 1`] = `
 }
 
 <button
+  aria-disabled={false}
   className="emotion-2 emotion-3"
   disabled={false}
   onClick={[Function]}

--- a/src/shared-components/button/components/textButton/index.tsx
+++ b/src/shared-components/button/components/textButton/index.tsx
@@ -29,6 +29,7 @@ const TextButton = ({
   ...rest
 }: TextButtonProps) => (
   <BaseTextButton
+    aria-disabled={disabled}
     disabled={disabled}
     onClick={!disabled ? onClick : event => event.preventDefault()}
     // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/shared-components/button/index.tsx
+++ b/src/shared-components/button/index.tsx
@@ -87,6 +87,7 @@ class Button extends React.Component<ButtonProps> {
 
     return (
       <ButtonBase
+        aria-disabled={disabled}
         disabled={disabled}
         onClick={
           !disabled && !loadingVal ? onClick : event => event.preventDefault()

--- a/src/shared-components/button/shared-components/loader/index.tsx
+++ b/src/shared-components/button/shared-components/loader/index.tsx
@@ -29,6 +29,7 @@ const Loader = ({
     buttonType={buttonType}
     className={className}
     disabled={disabled}
+    aria-disabled={disabled}
     isFullWidth={!!isFullWidth}
     isLoading={isLoading}
     textColor={textColor}

--- a/src/shared-components/carousel/arrow/index.js
+++ b/src/shared-components/carousel/arrow/index.js
@@ -8,11 +8,11 @@ import ArrowContainer from './style';
 
 class Arrow extends React.Component {
   static propTypes = {
-    prev: PropTypes.bool,
-    next: PropTypes.bool,
-    disabled: PropTypes.bool,
-    onUserInteraction: PropTypes.func,
-    onClick: PropTypes.func,
+    prev: PropTypes.bool.isRequired,
+    next: PropTypes.bool.isRequired,
+    disabled: PropTypes.bool.isRequired,
+    onUserInteraction: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
   };
 
   arrowClickHandler = () => {
@@ -24,7 +24,12 @@ class Arrow extends React.Component {
   render() {
     const { prev, next, disabled } = this.props;
     return (
-      <ArrowContainer prev={prev} next={next} disabled={disabled}>
+      <ArrowContainer
+        prev={prev}
+        next={next}
+        disabled={disabled}
+        aria-disabled={disabled}
+      >
         {prev && (
           <RoundButton
             buttonType="action"

--- a/src/shared-components/carousel/index.js
+++ b/src/shared-components/carousel/index.js
@@ -155,7 +155,7 @@ class Carousel extends React.Component {
 
     const timeoutId = setTimeout(
       () => this.slider.current.slickGoTo(firstIndex),
-      autoplaySpeed
+      autoplaySpeed,
     );
 
     this.timeoutId = timeoutId;
@@ -171,6 +171,7 @@ class Carousel extends React.Component {
           carouselType={carouselType}
           onClick={this.onUserInteraction}
         >
+          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
           <Slider ref={this.slider} {...settings}>
             {children}
           </Slider>

--- a/src/shared-components/dropdown/desktopDropdown.js
+++ b/src/shared-components/dropdown/desktopDropdown.js
@@ -59,6 +59,7 @@ const DesktopDropdown = ({
               key={optionValue}
               value={optionValue}
               selected={value === optionValue}
+              aria-disabled={disabled}
               disabled={disabled}
               onClick={onOptionClick}
               // eslint-disable-next-line react/jsx-props-no-spreading

--- a/src/shared-components/dropdown/mobileDropdown.js
+++ b/src/shared-components/dropdown/mobileDropdown.js
@@ -23,7 +23,12 @@ const MobileDropdown = ({
         }
 
         return (
-          <option key={option.value} value={option.value} disabled={isDisabled}>
+          <option
+            key={option.value}
+            value={option.value}
+            disabled={isDisabled}
+            aria-disabled={isDisabled}
+          >
             {option.label}
           </option>
         );
@@ -39,7 +44,7 @@ MobileDropdown.defaultProps = {
   value: null,
   options: [{ value: null, label: '' }],
   textAlign: 'left',
-  onSelectChange() {},
+  onSelectChange: () => undefined,
 };
 
 MobileDropdown.propTypes = {
@@ -51,7 +56,7 @@ MobileDropdown.propTypes = {
       value: PropTypes.any,
       label: PropTypes.string,
       disabled: PropTypes.bool,
-    })
+    }),
   ),
   textAlign: PropTypes.oneOf(['left', 'center']),
   onSelectChange: PropTypes.func,

--- a/src/shared-components/field/__snapshots__/test.js.snap
+++ b/src/shared-components/field/__snapshots__/test.js.snap
@@ -97,6 +97,7 @@ exports[`<Field /> UI Snapshot renders with label and labelFor 1`] = `
   className="emotion-8 emotion-9"
 >
   <label
+    aria-disabled={false}
     className="emotion-0 emotion-1"
     disabled={false}
     htmlFor="for-input-id"
@@ -218,6 +219,7 @@ exports[`<Field /> UI Snapshot renders with label prop 1`] = `
   className="emotion-8 emotion-9"
 >
   <label
+    aria-disabled={false}
     className="emotion-0 emotion-1"
     disabled={false}
     htmlFor="Test Label"

--- a/src/shared-components/field/index.js
+++ b/src/shared-components/field/index.js
@@ -68,7 +68,7 @@ class Field extends React.Component {
     return (
       <FieldContainer>
         {!!label && (
-          <Label htmlFor={htmlFor} disabled={disabled}>
+          <Label htmlFor={htmlFor} disabled={disabled} aria-disabled={disabled}>
             {label}
           </Label>
         )}


### PR DESCRIPTION
### What and Why

Our accessibility tooling requires explicit directives to ignore contrast/etc. issues on "disabled" content. The HTML `disabled` attribute is not sufficient, so this PR adds `aria-disabled` alongside our `disabled` prop logic (in the outermost element, in the case of a component with multiple `disabled` prop usages). 