### PR TITLE
[a11y] Remove id on LoadingSpinner

### DIFF
--- a/src/shared-components/loadingSpinner/__snapshots__/test.js.snap
+++ b/src/shared-components/loadingSpinner/__snapshots__/test.js.snap
@@ -95,7 +95,6 @@ exports[`<LoadingSpinner /> UI snapshots renders the correct css 1`] = `
 
 <div
   className="emotion-8 emotion-9"
-  id="loading-spinner"
 >
   <div
     className="emotion-6 emotion-7"

--- a/src/shared-components/loadingSpinner/index.js
+++ b/src/shared-components/loadingSpinner/index.js
@@ -4,8 +4,10 @@ import PropTypes from 'prop-types';
 import { COLORS } from '../../constants';
 import { LoadingSpinnerContainer, Overlay, Dot } from './style';
 
-const LoadingSpinner = ({ bgColor, color, translateX, duration, size }) => (
-  <LoadingSpinnerContainer bgColor={bgColor} id="loading-spinner">
+const LoadingSpinner = ({
+  bgColor, color, translateX, duration, size, 
+}) => (
+  <LoadingSpinnerContainer bgColor={bgColor}>
     <Overlay>
       <Dot
         color={color}


### PR DESCRIPTION
### What and Why

We put an id on the LoadingSpinner, but pages can have multiple LoadingSpinners, which violates the unique id rule. It doesn't look like we rely on this id for anything, so this PR removes it. 