### PR TITLE
[a11y] Trap keyboard focus in DialogModal

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
   "dependencies": {
     "@emotion/core": "10.0.10",
     "@emotion/styled": "10.0.10",
+    "@react-aria/focus": "^3.0.2",
     "lodash.round": "^4.0.4",
     "lodash.throttle": "^4.1.1",
     "lodash.uniqueid": "^4.0.1",

--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Transition } from 'react-transition-group';
+import { FocusScope } from '@react-aria/focus';
 
 import CrossIcon from '../../svgs/icons/cross-icon.svg';
 import {
@@ -90,15 +91,17 @@ class DialogModal extends React.Component<DialogModalProps, DialogModalState> {
         {(transitionState): JSX.Element => (
           // eslint-disable-next-line react/jsx-props-no-spreading
           <Overlay className={transitionState} {...rest}>
-            <ModalContainer className={transitionState}>
-              {onCloseIconClick && (
-                <CrossIconContainer onClick={this.handleCloseIntent}>
-                  <CrossIcon />
-                </CrossIconContainer>
-              )}
-              {!!title && <ModalTitle>{title}</ModalTitle>}
-              {children}
-            </ModalContainer>
+            <FocusScope contain autoFocus restoreFocus>
+              <ModalContainer className={transitionState}>
+                {onCloseIconClick && (
+                  <CrossIconContainer onClick={this.handleCloseIntent}>
+                    <CrossIcon />
+                  </CrossIconContainer>
+                )}
+                {!!title && <ModalTitle>{title}</ModalTitle>}
+                {children}
+              </ModalContainer>
+            </FocusScope>
           </Overlay>
         )}
       </Transition>,

--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -97,7 +97,7 @@ class DialogModal extends React.Component<DialogModalProps, DialogModalState> {
         {(transitionState): JSX.Element => (
           // eslint-disable-next-line react/jsx-props-no-spreading
           <Overlay className={transitionState} {...rest}>
-            <FocusScope contain restoreFocus>
+            <FocusScope contain restoreFocus autoFocus>
               <ModalContainer
                 className={transitionState}
                 onKeyDown={this.handleKeyDown}

--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -70,6 +70,12 @@ class DialogModal extends React.Component<DialogModalProps, DialogModalState> {
     }
   };
 
+  handleKeyDown = (event: React.KeyboardEvent): void => {
+    if (event.key === 'Escape') {
+      this.handleCloseIntent();
+    }
+  };
+
   render(): JSX.Element {
     const {
       children, title, onCloseIconClick, ...rest 
@@ -91,10 +97,18 @@ class DialogModal extends React.Component<DialogModalProps, DialogModalState> {
         {(transitionState): JSX.Element => (
           // eslint-disable-next-line react/jsx-props-no-spreading
           <Overlay className={transitionState} {...rest}>
-            <FocusScope contain autoFocus restoreFocus>
-              <ModalContainer className={transitionState}>
+            <FocusScope contain restoreFocus>
+              <ModalContainer
+                className={transitionState}
+                onKeyDown={this.handleKeyDown}
+              >
                 {onCloseIconClick && (
-                  <CrossIconContainer onClick={this.handleCloseIntent}>
+                  <CrossIconContainer
+                    onClick={this.handleCloseIntent}
+                    role="button"
+                    tabIndex={0}
+                    aria-label="Close modal"
+                  >
                     <CrossIcon />
                   </CrossIconContainer>
                 )}

--- a/src/shared-components/dialogModal/style.ts
+++ b/src/shared-components/dialogModal/style.ts
@@ -2,7 +2,11 @@ import styled from '@emotion/styled';
 
 import Typography from '../typography';
 import {
-  COLORS, MEDIA_QUERIES, SPACER, Z_SCALE, 
+  COLORS,
+  MEDIA_QUERIES,
+  SPACER,
+  Z_SCALE,
+  BOX_SHADOWS,
 } from '../../constants';
 
 export const Overlay = styled.div`
@@ -106,5 +110,9 @@ export const CrossIconContainer = styled.div`
   ${MEDIA_QUERIES.mdUp} {
     top: 16px;
     right: 16px;
+  }
+  &:focus {
+    outline: none;
+    box-shadow: ${BOX_SHADOWS.focusSecondary};
   }
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1527,6 +1527,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.6.2":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
+  integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.7":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.6.tgz#a9102eb5cadedf3f31d08a9ecf294af7827ea29f"
@@ -2144,6 +2151,40 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
+
+"@react-aria/focus@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.0.2.tgz#e56b2d66c2d11fc59f4e6e0755b2fa8e889055ac"
+  integrity sha512-1P8saw0YRcFi+gi+UpqaBwNuki/PvK/OQEvZEHuitbOYmI6MPigyAJHq+1qUwG155xdHmMVkWtZzdPDqXuy4uQ==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/interactions" "^3.0.2"
+    "@react-aria/utils" "^3.0.2"
+    "@react-types/shared" "^3.0.2"
+    classnames "^2.2.5"
+
+"@react-aria/interactions@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.0.2.tgz#3f1ef9ba2bec1148e98c79330a7efee342df8e10"
+  integrity sha512-TtLHlfz/2IWcRhTxuhVM/hxM2z3L7QZRDL6Cs+ZjHDHPyGAPEsEvxS0s0lQpx7KmIhNPV+nU5i+iFQ37exJ8kg==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/utils" "^3.0.2"
+    "@react-types/shared" "^3.0.2"
+
+"@react-aria/utils@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.0.2.tgz#08b991c98c5b44fcc0dd6cb08d09fb6247d9bf3d"
+  integrity sha512-75rBhdZXYXk73QhL+p9eeXvp5HpKrtrbC7R0+aGOvLCnc8HQkzg6kdSwsXwyjUdRJOz1KpLOlzRVwVpsOaIiJw==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-types/shared" "^3.0.2"
+    classnames "^2.2.5"
+
+"@react-types/shared@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.0.2.tgz#99aed8bbc902e40c796e8cab6d554eee02a4ed5e"
+  integrity sha512-j7wuNbh/o+iMqyCWL0HybxWmThPBoEaPVALCS3Q8eUmNbsnZUMGqMrbartmN1YVBbceDbBl3D840NolL3Gx6wA==
 
 "@rollup/plugin-babel@^5.0.3":
   version "5.0.3"


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/1182623358122135/1182893274583740)

When the `DialogModal` is open, we should lock the focus inside of the modal to make it easy for keyboard users to interact with. This PR accomplishes this by using the [FocusScope](https://react-spectrum.adobe.com/react-aria/FocusScope.html) component from react-aria. We automatically trap focus inside the modal when it opens, and return focus to the last focused element when it closes. In addition, if a close icon is present, we allow the user to dismiss the modal using the Escape key. 

![Screen Shot 2020-07-22 at 2 47 57 PM](https://user-images.githubusercontent.com/6826778/88215928-61d0fb80-cc2a-11ea-8200-50919ad6cbd8.png)
