### PR TITLE
Update Carousel component to have bottom right aligned arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# v11.1.0
+
+- Adds new positioning of arrows to the Carousel component. It is denoted as a prop with the name 'bottomRightAlignedArrows'.
+
 # v11.0.0
 
 This update is **potentially breaking**. Applications that use different versions of emotion than those used in `radiance-ui` can result in unexpected behavior when adding styling to already-styled components. This update adds explicit `peerDependencies` to account for this.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # CHANGELOG
 
-# v11.1.0
-
-- Adds new positioning of arrows to the Carousel component. It is denoted as a prop with the name 'bottomRightAlignedArrows'.
-
 # v11.0.0
 
 This update is **potentially breaking**. Applications that use different versions of emotion than those used in `radiance-ui` can result in unexpected behavior when adding styling to already-styled components. This update adds explicit `peerDependencies` to account for this.

--- a/docs/carousel.md
+++ b/docs/carousel.md
@@ -42,7 +42,7 @@ const cards = [
 <Carousel numCardsVisible={1} hideArrows>{cards}</Carousel>
 
 // Bottom Right Aligned Arrows
-<Carousel numCardsVisible={2} bottomRightAlignedArrows hideDots>{cards}</Carousel>
+<Carousel numCardsVisible={2} bottomRightAlignedArrows>{cards}</Carousel>
 
 // Secondary Style - dots are white
 <Carousel numCardsVisible={1} carouselType="secondary">{cards}</Carousel>
@@ -61,7 +61,7 @@ const cards = [
 | children                 | node     | yes      | -         | array of `Carousel.Card`                                                     |
 | hideDots                 | bool     | no       | false     | hide the dots                                                                |
 | hideArrows               | bool     | no       | false     | hide the arrows                                                              |
-| bottomRightAlignedArrows | bool     | no       | false     | align the arrows on the bottom right                                         |
+| bottomRightAlignedArrows | bool     | no       | false     | align the arrows on the bottom right (dots are automatically hidden)         |
 | infinite                 | bool     | no       | false     | creates a carousel loop, i.e. if true you can go backwards form the begining |
 | numCardsVisible          | number   | yes      | -         | number of visible cards, must be one of: 1, 2 or 3                           |
 

--- a/docs/carousel.md
+++ b/docs/carousel.md
@@ -1,4 +1,5 @@
 # Carousel
+
 ## Usage
 
 ```jsx
@@ -40,6 +41,9 @@ const cards = [
 // Hide Arrows (swipe to navigate)
 <Carousel numCardsVisible={1} hideArrows>{cards}</Carousel>
 
+// Bottom Right Aligned Arrows
+<Carousel numCardsVisible={1} bottomRightAlignedArrows>{cards}</Carousel>
+
 // Secondary Style - dots are white
 <Carousel numCardsVisible={1} carouselType="secondary">{cards}</Carousel>
 ```
@@ -47,19 +51,22 @@ const cards = [
 <!-- STORY -->
 
 ### Proptypes
-| prop                | propType   | required | default      | description                                                                                                                  
-|---------------------|------------|----------|--------------|------------------------------------------------------------------------------------------------------------------------------|
-| autoplay            | bool       | no       | false        | auto advance the carousel cards |
-| autoplaySpeed       | number     | no       | 5000         | autoplay speed in milliseconds (ignored if autoplay is false) |
-| carouselType        | string     | no       | 'primary'    | must be one of: 'primary', 'secondary' |
-| centerMode          | bool       | no       | true         | center the current card |
-| children            | node       | yes      | -            | array of `Carousel.Card` |
-| hideArrows          | bool       | no       | false        | hide the arrows |
-| hideDots            | bool       | no       | false        | hide the dots |
-| infinite            | bool       | no       | false        | creates a carousel loop, i.e. if true you can go backwards form the begining |
-| numCardsVisible     | number     | yes      | -            | number of visible cards, must be one of: 1, 2 or 3 |
+
+| prop                     | propType | required | default   | description                                                                  |
+| ------------------------ | -------- | -------- | --------- | ---------------------------------------------------------------------------- |
+| autoplay                 | bool     | no       | false     | auto advance the carousel cards                                              |
+| autoplaySpeed            | number   | no       | 5000      | autoplay speed in milliseconds (ignored if autoplay is false)                |
+| carouselType             | string   | no       | 'primary' | must be one of: 'primary', 'secondary'                                       |
+| centerMode               | bool     | no       | true      | center the current card                                                      |
+| children                 | node     | yes      | -         | array of `Carousel.Card`                                                     |
+| hideDots                 | bool     | no       | false     | hide the dots                                                                |
+| hideArrows               | bool     | no       | false     | hide the arrows                                                              |
+| bottomRightAlignedArrows | bool     | no       | false     | align the arrows on the bottom right                                         |
+| infinite                 | bool     | no       | false     | creates a carousel loop, i.e. if true you can go backwards form the begining |
+| numCardsVisible          | number   | yes      | -         | number of visible cards, must be one of: 1, 2 or 3                           |
 
 ### Notes
+
 The property `numCardsVisible` will define the width of the Carousel Container.
 
 An array of `Carousel.Card` must be used for the carousel content. It includes the base styles for the Card which may be extended as shown above.

--- a/docs/carousel.md
+++ b/docs/carousel.md
@@ -42,7 +42,7 @@ const cards = [
 <Carousel numCardsVisible={1} hideArrows>{cards}</Carousel>
 
 // Bottom Right Aligned Arrows
-<Carousel numCardsVisible={1} bottomRightAlignedArrows>{cards}</Carousel>
+<Carousel numCardsVisible={2} bottomRightAlignedArrows hideDots>{cards}</Carousel>
 
 // Secondary Style - dots are white
 <Carousel numCardsVisible={1} carouselType="secondary">{cards}</Carousel>

--- a/src/shared-components/carousel/__snapshots__/test.tsx.snap
+++ b/src/shared-components/carousel/__snapshots__/test.tsx.snap
@@ -1,5 +1,248 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Carousel /> UI snapshots renders with bottom right aligned arrows 1`] = `
+.emotion-2 {
+  overflow: hidden !important;
+  padding-bottom: 1.5rem;
+}
+
+.emotion-2 .slick-slider {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 0 1.5rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  -khtml-user-select: none;
+  -ms-touch-action: pan-y;
+  touch-action: pan-y;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.emotion-2 .slick-list {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  overflow: hidden;
+}
+
+.emotion-2 .slick-list:focus {
+  outline: none;
+}
+
+.emotion-2 .slick-list.dragging {
+  cursor: pointer;
+  cursor: hand;
+}
+
+.emotion-2 .slick-slider .slick-track,
+.emotion-2 .slick-slider .slick-list {
+  -webkit-transform: translate3d(0,0,0);
+  -moz-transform: translate3d(0,0,0);
+  -ms-transform: translate3d(0,0,0);
+  -o-transform: translate3d(0,0,0);
+  -webkit-transform: translate3d(0,0,0);
+  -ms-transform: translate3d(0,0,0);
+  transform: translate3d(0,0,0);
+}
+
+.emotion-2 .slick-track {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-2 .slick-loading .slick-track {
+  visibility: hidden;
+}
+
+.emotion-2 .slick-slide {
+  display: none;
+  float: left;
+  height: 100%;
+  min-height: 1px;
+}
+
+.emotion-2 .slick-slide.slick-loading img {
+  display: none;
+}
+
+.emotion-2 .slick-slide.dragging img {
+  pointer-events: none;
+}
+
+.emotion-2 .slick-initialized .slick-slide {
+  display: block;
+}
+
+.emotion-2 .slick-loading .slick-slide {
+  visibility: hidden;
+}
+
+.emotion-2 .slick-vertical .slick-slide {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: auto;
+  border: 1px solid transparent;
+}
+
+.emotion-2 .slick-arrow.slick-hidden {
+  display: none;
+}
+
+.emotion-2 .slick-slider {
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.emotion-2 .slick-dots {
+  display: -webkit-box !important;
+  display: -webkit-flex !important;
+  display: -ms-flexbox !important;
+  display: flex !important;
+  position: absolute;
+  left: 50%;
+  -webkit-transform: translate(-50%);
+  -ms-transform: translate(-50%);
+  transform: translate(-50%);
+  bottom: -32px;
+}
+
+.emotion-2 .slick-dots li {
+  border-radius: 50%;
+  height: 0.25rem;
+  width: 0.25rem;
+  margin-right: 0.25rem;
+  opacity: 0.25;
+}
+
+.emotion-2 .slick-dots li:first-of-type {
+  margin-left: 0.25rem;
+}
+
+.emotion-2 .slick-dots li button {
+  display: none;
+}
+
+.emotion-2 .slick-dots li.slick-active {
+  opacity: 1;
+}
+
+.emotion-2 .slick-dots li {
+  background-color: #332e54;
+}
+
+.emotion-0 {
+  width: 311px !important;
+  min-height: 48px;
+  margin: 0 0.5rem;
+}
+
+.emotion-4 {
+  max-width: 702px;
+}
+
+<div
+  className="emotion-4 emotion-5"
+>
+  <div
+    className="emotion-2 emotion-3"
+    onClick={[Function]}
+  >
+    <div
+      className="slick-slider slick-initialized"
+    >
+      
+      <div
+        className="slick-list"
+      >
+        <div
+          className="slick-track"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          style={
+            Object {
+              "WebkitTransform": "translate3d(0px, 0px, 0px)",
+              "WebkitTransition": "",
+              "msTransform": "translateX(0px)",
+              "opacity": 1,
+              "transform": "translate3d(0px, 0px, 0px)",
+              "transition": "",
+            }
+          }
+        >
+          <div
+            aria-hidden={false}
+            className="slick-slide slick-active slick-current"
+            data-index={0}
+            onClick={[Function]}
+            style={
+              Object {
+                "outline": "none",
+                "width": null,
+              }
+            }
+            tabIndex="-1"
+          >
+            <div>
+              <div
+                className="emotion-0 emotion-1"
+                style={
+                  Object {
+                    "display": "inline-block",
+                    "width": "100%",
+                  }
+                }
+                tabIndex={-1}
+              >
+                Card 1
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Carousel /> UI snapshots renders with props 1`] = `
 .emotion-4 {
   max-width: 375px;
@@ -125,6 +368,12 @@ exports[`<Carousel /> UI snapshots renders with props 1`] = `
 
 .emotion-2 .slick-arrow.slick-hidden {
   display: none;
+}
+
+.emotion-2 .slick-slider {
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .emotion-2 .slick-dots {

--- a/src/shared-components/carousel/arrow/__snapshots__/test.tsx.snap
+++ b/src/shared-components/carousel/arrow/__snapshots__/test.tsx.snap
@@ -1,0 +1,646 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Arrow /> UI snapshots renders with bottom right alignment 1`] = `
+@keyframes animation-0 {
+  0% {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0) scale(1,1);
+    -ms-transform: translate3d(0,0,0) scale(1,1);
+    transform: translate3d(0,0,0) scale(1,1);
+  }
+
+  20% {
+    opacity: .95;
+    -webkit-transform: translate3d(12px,0,0) scale(1,1);
+    -ms-transform: translate3d(12px,0,0) scale(1,1);
+    transform: translate3d(12px,0,0) scale(1,1);
+  }
+
+  35% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0) scale(.85,.85);
+    -ms-transform: translate3d(16px,0,0) scale(.85,.85);
+    transform: translate3d(16px,0,0) scale(.85,.85);
+  }
+
+  100% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0);
+    -ms-transform: translate3d(16px,0,0);
+    transform: translate3d(16px,0,0);
+  }
+}
+
+@keyframes animation-0 {
+  0% {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0) scale(1,1);
+    -ms-transform: translate3d(0,0,0) scale(1,1);
+    transform: translate3d(0,0,0) scale(1,1);
+  }
+
+  20% {
+    opacity: .95;
+    -webkit-transform: translate3d(12px,0,0) scale(1,1);
+    -ms-transform: translate3d(12px,0,0) scale(1,1);
+    transform: translate3d(12px,0,0) scale(1,1);
+  }
+
+  35% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0) scale(.85,.85);
+    -ms-transform: translate3d(16px,0,0) scale(.85,.85);
+    transform: translate3d(16px,0,0) scale(.85,.85);
+  }
+
+  100% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0);
+    -ms-transform: translate3d(16px,0,0);
+    transform: translate3d(16px,0,0);
+  }
+}
+
+@keyframes animation-0 {
+  0% {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0) scale(1,1);
+    -ms-transform: translate3d(0,0,0) scale(1,1);
+    transform: translate3d(0,0,0) scale(1,1);
+  }
+
+  20% {
+    opacity: .95;
+    -webkit-transform: translate3d(12px,0,0) scale(1,1);
+    -ms-transform: translate3d(12px,0,0) scale(1,1);
+    transform: translate3d(12px,0,0) scale(1,1);
+  }
+
+  35% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0) scale(.85,.85);
+    -ms-transform: translate3d(16px,0,0) scale(.85,.85);
+    transform: translate3d(16px,0,0) scale(.85,.85);
+  }
+
+  100% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0);
+    -ms-transform: translate3d(16px,0,0);
+    transform: translate3d(16px,0,0);
+  }
+}
+
+@keyframes animation-0 {
+  0% {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0) scale(1,1);
+    -ms-transform: translate3d(0,0,0) scale(1,1);
+    transform: translate3d(0,0,0) scale(1,1);
+  }
+
+  20% {
+    opacity: .95;
+    -webkit-transform: translate3d(12px,0,0) scale(1,1);
+    -ms-transform: translate3d(12px,0,0) scale(1,1);
+    transform: translate3d(12px,0,0) scale(1,1);
+  }
+
+  35% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0) scale(.85,.85);
+    -ms-transform: translate3d(16px,0,0) scale(.85,.85);
+    transform: translate3d(16px,0,0) scale(.85,.85);
+  }
+
+  100% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0);
+    -ms-transform: translate3d(16px,0,0);
+    transform: translate3d(16px,0,0);
+  }
+}
+
+@keyframes animation-0 {
+  0% {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0) scale(1,1);
+    -ms-transform: translate3d(0,0,0) scale(1,1);
+    transform: translate3d(0,0,0) scale(1,1);
+  }
+
+  20% {
+    opacity: .95;
+    -webkit-transform: translate3d(12px,0,0) scale(1,1);
+    -ms-transform: translate3d(12px,0,0) scale(1,1);
+    transform: translate3d(12px,0,0) scale(1,1);
+  }
+
+  35% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0) scale(.85,.85);
+    -ms-transform: translate3d(16px,0,0) scale(.85,.85);
+    transform: translate3d(16px,0,0) scale(.85,.85);
+  }
+
+  100% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0);
+    -ms-transform: translate3d(16px,0,0);
+    transform: translate3d(16px,0,0);
+  }
+}
+
+@keyframes animation-0 {
+  0% {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0) scale(1,1);
+    -ms-transform: translate3d(0,0,0) scale(1,1);
+    transform: translate3d(0,0,0) scale(1,1);
+  }
+
+  20% {
+    opacity: .95;
+    -webkit-transform: translate3d(12px,0,0) scale(1,1);
+    -ms-transform: translate3d(12px,0,0) scale(1,1);
+    transform: translate3d(12px,0,0) scale(1,1);
+  }
+
+  35% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0) scale(.85,.85);
+    -ms-transform: translate3d(16px,0,0) scale(.85,.85);
+    transform: translate3d(16px,0,0) scale(.85,.85);
+  }
+
+  100% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0);
+    -ms-transform: translate3d(16px,0,0);
+    transform: translate3d(16px,0,0);
+  }
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-6 {
+  display: block;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  margin: 0.5rem;
+  -webkit-order: 2;
+  -ms-flex-order: 2;
+  order: 2;
+  margin-left: auto;
+}
+
+.emotion-6 button {
+  background-color: none;
+  border-color: #332e54;
+  color: #332e54;
+}
+
+.emotion-6 button:hover {
+  color: #332e54;
+}
+
+.emotion-2 {
+  color: #524D6E;
+  font-size: 0.75rem;
+  line-height: 1.67;
+  font-weight: bold;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0.25rem;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: block;
+  margin: 0;
+  min-height: 52px;
+  opacity: 1;
+  padding: 0 1.5rem;
+  position: relative;
+  -webkit-transition: all 350ms ease-in-out;
+  transition: all 350ms ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: #ededf0;
+  border-color: #ededf0;
+  color: #c3c0cd;
+  cursor: not-allowed;
+  fill: #c3c0cd;
+  min-width: 208px;
+  max-width: 325px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  border-radius: 50%;
+  max-width: unset;
+  min-height: unset;
+  min-width: unset;
+  height: 48px;
+  width: 48px;
+  padding: 0;
+}
+
+.emotion-2:hover {
+  -webkit-transition: all 350ms ease-in-out;
+  transition: all 350ms ease-in-out;
+}
+
+.emotion-2:active,
+.emotion-2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+}
+
+.emotion-2:visited,
+.emotion-2:hover {
+  opacity: 1;
+  color: #c3c0cd;
+}
+
+.emotion-2 > svg {
+  opacity: 1;
+  -webkit-transition: opacity 350ms;
+  transition: opacity 350ms;
+  margin: 0 auto;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  top: 0;
+  margin-top: -6px;
+  width: 38px;
+  opacity: 0;
+  width: 36px;
+  margin: -3px -3px 0 0;
+}
+
+.emotion-0 span {
+  border-radius: 50%;
+  display: inline-block;
+  height: 4px;
+  width: 4px;
+  position: absolute;
+}
+
+.emotion-0 span:nth-of-type(1) {
+  -webkit-animation: animation-0 1750ms infinite linear;
+  animation: animation-0 1750ms infinite linear;
+}
+
+.emotion-0 span:nth-of-type(2) {
+  -webkit-animation: animation-0 1750ms infinite linear -300ms;
+  animation: animation-0 1750ms infinite linear -300ms;
+}
+
+.emotion-0 span:nth-of-type(3) {
+  -webkit-animation: animation-0 1750ms infinite linear -600ms;
+  animation: animation-0 1750ms infinite linear -600ms;
+}
+
+.emotion-0 span {
+  background-color: #ffffff;
+}
+
+<div
+  className="emotion-6 emotion-7"
+  disabled={true}
+>
+  <div
+    className="emotion-4 emotion-5"
+  >
+    <button
+      className="emotion-2 emotion-3"
+      disabled={true}
+      onClick={[Function]}
+      type="button"
+    >
+      <svg />
+      <div
+        className="emotion-0 emotion-1"
+        disabled={true}
+      >
+        <div>
+          <span />
+          <span />
+          <span />
+        </div>
+      </div>
+    </button>
+    
+  </div>
+</div>
+`;
+
+exports[`<Arrow /> UI snapshots renders with props 1`] = `
+@keyframes animation-0 {
+  0% {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0) scale(1,1);
+    -ms-transform: translate3d(0,0,0) scale(1,1);
+    transform: translate3d(0,0,0) scale(1,1);
+  }
+
+  20% {
+    opacity: .95;
+    -webkit-transform: translate3d(12px,0,0) scale(1,1);
+    -ms-transform: translate3d(12px,0,0) scale(1,1);
+    transform: translate3d(12px,0,0) scale(1,1);
+  }
+
+  35% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0) scale(.85,.85);
+    -ms-transform: translate3d(16px,0,0) scale(.85,.85);
+    transform: translate3d(16px,0,0) scale(.85,.85);
+  }
+
+  100% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0);
+    -ms-transform: translate3d(16px,0,0);
+    transform: translate3d(16px,0,0);
+  }
+}
+
+@keyframes animation-0 {
+  0% {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0) scale(1,1);
+    -ms-transform: translate3d(0,0,0) scale(1,1);
+    transform: translate3d(0,0,0) scale(1,1);
+  }
+
+  20% {
+    opacity: .95;
+    -webkit-transform: translate3d(12px,0,0) scale(1,1);
+    -ms-transform: translate3d(12px,0,0) scale(1,1);
+    transform: translate3d(12px,0,0) scale(1,1);
+  }
+
+  35% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0) scale(.85,.85);
+    -ms-transform: translate3d(16px,0,0) scale(.85,.85);
+    transform: translate3d(16px,0,0) scale(.85,.85);
+  }
+
+  100% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0);
+    -ms-transform: translate3d(16px,0,0);
+    transform: translate3d(16px,0,0);
+  }
+}
+
+@keyframes animation-0 {
+  0% {
+    opacity: 1;
+    -webkit-transform: translate3d(0,0,0) scale(1,1);
+    -ms-transform: translate3d(0,0,0) scale(1,1);
+    transform: translate3d(0,0,0) scale(1,1);
+  }
+
+  20% {
+    opacity: .95;
+    -webkit-transform: translate3d(12px,0,0) scale(1,1);
+    -ms-transform: translate3d(12px,0,0) scale(1,1);
+    transform: translate3d(12px,0,0) scale(1,1);
+  }
+
+  35% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0) scale(.85,.85);
+    -ms-transform: translate3d(16px,0,0) scale(.85,.85);
+    transform: translate3d(16px,0,0) scale(.85,.85);
+  }
+
+  100% {
+    opacity: 0;
+    -webkit-transform: translate3d(16px,0,0);
+    -ms-transform: translate3d(16px,0,0);
+    transform: translate3d(16px,0,0);
+  }
+}
+
+.emotion-6 {
+  position: absolute;
+  top: 50%;
+  z-index: 2000;
+  -webkit-transform: translate(0%,-50%);
+  -ms-transform: translate(0%,-50%);
+  transform: translate(0%,-50%);
+  display: block;
+  left: 0.5rem;
+}
+
+.emotion-4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-2 {
+  color: #524D6E;
+  font-size: 0.75rem;
+  line-height: 1.67;
+  font-weight: bold;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0.25rem;
+  border-style: solid;
+  border-width: 1px;
+  cursor: pointer;
+  display: block;
+  margin: 0;
+  min-height: 52px;
+  opacity: 1;
+  padding: 0 1.5rem;
+  position: relative;
+  -webkit-transition: all 350ms ease-in-out;
+  transition: all 350ms ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  border-width: 1px;
+  border-color: #ededf0;
+  background-color: #ffffff;
+  color: #332e54;
+  fill: #332e54;
+  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.06);
+  min-width: 208px;
+  max-width: 325px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  border-radius: 50%;
+  max-width: unset;
+  min-height: unset;
+  min-width: unset;
+  height: 48px;
+  width: 48px;
+  padding: 0;
+}
+
+.emotion-2:hover {
+  -webkit-transition: all 350ms ease-in-out;
+  transition: all 350ms ease-in-out;
+}
+
+.emotion-2:active,
+.emotion-2:focus {
+  outline: none;
+  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+}
+
+.emotion-2:hover {
+  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.15);
+}
+
+.emotion-2:hover {
+  -webkit-transition: all 350ms ease-in-out;
+  transition: all 350ms ease-in-out;
+  opacity: 1;
+}
+
+.emotion-2 > svg {
+  opacity: 1;
+  -webkit-transition: opacity 350ms;
+  transition: opacity 350ms;
+  margin: 0 auto;
+}
+
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  top: 0;
+  margin-top: -6px;
+  width: 38px;
+  opacity: 0;
+  width: 36px;
+  margin: -3px -3px 0 0;
+}
+
+.emotion-0 span {
+  background-color: #332e54;
+  border-radius: 50%;
+  display: inline-block;
+  height: 4px;
+  width: 4px;
+  position: absolute;
+}
+
+.emotion-0 span:nth-of-type(1) {
+  -webkit-animation: animation-0 1750ms infinite linear;
+  animation: animation-0 1750ms infinite linear;
+}
+
+.emotion-0 span:nth-of-type(2) {
+  -webkit-animation: animation-0 1750ms infinite linear -300ms;
+  animation: animation-0 1750ms infinite linear -300ms;
+}
+
+.emotion-0 span:nth-of-type(3) {
+  -webkit-animation: animation-0 1750ms infinite linear -600ms;
+  animation: animation-0 1750ms infinite linear -600ms;
+}
+
+<div
+  className="emotion-6 emotion-7"
+  disabled={false}
+>
+  <div
+    className="emotion-4 emotion-5"
+  >
+    <button
+      className="emotion-2 emotion-3"
+      disabled={false}
+      onClick={[Function]}
+      type="button"
+    >
+      <svg />
+      <div
+        className="emotion-0 emotion-1"
+        disabled={false}
+      >
+        <div>
+          <span />
+          <span />
+          <span />
+        </div>
+      </div>
+    </button>
+    
+  </div>
+</div>
+`;

--- a/src/shared-components/carousel/arrow/index.tsx
+++ b/src/shared-components/carousel/arrow/index.tsx
@@ -4,9 +4,10 @@ import PropTypes from 'prop-types';
 import { RoundButton } from '../../button';
 import ArrowLeftIcon from '../../../svgs/icons/arrow-left-icon.svg';
 import ArrowRightIcon from '../../../svgs/icons/arrow-right-icon.svg';
-import ArrowContainer from './style';
+import { ArrowContainer, BottomRightAlignedArrowContainer } from './style';
 
 type ArrowProps = {
+  bottomRightAlignedArrows?: boolean;
   prev?: boolean;
   next?: boolean;
   disabled?: boolean;
@@ -15,6 +16,7 @@ type ArrowProps = {
 
 class Arrow extends React.Component<ArrowProps> {
   static propTypes = {
+    bottomRightAlignedArrows: PropTypes.bool,
     prev: PropTypes.bool,
     next: PropTypes.bool,
     disabled: PropTypes.bool,
@@ -22,6 +24,7 @@ class Arrow extends React.Component<ArrowProps> {
   };
 
   static defaultProps = {
+    bottomRightAlignedArrows: false,
     prev: false,
     next: false,
     disabled: false,
@@ -33,24 +36,35 @@ class Arrow extends React.Component<ArrowProps> {
   };
 
   render() {
-    const { prev = false, next = false, disabled = false } = this.props;
+    const {
+      bottomRightAlignedArrows = false,
+      prev = false,
+      next = false,
+      disabled = false,
+    } = this.props;
+    const ArrowContainerComponent = bottomRightAlignedArrows
+      ? BottomRightAlignedArrowContainer
+      : ArrowContainer;
+
     return (
-      <ArrowContainer prev={prev} next={next} disabled={disabled}>
+      <ArrowContainerComponent prev={prev} next={next} disabled={disabled}>
         {prev && (
           <RoundButton
-            buttonType="action"
+            buttonType={bottomRightAlignedArrows ? 'primary' : 'action'}
+            disabled={disabled}
             icon={<ArrowLeftIcon />}
             onClick={this.arrowClickHandler}
           />
         )}
         {next && (
           <RoundButton
-            buttonType="action"
+            buttonType={bottomRightAlignedArrows ? 'primary' : 'action'}
+            disabled={disabled}
             icon={<ArrowRightIcon />}
             onClick={this.arrowClickHandler}
           />
         )}
-      </ArrowContainer>
+      </ArrowContainerComponent>
     );
   }
 }

--- a/src/shared-components/carousel/arrow/style.ts
+++ b/src/shared-components/carousel/arrow/style.ts
@@ -25,14 +25,12 @@ export const BottomRightAlignedArrowContainer = styled.div<{
   next: boolean;
   disabled: boolean;
 }>`
-  position: absolute;
-  top: 50%;
-  z-index: ${Z_SCALE.e2000};
-  transform: translate(0%, -50%);
   display: block;
+  align-self: flex-end;
+  margin: ${SPACER.small};
 
-  ${({ prev }) => prev && `left: ${SPACER.small};`};
-  ${({ next }) => next && `right: ${SPACER.small};`};
+  ${({ prev }) => prev && `order: 2; margin-left: auto;`};
+  ${({ next }) => next && `order: 3;`};
 
   ${({ disabled }) =>
     disabled &&
@@ -41,6 +39,10 @@ export const BottomRightAlignedArrowContainer = styled.div<{
         background-color: none;
         border-color: ${COLORS.primary};
         color: ${COLORS.primary};
+
+        &:hover {
+          color: ${COLORS.primary};
+        }
       }
     `};
 `;

--- a/src/shared-components/carousel/arrow/style.ts
+++ b/src/shared-components/carousel/arrow/style.ts
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
+import { css } from '@emotion/core';
 
-import { SPACER, Z_SCALE } from '../../../constants';
+import { COLORS, SPACER, Z_SCALE } from '../../../constants';
 
-const ArrowContainer = styled.div<{
+export const ArrowContainer = styled.div<{
   prev: boolean;
   next: boolean;
   disabled: boolean;
@@ -19,4 +20,27 @@ const ArrowContainer = styled.div<{
   ${({ disabled }) => disabled && `display: none;`};
 `;
 
-export default ArrowContainer;
+export const BottomRightAlignedArrowContainer = styled.div<{
+  prev: boolean;
+  next: boolean;
+  disabled: boolean;
+}>`
+  position: absolute;
+  top: 50%;
+  z-index: ${Z_SCALE.e2000};
+  transform: translate(0%, -50%);
+  display: block;
+
+  ${({ prev }) => prev && `left: ${SPACER.small};`};
+  ${({ next }) => next && `right: ${SPACER.small};`};
+
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      button {
+        background-color: none;
+        border-color: ${COLORS.primary};
+        color: ${COLORS.primary};
+      }
+    `};
+`;

--- a/src/shared-components/carousel/arrow/test.tsx
+++ b/src/shared-components/carousel/arrow/test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import Arrow from './index';
+
+describe('<Arrow />', () => {
+  describe('UI snapshots', () => {
+    it('renders with props', () => {
+      const tree = renderer
+        .create(<Arrow prev disabled={false} onClick={() => undefined} />)
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('renders with bottom right alignment', () => {
+      const tree = renderer
+        .create(
+          <Arrow
+            bottomRightAlignedArrows
+            prev
+            disabled
+            onClick={() => undefined}
+          />,
+        )
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
+  });
+});

--- a/src/shared-components/carousel/index.tsx
+++ b/src/shared-components/carousel/index.tsx
@@ -22,6 +22,7 @@ type CarouselProps = {
   children: Array<React.ReactNode>;
   hideArrows?: boolean;
   hideDots?: boolean;
+  bottomRightAlignedArrows?: boolean;
   infinite?: boolean;
   numCardsVisible: number;
 };
@@ -42,6 +43,7 @@ class Carousel extends React.Component<CarouselProps, CarouselState> {
     children: PropTypes.arrayOf(PropTypes.node).isRequired,
     hideArrows: PropTypes.bool,
     hideDots: PropTypes.bool,
+    bottomRightAlignedArrows: PropTypes.bool,
     infinite: PropTypes.bool,
     numCardsVisible: PropTypes.number.isRequired,
   };
@@ -53,6 +55,7 @@ class Carousel extends React.Component<CarouselProps, CarouselState> {
     centerMode: true,
     hideArrows: false,
     hideDots: false,
+    bottomRightAlignedArrows: false,
     infinite: false,
   };
 
@@ -105,6 +108,7 @@ class Carousel extends React.Component<CarouselProps, CarouselState> {
       centerMode,
       hideArrows,
       hideDots,
+      bottomRightAlignedArrows,
       infinite,
       numCardsVisible,
     } = this.props;
@@ -124,6 +128,7 @@ class Carousel extends React.Component<CarouselProps, CarouselState> {
       onSwipe: this.onUserInteraction,
       prevArrow: (
         <Arrow
+          bottomRightAlignedArrows={bottomRightAlignedArrows}
           prev
           disabled={currentIndex === firstIndex && !infinite}
           onClick={this.onUserInteraction}
@@ -131,6 +136,7 @@ class Carousel extends React.Component<CarouselProps, CarouselState> {
       ),
       nextArrow: (
         <Arrow
+          bottomRightAlignedArrows={bottomRightAlignedArrows}
           next
           disabled={currentIndex === lastIndex && !infinite}
           onClick={this.onUserInteraction}

--- a/src/shared-components/carousel/index.tsx
+++ b/src/shared-components/carousel/index.tsx
@@ -121,7 +121,7 @@ class Carousel extends React.Component<CarouselProps, CarouselState> {
       autoplay,
       autoplaySpeed,
       centerMode: allowCenterMode ? false : centerMode,
-      dots: !hideDots,
+      dots: !hideDots && !bottomRightAlignedArrows,
       infinite,
       slidesToShow: numCardsVisible,
       beforeChange: this.onCardChange,

--- a/src/shared-components/carousel/style.ts
+++ b/src/shared-components/carousel/style.ts
@@ -191,6 +191,10 @@ export const InnerContainer = styled.div<{
 
   ${reactSlickStyles};
 
+  .slick-slider {
+    flex-wrap: wrap;
+  }
+
   .slick-dots {
     ${dotStyles};
   }

--- a/src/shared-components/carousel/test.tsx
+++ b/src/shared-components/carousel/test.tsx
@@ -14,5 +14,17 @@ describe('<Carousel />', () => {
 
       expect(tree).toMatchSnapshot();
     });
+
+    it('renders with bottom right aligned arrows', () => {
+      const tree = renderer
+        .create(
+          <Carousel numCardsVisible={2} bottomRightAlignedArrows hideDots>
+            {cards}
+          </Carousel>,
+        )
+        .toJSON();
+
+      expect(tree).toMatchSnapshot();
+    });
   });
 });

--- a/stories/carousel/index.js
+++ b/stories/carousel/index.js
@@ -106,7 +106,7 @@ stories.add(
 
         <CarouselContainer>
           <Header>Bottom Right Aligned Arrows</Header>
-          <Carousel numCardsVisible={2} bottomRightAlignedArrows hideDots>
+          <Carousel numCardsVisible={2} bottomRightAlignedArrows>
             {cards}
           </Carousel>
         </CarouselContainer>

--- a/stories/carousel/index.js
+++ b/stories/carousel/index.js
@@ -106,7 +106,7 @@ stories.add(
 
         <CarouselContainer>
           <Header>Bottom Right Aligned Arrows</Header>
-          <Carousel numCardsVisible={1} bottomRightAlignedArrows>
+          <Carousel numCardsVisible={2} bottomRightAlignedArrows hideDots>
             {cards}
           </Carousel>
         </CarouselContainer>

--- a/stories/carousel/index.js
+++ b/stories/carousel/index.js
@@ -10,8 +10,7 @@ import {
 } from '@storybook/addon-knobs';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
-
-import CarouselReadme from 'docs/carousel.md';
+import CarouselReadme from 'docs/carousel';
 import { Carousel, Typography } from 'src/shared-components';
 import { SPACER, COLORS } from 'src/constants';
 
@@ -105,6 +104,13 @@ stories.add(
           </Carousel>
         </CarouselContainer>
 
+        <CarouselContainer>
+          <Header>Bottom Right Aligned Arrows</Header>
+          <Carousel numCardsVisible={1} bottomRightAlignedArrows>
+            {cards}
+          </Carousel>
+        </CarouselContainer>
+
         <CarouselContainer bgColor={COLORS.lavender100}>
           <Header>Secondary Style - dots are white</Header>
           <Carousel numCardsVisible={1} carouselType="secondary">
@@ -131,10 +137,14 @@ stories.add(
             carouselType={select(
               'carouselType',
               ['primary', 'secondary'],
-              'primary'
+              'primary',
             )}
             centerMode={boolean('centerMode', true)}
             hideArrows={boolean('hideArrows', false)}
+            bottomRightAlignedArrows={boolean(
+              'bottomRightAlignedArrows',
+              false,
+            )}
             hideDots={boolean('hideDots', false)}
             infinite={boolean('infinite', false)}
             numCardsVisible={number('numCardsVisible', 1)}
@@ -144,5 +154,5 @@ stories.add(
         </CarouselContainer>
       </FlexContainer>
     </MainContainer>
-  ))
+  )),
 );


### PR DESCRIPTION
The [new LP pricing module](https://www.notion.so/curology/Pitch-New-Landing-Page-Pricing-Module-412f1153db264ea8a1d33c7416aa56d1) has a different positioning for the carousel arrows. They are aligned beneath the carousel cards on the bottom right side. The coloring of the arrows is also a bit different. Because this component will only be used in the pricing module on the site, rather than creating a new `arrowColor` prop, I just added both of these things (new alignment and new coloring) as a `bottomRightAlignedArrows` prop to the Radiance Carousel component.

![Screen Shot 2020-09-08 at 5 51 55 PM](https://user-images.githubusercontent.com/22719577/92531645-b2151480-f1fc-11ea-904c-bdf737a31293.png)
 