### PR TITLE
[a11y] Fix dropdown aria-label and ID

### DIFF
--- a/src/shared-components/dropdown/desktopDropdown.tsx
+++ b/src/shared-components/dropdown/desktopDropdown.tsx
@@ -64,11 +64,9 @@ const DesktopDropdown = ({
     >
       <DropdownContainer textAlign={textAlign}>
         <div
-          id="select-input-box"
           onClick={onSelectClick}
           onKeyDown={handleKeyDown}
           tabIndex={0}
-          aria-label="Open dropdown option"
           aria-haspopup="menu"
           role="button"
           ref={initialFocus}
@@ -86,7 +84,6 @@ const DesktopDropdown = ({
           optionsContainerMaxHeight={optionsContainerMaxHeight}
           role="menu"
           aria-activedescendant={value}
-          aria-labelledby="select-input-box"
           aria-hidden={!isOpen}
         >
           {options.map(option => {

--- a/src/shared-components/dropdown/test.tsx
+++ b/src/shared-components/dropdown/test.tsx
@@ -84,7 +84,7 @@ describe('<DesktopDropdown />', () => {
 
     expect(
       wrapper
-        .find('#select-input-box')
+        .find('[role="button"]')
         .text()
         .includes('Test1'),
     ).toEqual(true);
@@ -104,7 +104,7 @@ describe('<DesktopDropdown />', () => {
         />,
       );
 
-      wrapper.find('#select-input-box').simulate('click');
+      wrapper.find('[role="button"]').simulate('click');
       expect(spy).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
After upgrading to the WCAG 2.1 standard in our Cypress test, there was an issue raised with the dropdown component's aria-label. The 2.1 standard includes a rule that the text of an element should be contained within the `aria-label` https://dequeuniversity.com/rules/axe/3.5/label-content-name-mismatch?application=axeAPI The `aria-label` I was using on the component was too generic. I tested this using a screen reader and actually found that it worked well without the `aria-label`, because the `role` and `haspopup` attributes made it reasonably clear the intention. More user testing would be required to be sure, but for now I'd rather have less `aria` information than incorrect information. 

In addition, I removed the `id` from the Dropdown. There are some places where we render multiple `Dropdown` components, which leads to the `id` not being unique. 