### PR TITLE
Add disabled prop to Checkbox component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# v10.1.1
+
+- Adds a disabled prop to the Checkbox component
+
 # v10.1.0
 
 - [Internal] TypeScript conversion: Callout and Carousel ([#300](https://github.com/curology/radiance-ui/pull/300))

--- a/docs/checkbox.md
+++ b/docs/checkbox.md
@@ -11,6 +11,9 @@ import { Checkbox } from 'radiance-ui';
 <Checkbox type='secondary' checked>
  This is a secondary checkbox
 </Checkbox>
+<Checkbox checked disabled>
+ This is a disabled checkbox
+</Checkbox>
 ```
 
  <!-- STORY -->
@@ -20,6 +23,7 @@ import { Checkbox } from 'radiance-ui';
 | prop     | propType | required | default         | description                                                                                             |
 | -------- | -------- | -------- | --------------- | ------------------------------------------------------------------------------------------------------- |
 | checked  | bool     | yes      | -               | control prop for checked state                                                                          |
+| disabled | bool     | no       | false           | when disabled, click listener will not be called and the UI will look disabled                          |
 | type     | string   | no       | primary         | must be one of: 'primary', 'secondary'                                                                  |
 | icon     | node     | no       | -               | icon optionally displayed inside the radio button. Icons are only displayed at the 'large' size         |
 | size     | string   | no       | small           | must be one of: 'large', 'small'                                                                        |  |

--- a/src/shared-components/checkbox/index.js
+++ b/src/shared-components/checkbox/index.js
@@ -5,6 +5,7 @@ import SelectorButton from '../selectorButton';
 
 const propTypes = {
   checked: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
   onClick: PropTypes.func,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
@@ -17,6 +18,7 @@ const propTypes = {
 
 const defaultProps = {
   children: null,
+  disabled: false,
   icon: undefined,
   onClick: () => undefined,
   type: 'primary',
@@ -25,6 +27,7 @@ const defaultProps = {
 
 const Checkbox = ({
   checked,
+  disabled,
   onClick,
   children,
   type,
@@ -35,7 +38,8 @@ const Checkbox = ({
   <SelectorButton
     selector="checkbox"
     checked={checked}
-    onClick={onClick}
+    disabled={disabled}
+    onClick={!disabled ? onClick : event => event.preventDefault()}
     type={type}
     icon={icon}
     size={size}

--- a/src/shared-components/selectorButton/__snapshots__/test.js.snap
+++ b/src/shared-components/selectorButton/__snapshots__/test.js.snap
@@ -18,7 +18,6 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 }
 
 .emotion-1 {
-  cursor: pointer;
   fill: currentColor;
   left: 50%;
   position: absolute;
@@ -26,6 +25,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
+  cursor: pointer;
 }
 
 .emotion-7 {
@@ -110,6 +110,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
   >
     <div
       className="emotion-1 emotion-2"
+      disabled={false}
     >
       <svg
         className="emotion-0"
@@ -120,6 +121,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
     <div
       checked={true}
       className="emotion-3 emotion-4"
+      disabled={false}
       size="large"
       type="primary"
     />
@@ -176,7 +178,6 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 }
 
 .emotion-1 {
-  cursor: pointer;
   fill: currentColor;
   left: 50%;
   position: absolute;
@@ -184,6 +185,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
+  cursor: pointer;
 }
 
 .emotion-7 {
@@ -242,6 +244,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
   >
     <div
       className="emotion-1 emotion-2"
+      disabled={false}
     >
       <svg
         className="emotion-0"
@@ -252,6 +255,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
     <div
       checked={true}
       className="emotion-3 emotion-4"
+      disabled={false}
       size="large"
       type="primary"
     />
@@ -282,7 +286,6 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for check
 }
 
 .emotion-0 {
-  cursor: pointer;
   fill: currentColor;
   left: 50%;
   position: absolute;
@@ -290,6 +293,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for check
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
+  cursor: pointer;
 }
 
 .emotion-6 {
@@ -370,6 +374,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for check
   >
     <div
       className="emotion-0 emotion-1"
+      disabled={false}
     >
       <svg
         height={16}
@@ -379,6 +384,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for check
     <div
       checked={false}
       className="emotion-2 emotion-3"
+      disabled={false}
       size="large"
       type="primary"
     />
@@ -435,7 +441,6 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for radio
 }
 
 .emotion-0 {
-  cursor: pointer;
   fill: currentColor;
   left: 50%;
   position: absolute;
@@ -443,6 +448,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for radio
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
+  cursor: pointer;
 }
 
 .emotion-6 {
@@ -497,6 +503,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for radio
   >
     <div
       className="emotion-0 emotion-1"
+      disabled={false}
     >
       <svg
         height={16}
@@ -506,6 +513,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for radio
     <div
       checked={false}
       className="emotion-2 emotion-3"
+      disabled={false}
       size="large"
       type="primary"
     />
@@ -536,7 +544,6 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for checkbox
 }
 
 .emotion-0 {
-  cursor: pointer;
   fill: currentColor;
   left: 50%;
   position: absolute;
@@ -544,6 +551,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for checkbox
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
+  cursor: pointer;
 }
 
 .emotion-6 {
@@ -624,10 +632,12 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for checkbox
   >
     <div
       className="emotion-0 emotion-1"
+      disabled={false}
     />
     <div
       checked={false}
       className="emotion-2 emotion-3"
+      disabled={false}
       size="small"
       type="primary"
     />
@@ -684,7 +694,6 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for radio bu
 }
 
 .emotion-0 {
-  cursor: pointer;
   fill: currentColor;
   left: 50%;
   position: absolute;
@@ -692,6 +701,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for radio bu
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
+  cursor: pointer;
 }
 
 .emotion-2 {
@@ -746,10 +756,12 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for radio bu
   >
     <div
       className="emotion-0 emotion-1"
+      disabled={false}
     />
     <div
       checked={false}
       className="emotion-2 emotion-3"
+      disabled={false}
       size="small"
       type="primary"
     />
@@ -806,7 +818,6 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
 }
 
 .emotion-1 {
-  cursor: pointer;
   fill: currentColor;
   left: 50%;
   position: absolute;
@@ -814,6 +825,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
+  cursor: pointer;
 }
 
 .emotion-7 {
@@ -872,6 +884,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
   >
     <div
       className="emotion-1 emotion-2"
+      disabled={false}
     >
       <svg
         className="emotion-0"
@@ -882,6 +895,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
     <div
       checked={true}
       className="emotion-3 emotion-4"
+      disabled={false}
       type="primary"
     />
   </div>
@@ -937,7 +951,6 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
 }
 
 .emotion-1 {
-  cursor: pointer;
   fill: currentColor;
   left: 50%;
   position: absolute;
@@ -945,6 +958,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
+  cursor: pointer;
 }
 
 .emotion-7 {
@@ -1003,6 +1017,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
   >
     <div
       className="emotion-1 emotion-2"
+      disabled={false}
     >
       <svg
         className="emotion-0"
@@ -1013,6 +1028,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
     <div
       checked={true}
       className="emotion-3 emotion-4"
+      disabled={false}
       type="secondary"
     />
   </div>
@@ -1068,7 +1084,6 @@ exports[`<SelectorButton /> UI snapshots when children is a node 1`] = `
 }
 
 .emotion-0 {
-  cursor: pointer;
   fill: currentColor;
   left: 50%;
   position: absolute;
@@ -1076,6 +1091,7 @@ exports[`<SelectorButton /> UI snapshots when children is a node 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
+  cursor: pointer;
 }
 
 .emotion-2 {
@@ -1130,10 +1146,12 @@ exports[`<SelectorButton /> UI snapshots when children is a node 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
+      disabled={false}
     />
     <div
       checked={false}
       className="emotion-2 emotion-3"
+      disabled={false}
       type="primary"
     />
   </div>
@@ -1189,7 +1207,6 @@ exports[`<SelectorButton /> UI snapshots when children is undefined 1`] = `
 }
 
 .emotion-0 {
-  cursor: pointer;
   fill: currentColor;
   left: 50%;
   position: absolute;
@@ -1197,6 +1214,7 @@ exports[`<SelectorButton /> UI snapshots when children is undefined 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
+  cursor: pointer;
 }
 
 .emotion-2 {
@@ -1244,10 +1262,12 @@ exports[`<SelectorButton /> UI snapshots when children is undefined 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
+      disabled={false}
     />
     <div
       checked={false}
       className="emotion-2 emotion-3"
+      disabled={false}
       type="primary"
     />
   </div>
@@ -1272,7 +1292,6 @@ exports[`<SelectorButton /> UI snapshots when is checkbox 1`] = `
 }
 
 .emotion-0 {
-  cursor: pointer;
   fill: currentColor;
   left: 50%;
   position: absolute;
@@ -1280,6 +1299,7 @@ exports[`<SelectorButton /> UI snapshots when is checkbox 1`] = `
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
+  cursor: pointer;
 }
 
 .emotion-6 {
@@ -1360,10 +1380,12 @@ exports[`<SelectorButton /> UI snapshots when is checkbox 1`] = `
   >
     <div
       className="emotion-0 emotion-1"
+      disabled={false}
     />
     <div
       checked={false}
       className="emotion-2 emotion-3"
+      disabled={false}
       type="primary"
     />
   </div>

--- a/src/shared-components/selectorButton/index.js
+++ b/src/shared-components/selectorButton/index.js
@@ -15,6 +15,7 @@ import {
 
 const propTypes = {
   checked: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
   onClick: PropTypes.func,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
@@ -27,6 +28,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  disabled: false,
   onClick: undefined,
   type: 'primary',
   selector: 'radio',
@@ -37,6 +39,7 @@ const defaultProps = {
 
 const SelectorButton = ({
   checked,
+  disabled,
   onClick,
   children,
   type,
@@ -75,12 +78,13 @@ const SelectorButton = ({
       {...rest}
     >
       <SelectorContainer>
-        <SelectorIcon>
+        <SelectorIcon disabled={disabled}>
           {checked ? checkedIcon : size === 'large' && icon}
         </SelectorIcon>
         <Selector
           type={type}
           checked={checked}
+          disabled={disabled}
           selector={selector}
           size={size}
         />

--- a/src/shared-components/selectorButton/style.js
+++ b/src/shared-components/selectorButton/style.js
@@ -51,8 +51,8 @@ const secondarySelectorStyle = checked => css`
 `;
 
 const disabledSelectorStyle = css`
-  background-color: ${COLORS.purple30};
-  border-color: ${COLORS.purple30};
+  background-color: ${COLORS.disabled};
+  border-color: ${COLORS.disabled};
   cursor: not-allowed;
 `;
 

--- a/src/shared-components/selectorButton/style.js
+++ b/src/shared-components/selectorButton/style.js
@@ -51,8 +51,8 @@ const secondarySelectorStyle = checked => css`
 `;
 
 const disabledSelectorStyle = css`
-  background-color: ${COLORS.disabled};
-  border-color: ${COLORS.disabled};
+  background-color: ${COLORS.purple30};
+  border-color: ${COLORS.purple30};
   cursor: not-allowed;
 `;
 

--- a/src/shared-components/selectorButton/style.js
+++ b/src/shared-components/selectorButton/style.js
@@ -30,12 +30,14 @@ export const OuterContainer = styled.div`
 `;
 
 export const SelectorIcon = styled.div`
-  cursor: pointer;
   fill: currentColor;
   left: 50%;
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);
+  ${({ disabled }) => css`
+    cursor: ${disabled ? 'not-allowed' : 'pointer'};
+  `};
 `;
 
 const primarySelectorStyle = checked => css`
@@ -46,6 +48,12 @@ const primarySelectorStyle = checked => css`
 const secondarySelectorStyle = checked => css`
   background-color: ${checked ? COLORS.secondary : 'transparent'};
   border-color: ${checked ? COLORS.secondary : COLORS.primary};
+`;
+
+const disabledSelectorStyle = css`
+  background-color: ${COLORS.purple30};
+  border-color: ${COLORS.purple30};
+  cursor: not-allowed;
 `;
 
 export const Selector = styled.div`
@@ -62,7 +70,10 @@ export const Selector = styled.div`
 
   ${({ selector }) => css`
     border-radius: ${selector === 'checkbox' ? '4px' : '100%'};
-  `} ${({ type, checked }) => {
+  `} ${({ type, checked, disabled }) => {
+    if (disabled) {
+      return disabledSelectorStyle;
+    }
     switch (type) {
       case 'primary':
         return primarySelectorStyle(checked);

--- a/stories/checkbox/index.js
+++ b/stories/checkbox/index.js
@@ -39,6 +39,7 @@ stories.add(
       </Typography.Heading>
       <Checkbox
         checked={boolean('checked', false)}
+        disabled={boolean('disabled', false)}
         type={select('type', ['primary', 'secondary'], 'primary')}
         onClick={action('checkbox clicked')}
         icon={

--- a/stories/checkbox/index.js
+++ b/stories/checkbox/index.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withDocs } from 'storybook-readme';
-import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
+import {
+  withKnobs, text, boolean, select, 
+} from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { css } from '@emotion/core';
-
+// eslint-disable-next-line import/extensions
 import CheckboxReadme from 'docs/checkbox.md';
 import { Checkbox, Typography } from 'src/shared-components';
 import { SPACER } from 'src/constants';
@@ -23,6 +25,9 @@ stories.add(
       </Checkbox>
       <Checkbox type="secondary" checked>
         This is a secondary checkbox
+      </Checkbox>
+      <Checkbox checked disabled>
+        This is a disabled checkbox
       </Checkbox>
       <Typography.Heading
         css={css`
@@ -46,5 +51,5 @@ stories.add(
         {text('children', 'Render checkbox label here')}
       </Checkbox>
     </React.Fragment>
-  ))
+  )),
 );


### PR DESCRIPTION
This PR adds a disabled prop to the Checkbox component and disables the checkbox when this prop is true by changing the background color of it and preventing the user from clicking the checkbox. This is needed more immediately for the CCPA Opt Out project.

Note: This is no longer needed for the CCPA Opt Out project (we decided to use a button instead), but I might as well still publish this in Radiance since I did the work for it.

<img width="274" alt="Screen Shot 2020-08-10 at 4 14 16 PM" src="https://user-images.githubusercontent.com/22719577/89826651-8ed74680-db24-11ea-9e47-cd62586312d6.png">
