### PR TITLE
[TypeScript] Add CI Check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
                 paths:
                     - node_modules
 
-    test:
+    test-js:
         <<: *defaults
 
         docker:
@@ -103,7 +103,7 @@ workflows:
     build-and-test:
         jobs:
             - build
-            - test:
+            - test-js:
                 requires:
                     - build
             - test-tsc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,11 @@ aliases:
     - &defaults
         working_directory: *root
 
+    - &prepare-environment
+        run:
+            name: Prepare Environment
+            command: mkdir test-results
+
     - &cache-yarn-key-base yarn-packages-v1-{{ arch }}-
     - &cache-yarn-key yarn-packages-v1-{{ arch }}-{{ checksum "yarn.lock" }}
 
@@ -62,14 +67,33 @@ jobs:
             - <<: *prospective-merge
             - attach_workspace:
                 at: *root
-            - run:
-                name: Prepare Environment
-                command: mkdir test-results
+            - <<: *prepare-environment
             - run:
                 name: Run Jest Tests
                 command: yarn run jest --ci --runInBand --reporters=default --reporters=jest-junit
                 environment:
                     JEST_JUNIT_OUTPUT: test-results/jest/junit-${CIRCLE_NODE_INDEX}.xml
+            - store_test_results:
+                path: test-results
+
+    test-tsc:
+        <<: *defaults
+
+        docker:
+            - image: circleci/node:10-stretch
+
+        environment:
+            NODE_OPTIONS: --max_old_space_size=4096
+
+        steps:
+            - checkout
+            - <<: *prospective-merge
+            - attach_workspace:
+                at: *root
+            - <<: *prepare-environment
+            - run:
+                name: Run TypeScript type-checking
+                command: yarn run tsc -p tsconfig.json
             - store_test_results:
                 path: test-results
 
@@ -80,5 +104,8 @@ workflows:
         jobs:
             - build
             - test:
+                requires:
+                    - build
+            - test-tsc:
                 requires:
                     - build


### PR DESCRIPTION
### What and Why

- Adds corresponding `test-tsc` check to our CI build to check there are no TypeScript errors in our builds. 
- Renames `test` to `test-js` to clarify scope. 

### Other

- Once this is merged in I will update the repo settings to set `test-js` and `test-tsc` to `required`, and remove `required` from `test`.

<img width="811" alt="Screen Shot 2020-07-20 at 11 03 54 AM" src="https://user-images.githubusercontent.com/13544620/87959604-c4829580-ca78-11ea-9c09-e9b5bb70be72.png">
