### PR TITLE
[a11y] Add aria-disabled to dropdown options

### DIFF
--- a/src/shared-components/dropdown/desktopDropdown.tsx
+++ b/src/shared-components/dropdown/desktopDropdown.tsx
@@ -104,6 +104,7 @@ const DesktopDropdown = ({
                 onClick={onOptionClick}
                 onKeyDown={handleOptionKeydown}
                 role="menuitemradio"
+                aria-disabled={!!disabled}
                 aria-checked={value === optionValue}
                 tabIndex={isOpen && !disabled ? 0 : -1}
                 // eslint-disable-next-line react/jsx-props-no-spreading


### PR DESCRIPTION
I forgot to include the `aria-disabled` prop on the list element, which mean that we were seeing a color contrast violation for the disabled form elements. It also was unclear to the screen reader that the disabled options were actually disabled. I didn't catch this originally in the Storybook, because the text of the disabled example had the word "Disabled" in it, so the screen reader was announcing that it was a disabled element 😅 

Note that this is only required because we're stying an `li` to behave as a menu item. For any element that natively supports the `disabled` property, that is sufficient for the screen reader to interpret it properly and for `axe` to remove it from color-contrast checks. 