### PR TITLE
[a11y] Add keyboard control to Accordion component

### DIFF
--- a/src/shared-components/accordion/__snapshots__/test.tsx.snap
+++ b/src/shared-components/accordion/__snapshots__/test.tsx.snap
@@ -51,14 +51,24 @@ exports[`<Accordion /> renders disabled accordion 1`] = `
   cursor: not-allowed;
 }
 
+.emotion-4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+}
+
 <div
   className="emotion-8 emotion-9"
   disabled={true}
 >
   <div
+    aria-disabled={true}
+    aria-expanded={false}
     className="emotion-4 emotion-5"
     disabled={true}
     onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex={-1}
   >
     <div
       className="emotion-0 emotion-1"
@@ -79,6 +89,8 @@ exports[`<Accordion /> renders disabled accordion 1`] = `
     </div>
   </div>
   <div
+    aria-disabled={true}
+    aria-hidden={true}
     className="emotion-6 emotion-7"
   >
     <div>
@@ -101,6 +113,11 @@ exports[`<Accordion /> renders no border accordion 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   cursor: pointer;
+}
+
+.emotion-4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
 }
 
 .emotion-0 {
@@ -142,9 +159,14 @@ exports[`<Accordion /> renders no border accordion 1`] = `
   disabled={false}
 >
   <div
+    aria-disabled={false}
+    aria-expanded={false}
     className="emotion-4 emotion-5"
     disabled={false}
     onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex={0}
   >
     <div
       className="emotion-0 emotion-1"
@@ -165,6 +187,8 @@ exports[`<Accordion /> renders no border accordion 1`] = `
     </div>
   </div>
   <div
+    aria-disabled={false}
+    aria-hidden={true}
     className="emotion-6 emotion-7"
   >
     <div>
@@ -198,6 +222,11 @@ exports[`<Accordion /> renders regular accordion 1`] = `
   cursor: pointer;
 }
 
+.emotion-4:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+}
+
 .emotion-0 {
   overflow: hidden;
   white-space: nowrap;
@@ -229,9 +258,14 @@ exports[`<Accordion /> renders regular accordion 1`] = `
   disabled={false}
 >
   <div
+    aria-disabled={false}
+    aria-expanded={false}
     className="emotion-4 emotion-5"
     disabled={false}
     onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    tabIndex={0}
   >
     <div
       className="emotion-0 emotion-1"
@@ -252,6 +286,8 @@ exports[`<Accordion /> renders regular accordion 1`] = `
     </div>
   </div>
   <div
+    aria-disabled={false}
+    aria-hidden={true}
     className="emotion-6 emotion-7"
   >
     <div>

--- a/src/shared-components/accordion/index.tsx
+++ b/src/shared-components/accordion/index.tsx
@@ -19,7 +19,9 @@ type AccordionProps = {
   disabled: boolean;
   isOpen: boolean;
   noBorder: boolean;
-  onClick: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  onClick: (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent> | React.KeyboardEvent,
+  ) => void;
   rightAlignArrow: boolean;
   title: React.ReactNode;
 };
@@ -91,6 +93,13 @@ class Accordion extends React.Component<
     }
   }
 
+  handleKeyDown = (event: React.KeyboardEvent): void => {
+    const { onClick, disabled } = this.props;
+    if (!disabled && event.key === 'Enter') {
+      onClick(event);
+    }
+  };
+
   render() {
     const { contentHeight } = this.state;
     const {
@@ -111,7 +120,12 @@ class Accordion extends React.Component<
               onClick(event);
             }
           }}
+          onKeyDown={this.handleKeyDown}
           disabled={!!disabled}
+          role="button"
+          tabIndex={disabled ? -1 : 0}
+          aria-disabled={!!disabled}
+          aria-expanded={isOpen}
         >
           <Truncate>{title}</Truncate>
           <ArrowWrapper rightAlign={!!rightAlignArrow}>
@@ -123,7 +137,11 @@ class Accordion extends React.Component<
             />
           </ArrowWrapper>
         </TitleWrapper>
-        <ExpansionWrapper contentHeight={contentHeight}>
+        <ExpansionWrapper
+          contentHeight={contentHeight}
+          aria-disabled={!!disabled}
+          aria-hidden={!isOpen}
+        >
           <div ref={this.contentRef}>{children}</div>
         </ExpansionWrapper>
       </AccordionBox>

--- a/src/shared-components/accordion/style.ts
+++ b/src/shared-components/accordion/style.ts
@@ -72,6 +72,10 @@ export const TitleWrapper = styled.div<{ disabled: boolean }>`
   display: flex;
   justify-content: space-between;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  &:focus {
+    outline: none;
+    box-shadow: ${BOX_SHADOWS.focusSecondary};
+  }
 `;
 
 export const Truncate = styled.div`


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/1182623358122135/1182893274583743)

In this PR:

  * Adds a keyDown listener so that you can expand or close the Accordion using the Enter key
  * Provides tabIndex, role, and our custom focus state to the Accordion title to make the button focusable
  * Uses `aria-expanded`, `aria-disabled`, and `aria-hidden` to provide additional info to screen readers and to ensure that disabled components will not raise color-contrast issues 
