### PR TITLE
[a11y] Add box-shadow to TextButton

### DIFF
--- a/src/shared-components/button/components/textButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/textButton/__snapshots__/test.tsx.snap
@@ -48,6 +48,7 @@ exports[`<TextButton /> UI snapshots renders with disabled prop 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
+  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
 }
 
 <button
@@ -79,6 +80,7 @@ exports[`<TextButton /> UI snapshots renders without any props 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
+  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
 }
 
 .emotion-0 {

--- a/src/shared-components/button/components/textButton/style.ts
+++ b/src/shared-components/button/components/textButton/style.ts
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
 
-import { COLORS } from '../../../../constants';
+import { BOX_SHADOWS, COLORS } from '../../../../constants';
 
-/* eslint-disable-next-line import/prefer-default-export */
 export const BaseTextButton = styled.button<{ disabled: boolean }>`
   border-color: transparent;
   background-color: transparent;
@@ -19,5 +18,6 @@ export const BaseTextButton = styled.button<{ disabled: boolean }>`
   &:active,
   &:focus {
     outline: none;
+    box-shadow: ${BOX_SHADOWS.focusSecondary};
   }
 `;


### PR DESCRIPTION
I've updated most of our button stylings, but saw that our TextButton component has it's own stand-alone focus outline override. This PR adds the box-shadow we've been adding across components for keyboard navigation focus management. 

<img width="233" alt="Screen Shot 2020-07-22 at 3 26 54 PM" src="https://user-images.githubusercontent.com/13544620/88226063-22f27400-cc31-11ea-879f-354dba66d729.png">

Andrew and Ben tagged as a general FYI