### PR TITLE
[Typography] Add focus styling to Link styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@svgr/webpack": "^4.0.2",
     "@types/enzyme": "^3.10.3",
     "@types/jest": "^24.0.20",
+    "@types/lodash.round": "^4.0.6",
     "@types/lodash.throttle": "^4.1.6",
     "@types/react": "^16.9.17",
     "@types/react-dom": "^16.9.4",

--- a/src/shared-components/typography/index.ts
+++ b/src/shared-components/typography/index.ts
@@ -2,7 +2,6 @@ import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import round from 'lodash.round';
 
-import { withDeprecationWarning } from '../../utils';
 import { BOX_SHADOWS, COLORS, TYPOGRAPHY_CONSTANTS } from '../../constants';
 
 const displayStyle = css`
@@ -118,19 +117,6 @@ const Typography = {
   Link,
   Success,
   Title,
-
-  // Legacy names. Will be removed in v2 (next major)
-  LinkTag: Link,
-  ButtonText: Button,
-  SuccessText: Success,
-  ErrorText: ErrorComponent,
 };
 
-const deprecatedProperties = {
-  LinkTag: 'LinkTag is deprecated. Use Link instead',
-  ButtonText: 'ButtonText is deprecated. Use Button instead',
-  SuccessText: 'SuccessText is deprecated. Use Success instead',
-  ErrorText: 'ErrorText is deprecated. Use Error instead',
-};
-
-export default withDeprecationWarning(Typography, deprecatedProperties);
+export default Typography;

--- a/src/shared-components/typography/index.ts
+++ b/src/shared-components/typography/index.ts
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import round from 'lodash.round';
 
 import { withDeprecationWarning } from '../../utils';
-import { COLORS, TYPOGRAPHY_CONSTANTS } from '../../constants';
+import { BOX_SHADOWS, COLORS, TYPOGRAPHY_CONSTANTS } from '../../constants';
 
 const displayStyle = css`
   color: ${COLORS.primary};
@@ -77,6 +77,11 @@ const linkStyle = css`
   &:hover {
     opacity: 0.6;
     transition: opacity 350ms;
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: ${BOX_SHADOWS.focusSecondary};
   }
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3367,6 +3367,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/lodash.round@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.round/-/lodash.round-4.0.6.tgz#dddd13d478baffaef66b5b65b88978140253fad3"
+  integrity sha512-4/fs+g0BRnsJZMg0Nl5zHbx4rvo2J6KeDBPsgNvDZ1WKl4/wPOn3yiA7VURP+W0ZgUUQHEpEuLCFRfdW/h5ONg==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.throttle@^4.1.6":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.throttle/-/lodash.throttle-4.1.6.tgz#f5ba2c22244ee42ff6c2c49e614401a870c1009c"


### PR DESCRIPTION
### What and Why

1. Adds focus styling to `TYPOGRAPHY_STYLE.link`

Holding off on review because this is perhaps best paired with the [`focus-visible polyfill`](https://github.com/WICG/focus-visible)

### Other

The next `radiance-ui` release that has this in it will need to be a v10 due to removing the deprecating `TYPOGRAPHY` properties. I checked and we do not currently use it, and the TODO was related to v2, so I'm finally getting rid of it. 