### PR TITLE
[Dropdown] Apply box-shadow changes 

### DIFF
--- a/src/constants/boxShadows/index.ts
+++ b/src/constants/boxShadows/index.ts
@@ -13,6 +13,7 @@ export const BASE_CONFIG = {
   clickableHover: `0 1px 3px 0 ${transparentize(boxShadowColor, 0.15)}`,
   message: `0 12px 20px 0 ${transparentize(boxShadowColor, 0.05)}`,
   focusSecondary: `0 0 2px 2px ${transparentize(COLORS.secondary, 0.5)}`,
+  TEMP_UPDATES: `0px 8px 24px rgba(52, 51, 82, 0.05)`,
 };
 
 export const OLD_BASE_CONFIG = {

--- a/src/constants/boxShadows/index.ts
+++ b/src/constants/boxShadows/index.ts
@@ -13,7 +13,8 @@ export const BASE_CONFIG = {
   clickableHover: `0 1px 3px 0 ${transparentize(boxShadowColor, 0.15)}`,
   message: `0 12px 20px 0 ${transparentize(boxShadowColor, 0.05)}`,
   focusSecondary: `0 0 2px 2px ${transparentize(COLORS.secondary, 0.5)}`,
-  TEMP_UPDATES: `0px 8px 24px rgba(52, 51, 82, 0.05)`,
+  nonButton: `0px 8px 24px rgba(52, 51, 82, 0.05)`,
+  nonButtonHover: `0px 8px 24px rgba(52, 51, 82, 0.10)`,
 };
 
 export const OLD_BASE_CONFIG = {

--- a/src/constants/boxShadows/index.ts
+++ b/src/constants/boxShadows/index.ts
@@ -9,12 +9,10 @@ const boxShadowColor = `${COLORS.primary}`;
 const boxShadowOverlayColor = '#505050';
 
 export const BASE_CONFIG = {
-  clickable: `0 1px 3px 0 ${transparentize(boxShadowColor, 0.06)}`,
-  clickableHover: `0 1px 3px 0 ${transparentize(boxShadowColor, 0.15)}`,
+  clickable: `0px 8px 24px rgba(52, 51, 82, 0.05)`,
+  clickableHover: `0px 8px 24px rgba(52, 51, 82, 0.10)`,
   message: `0 12px 20px 0 ${transparentize(boxShadowColor, 0.05)}`,
   focusSecondary: `0 0 2px 2px ${transparentize(COLORS.secondary, 0.5)}`,
-  nonButton: `0px 8px 24px rgba(52, 51, 82, 0.05)`,
-  nonButtonHover: `0px 8px 24px rgba(52, 51, 82, 0.10)`,
 };
 
 export const OLD_BASE_CONFIG = {

--- a/src/shared-components/carousel/arrow/__snapshots__/test.tsx.snap
+++ b/src/shared-components/carousel/arrow/__snapshots__/test.tsx.snap
@@ -524,7 +524,7 @@ exports[`<Arrow /> UI snapshots renders with props 1`] = `
   background-color: #ffffff;
   color: #332e54;
   fill: #332e54;
-  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.06);
+  box-shadow: 0px 8px 24px rgba(52,51,82,0.05);
   min-width: 208px;
   max-width: 325px;
   width: -webkit-max-content;
@@ -551,7 +551,7 @@ exports[`<Arrow /> UI snapshots renders with props 1`] = `
 }
 
 .emotion-2:hover {
-  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.15);
+  box-shadow: 0px 8px 24px rgba(52,51,82,0.10);
 }
 
 .emotion-2:hover {

--- a/src/shared-components/container/__snapshots__/test.tsx.snap
+++ b/src/shared-components/container/__snapshots__/test.tsx.snap
@@ -17,14 +17,14 @@ exports[`Container UI snapshots renders clickable container 1`] = `
 .emotion-0 {
   background-color: #ffffff;
   border: 1px solid #ededf0;
-  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.06);
+  box-shadow: 0px 8px 24px rgba(52,51,82,0.05);
   cursor: pointer;
   -webkit-transition: box-shadow 200ms;
   transition: box-shadow 200ms;
 }
 
 .emotion-0:hover {
-  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.15);
+  box-shadow: 0px 8px 24px rgba(52,51,82,0.10);
 }
 
 <div

--- a/src/shared-components/dropdown/__snapshots__/test.tsx.snap
+++ b/src/shared-components/dropdown/__snapshots__/test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<MobileDropdown /> UI snapshots renders correctly 1`] = `
   min-height: 3.5rem;
   max-height: 3.5rem;
   border: 1px solid #ededf0;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   color: #524D6E;
   line-height: 3.5rem;
   overflow: hidden;

--- a/src/shared-components/dropdown/__snapshots__/test.tsx.snap
+++ b/src/shared-components/dropdown/__snapshots__/test.tsx.snap
@@ -11,14 +11,14 @@ exports[`<MobileDropdown /> UI snapshots renders correctly 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.06);
+  box-shadow: 0px 8px 24px rgba(52,51,82,0.05);
   background: #ffffff;
   background-image: none;
   width: 100%;
   min-height: 3.5rem;
   max-height: 3.5rem;
   border: 1px solid #ededf0;
-  border-radius: 0;
+  border-radius: 0.25rem;
   color: #524D6E;
   line-height: 3.5rem;
   overflow: hidden;
@@ -33,14 +33,14 @@ exports[`<MobileDropdown /> UI snapshots renders correctly 1`] = `
 }
 
 .emotion-0:hover {
-  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.15);
+  box-shadow: 0px 8px 24px rgba(52,51,82,0.10);
   -webkit-transition: 200ms ease-in-out;
   transition: 200ms ease-in-out;
 }
 
 .emotion-0:focus {
   outline: none;
-  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.15);
+  box-shadow: 0px 8px 24px rgba(52,51,82,0.10);
   -webkit-transition: 200ms ease-in-out;
   transition: 200ms ease-in-out;
 }

--- a/src/shared-components/dropdown/desktopDropdown.tsx
+++ b/src/shared-components/dropdown/desktopDropdown.tsx
@@ -16,27 +16,29 @@ import {
 import { OptionType } from './index';
 
 type DesktopDropdownProps = {
-  value?: string;
-  options: OptionType[];
-  currentOption: OptionType;
-  textAlign: 'left' | 'center';
+  borderRadius: string;
   closeDropdown: () => void;
+  currentOption: OptionType;
+  isOpen: boolean;
   onOptionClick: (event: any) => void;
   onSelectClick: () => void;
-  isOpen: boolean;
+  options: OptionType[];
   optionsContainerMaxHeight: string;
+  textAlign: 'left' | 'center';
+  value?: string;
 };
 
 const DesktopDropdown = ({
-  value,
-  options,
-  textAlign,
-  currentOption,
+  borderRadius,
   closeDropdown,
+  currentOption,
+  isOpen,
   onOptionClick,
   onSelectClick,
-  isOpen,
+  options,
   optionsContainerMaxHeight,
+  textAlign,
+  value,
 }: DesktopDropdownProps) => {
   const { initialFocus, resetFocus } = useResetFocus<HTMLDivElement>();
 
@@ -73,8 +75,9 @@ const DesktopDropdown = ({
         >
           <div
             css={dropdownInputStyle({
-              textAlign,
+              borderRadius,
               shouldBeFullyRounded: !isOpen,
+              textAlign,
             })}
           >
             {currentOption && currentOption.label}
@@ -85,6 +88,7 @@ const DesktopDropdown = ({
         </div>
 
         <DropdownOptionsContainer
+          borderRadius={borderRadius}
           isOpen={isOpen}
           optionsContainerMaxHeight={optionsContainerMaxHeight}
           role="menu"
@@ -131,6 +135,7 @@ DesktopDropdown.defaultProps = {
 };
 
 DesktopDropdown.propTypes = {
+  borderRadius: PropTypes.string.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   value: PropTypes.any,
   options: PropTypes.arrayOf(

--- a/src/shared-components/dropdown/desktopDropdown.tsx
+++ b/src/shared-components/dropdown/desktopDropdown.tsx
@@ -71,7 +71,12 @@ const DesktopDropdown = ({
           role="button"
           ref={initialFocus}
         >
-          <div css={dropdownInputStyle({ textAlign })}>
+          <div
+            css={dropdownInputStyle({
+              textAlign,
+              shouldBeFullyRounded: !isOpen,
+            })}
+          >
             {currentOption && currentOption.label}
           </div>
           <IconContainer>

--- a/src/shared-components/dropdown/index.tsx
+++ b/src/shared-components/dropdown/index.tsx
@@ -6,27 +6,29 @@ import DesktopDropdown from './desktopDropdown';
 import allowNullPropType from '../../utils/allowNullPropType';
 
 export type OptionType = {
-  value: string;
+  value: string | undefined;
   label: string;
   disabled?: boolean;
 };
 
 type DropdownProps = {
-  value?: string;
+  borderRadius?: string;
   onChange: (option: OptionType) => void;
   options: OptionType[];
   optionsContainerMaxHeight?: string;
   textAlign?: 'left' | 'center';
+  value?: string;
 };
 
-const Dropdown = (props: DropdownProps) => {
-  const {
-    onChange,
-    value,
-    options,
-    optionsContainerMaxHeight = '250px',
-    textAlign,
-  } = props;
+const Dropdown = ({
+  borderRadius = '4px',
+  onChange,
+  options,
+  optionsContainerMaxHeight = '250px',
+  textAlign = 'left',
+  value,
+  ...rest
+}: DropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const touchSupported = 'ontouchstart' in document.documentElement;
 
@@ -63,6 +65,7 @@ const Dropdown = (props: DropdownProps) => {
   if (touchSupported) {
     return (
       <MobileDropdown
+        borderRadius={borderRadius}
         value={value}
         options={options}
         textAlign={textAlign}
@@ -75,6 +78,7 @@ const Dropdown = (props: DropdownProps) => {
 
   return (
     <DesktopDropdown
+      borderRadius={borderRadius}
       isOpen={isOpen}
       onOptionClick={onOptionClick}
       closeDropdown={closeDropdown}
@@ -82,12 +86,13 @@ const Dropdown = (props: DropdownProps) => {
       currentOption={currentOption}
       optionsContainerMaxHeight={optionsContainerMaxHeight}
       // eslint-disable-next-line react/jsx-props-no-spreading
-      {...props}
+      {...rest}
     />
   );
 };
 
 Dropdown.propTypes = {
+  borderRadius: PropTypes.string,
   value: allowNullPropType(
     PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   ),
@@ -101,12 +106,6 @@ Dropdown.propTypes = {
   textAlign: PropTypes.oneOf(['left', 'center']),
   onChange: PropTypes.func.isRequired,
   optionsContainerMaxHeight: PropTypes.string,
-};
-
-Dropdown.defaultProps = {
-  textAlign: 'left',
-  optionsContainerMaxHeight: '250px',
-  value: undefined,
 };
 
 export default Dropdown;

--- a/src/shared-components/dropdown/mobileDropdown.tsx
+++ b/src/shared-components/dropdown/mobileDropdown.tsx
@@ -21,7 +21,7 @@ const MobileDropdown = ({
 }: MobileDropdownProps) => (
   <DropdownContainer textAlign={textAlign}>
     <select
-      css={dropdownInputStyle({ textAlign })}
+      css={dropdownInputStyle({ textAlign, shouldBeFullyRounded: true })}
       value={value || ''}
       onChange={onSelectChange}
     >

--- a/src/shared-components/dropdown/mobileDropdown.tsx
+++ b/src/shared-components/dropdown/mobileDropdown.tsx
@@ -7,21 +7,27 @@ import { DropdownContainer, dropdownInputStyle, IconContainer } from './style';
 import { OptionType } from './index';
 
 type MobileDropdownProps = {
-  value: string | number | null;
-  options: OptionType[];
-  textAlign: 'left' | 'center';
+  borderRadius: string;
   onSelectChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+  options: OptionType[];
+  textAlign?: 'left' | 'center';
+  value?: string | number | undefined;
 };
 
 const MobileDropdown = ({
-  textAlign,
-  value,
+  borderRadius,
   onSelectChange,
-  options,
+  options = [{ value: undefined, label: '' }],
+  textAlign = 'left',
+  value,
 }: MobileDropdownProps) => (
   <DropdownContainer textAlign={textAlign}>
     <select
-      css={dropdownInputStyle({ textAlign, shouldBeFullyRounded: true })}
+      css={dropdownInputStyle({
+        borderRadius,
+        shouldBeFullyRounded: true,
+        textAlign,
+      })}
       value={value || ''}
       onChange={onSelectChange}
     >
@@ -47,14 +53,8 @@ const MobileDropdown = ({
   </DropdownContainer>
 );
 
-MobileDropdown.defaultProps = {
-  value: null,
-  options: [{ value: null, label: '' }],
-  textAlign: 'left',
-  onSelectChange: () => undefined,
-};
-
 MobileDropdown.propTypes = {
+  borderRadius: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   options: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/shared-components/dropdown/style.ts
+++ b/src/shared-components/dropdown/style.ts
@@ -9,6 +9,11 @@ import {
   TYPOGRAPHY_CONSTANTS,
 } from '../../constants';
 
+type DropdownInputStyleProps = {
+  textAlign: 'left' | 'center';
+  shouldBeFullyRounded?: boolean;
+};
+
 export const DropdownContainer = styled.div<{ textAlign: 'left' | 'center' }>`
   position: relative;
   width: 100%;
@@ -17,49 +22,58 @@ export const DropdownContainer = styled.div<{ textAlign: 'left' | 'center' }>`
 
 export const dropdownInputStyle = ({
   textAlign,
-}: {
-  textAlign: 'left' | 'center';
-}) => css`
-  appearance: none;
-  box-shadow: ${BOX_SHADOWS.clickable};
-  background: ${COLORS.white};
-  background-image: none;
+  shouldBeFullyRounded,
+}: DropdownInputStyleProps) => {
+  /**
+   * When Desktop dropdown is open, we want only the top borders rounded.
+   * Otherwise we set bottom rounded borders to last element in Dropdown.
+   */
+  const dropdownBorderRadius = shouldBeFullyRounded
+    ? `border-radius: ${SPACER.xsmall}`
+    : `border-radius: ${SPACER.xsmall} ${SPACER.xsmall} 0 0`;
 
-  width: 100%;
-  min-height: ${SPACER.x4large};
-  max-height: ${SPACER.x4large};
+  return css`
+    appearance: none;
+    box-shadow: ${BOX_SHADOWS.clickable};
+    background: ${COLORS.white};
+    background-image: none;
 
-  border: 1px solid ${COLORS.border};
-  border-radius: 0;
+    width: 100%;
+    min-height: ${SPACER.x4large};
+    max-height: ${SPACER.x4large};
 
-  color: ${COLORS.purple85};
-  line-height: ${SPACER.x4large};
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+    border: 1px solid ${COLORS.border};
+    ${dropdownBorderRadius};
 
-  padding: 0 ${SPACER.xlarge} 0 ${SPACER.medium};
-  text-align: ${textAlign};
-  text-align-last: ${textAlign};
-  transition: 200ms ease-in-out;
+    color: ${COLORS.purple85};
+    line-height: ${SPACER.x4large};
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
-  cursor: pointer;
-
-  &:hover {
-    box-shadow: ${BOX_SHADOWS.clickableHover};
+    padding: 0 ${SPACER.xlarge} 0 ${SPACER.medium};
+    text-align: ${textAlign};
+    text-align-last: ${textAlign};
     transition: 200ms ease-in-out;
-  }
 
-  &:focus {
-    outline: none;
-    box-shadow: ${BOX_SHADOWS.clickableHover};
-    transition: 200ms ease-in-out;
-  }
+    cursor: pointer;
 
-  &::-moz-focus-inner {
-    border: 0;
-  }
-`;
+    &:hover {
+      box-shadow: ${BOX_SHADOWS.clickableHover};
+      transition: 200ms ease-in-out;
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: ${BOX_SHADOWS.clickableHover};
+      transition: 200ms ease-in-out;
+    }
+
+    &::-moz-focus-inner {
+      border: 0;
+    }
+  `;
+};
 
 export const IconContainer = styled.div`
   position: absolute;
@@ -115,6 +129,10 @@ export const DropdownOptionsContainer = styled.ul<{
       border-bottom-width: 1px;
       transition: max-height ${ANIMATION.defaultTiming} ease-in-out;
     `};
+
+  &:last-of-type {
+    border-radius: 0 0 ${SPACER.xsmall} ${SPACER.xsmall};
+  }
 `;
 
 export const DropdownOption = styled.li<{

--- a/src/shared-components/dropdown/style.ts
+++ b/src/shared-components/dropdown/style.ts
@@ -34,7 +34,7 @@ export const dropdownInputStyle = ({
 
   return css`
     appearance: none;
-    box-shadow: ${BOX_SHADOWS.nonButton};
+    box-shadow: ${BOX_SHADOWS.clickable};
     background: ${COLORS.white};
     background-image: none;
 
@@ -59,13 +59,13 @@ export const dropdownInputStyle = ({
     cursor: pointer;
 
     &:hover {
-      box-shadow: ${BOX_SHADOWS.nonButtonHover};
+      box-shadow: ${BOX_SHADOWS.clickableHover};
       transition: 200ms ease-in-out;
     }
 
     &:focus {
       outline: none;
-      box-shadow: ${BOX_SHADOWS.nonButtonHover};
+      box-shadow: ${BOX_SHADOWS.clickableHover};
       transition: 200ms ease-in-out;
     }
 

--- a/src/shared-components/dropdown/style.ts
+++ b/src/shared-components/dropdown/style.ts
@@ -10,8 +10,9 @@ import {
 } from '../../constants';
 
 type DropdownInputStyleProps = {
+  borderRadius: string;
+  shouldBeFullyRounded: boolean;
   textAlign: 'left' | 'center';
-  shouldBeFullyRounded?: boolean;
 };
 
 export const DropdownContainer = styled.div<{ textAlign: 'left' | 'center' }>`
@@ -21,16 +22,17 @@ export const DropdownContainer = styled.div<{ textAlign: 'left' | 'center' }>`
 `;
 
 export const dropdownInputStyle = ({
-  textAlign,
+  borderRadius,
   shouldBeFullyRounded,
+  textAlign,
 }: DropdownInputStyleProps) => {
   /**
    * When Desktop dropdown is open, we want only the top borders rounded.
    * Otherwise we set bottom rounded borders to last element in Dropdown.
    */
   const dropdownBorderRadius = shouldBeFullyRounded
-    ? `border-radius: ${SPACER.xsmall}`
-    : `border-radius: ${SPACER.xsmall} ${SPACER.xsmall} 0 0`;
+    ? `border-radius: ${borderRadius}`
+    : `border-radius: ${borderRadius} ${borderRadius} 0 0`;
 
   return css`
     appearance: none;
@@ -99,6 +101,7 @@ export const IconContainer = styled.div`
 export const DropdownOptionsContainer = styled.ul<{
   isOpen: boolean;
   optionsContainerMaxHeight: string;
+  borderRadius: string;
 }>`
   position: absolute;
   top: 100%;
@@ -131,7 +134,8 @@ export const DropdownOptionsContainer = styled.ul<{
     `};
 
   &:last-of-type {
-    border-radius: 0 0 ${SPACER.xsmall} ${SPACER.xsmall};
+    border-radius: ${({ borderRadius }) =>
+    borderRadius ? `0 0 ${borderRadius} ${borderRadius}` : `0 0 4px 4px`};
   }
 `;
 

--- a/src/shared-components/dropdown/style.ts
+++ b/src/shared-components/dropdown/style.ts
@@ -34,7 +34,7 @@ export const dropdownInputStyle = ({
 
   return css`
     appearance: none;
-    box-shadow: ${BOX_SHADOWS.TEMP_UPDATES};
+    box-shadow: ${BOX_SHADOWS.nonButton};
     background: ${COLORS.white};
     background-image: none;
 
@@ -59,13 +59,13 @@ export const dropdownInputStyle = ({
     cursor: pointer;
 
     &:hover {
-      box-shadow: ${BOX_SHADOWS.clickableHover};
+      box-shadow: ${BOX_SHADOWS.nonButtonHover};
       transition: 200ms ease-in-out;
     }
 
     &:focus {
       outline: none;
-      box-shadow: ${BOX_SHADOWS.clickableHover};
+      box-shadow: ${BOX_SHADOWS.nonButtonHover};
       transition: 200ms ease-in-out;
     }
 

--- a/src/shared-components/dropdown/style.ts
+++ b/src/shared-components/dropdown/style.ts
@@ -34,7 +34,7 @@ export const dropdownInputStyle = ({
 
   return css`
     appearance: none;
-    box-shadow: ${BOX_SHADOWS.clickable};
+    box-shadow: ${BOX_SHADOWS.TEMP_UPDATES};
     background: ${COLORS.white};
     background-image: none;
 

--- a/src/shared-components/dropdown/test.tsx
+++ b/src/shared-components/dropdown/test.tsx
@@ -49,7 +49,13 @@ describe('<MobileDropdown />', () => {
   describe('UI snapshots', () => {
     it('renders correctly', () => {
       const tree = renderer
-        .create(<MobileDropdown options={options} />)
+        .create(
+          <MobileDropdown
+            onSelectChange={() => undefined}
+            borderRadius="4px"
+            options={options}
+          />,
+        )
         .toJSON();
 
       expect(tree).toMatchSnapshot();
@@ -60,7 +66,12 @@ describe('<MobileDropdown />', () => {
     it('should be invoked onClick', () => {
       const spy = jest.fn();
       const wrapper = mount(
-        <MobileDropdown options={options} onSelectChange={spy} value="" />,
+        <MobileDropdown
+          borderRadius="4px"
+          options={options}
+          onSelectChange={spy}
+          value=""
+        />,
       );
 
       wrapper.find('select').simulate('change', { target: { value: 'test1' } });
@@ -73,6 +84,7 @@ describe('<DesktopDropdown />', () => {
   it('renders the current option text', () => {
     const wrapper = mount(
       <DesktopDropdown
+        borderRadius="4px"
         options={options}
         currentOption={{ value: 'test1', label: 'Test1' }}
         optionsContainerMaxHeight="250px"
@@ -95,6 +107,7 @@ describe('<DesktopDropdown />', () => {
       const spy = jest.fn();
       const wrapper = mount(
         <DesktopDropdown
+          borderRadius="4px"
           options={options}
           currentOption={{ value: 'test1', label: 'Test1' }}
           onSelectClick={spy}
@@ -114,6 +127,7 @@ describe('<DesktopDropdown />', () => {
       const spy = jest.fn();
       const wrapper = mount(
         <DesktopDropdown
+          borderRadius="4px"
           options={options}
           currentOption={{ value: 'test1', label: 'Test1' }}
           onOptionClick={spy}

--- a/src/shared-components/optionButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/optionButton/__snapshots__/test.tsx.snap
@@ -4,7 +4,7 @@ exports[`<OptionButton /> UI snapshots checkbox selected, without custom icon 1`
 .emotion-8 {
   background-color: #ffffff;
   border: 1px solid #ededf0;
-  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.06);
+  box-shadow: 0px 8px 24px rgba(52,51,82,0.05);
   cursor: pointer;
   -webkit-transition: box-shadow 200ms;
   transition: box-shadow 200ms;
@@ -15,7 +15,7 @@ exports[`<OptionButton /> UI snapshots checkbox selected, without custom icon 1`
 }
 
 .emotion-8:hover {
-  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.15);
+  box-shadow: 0px 8px 24px rgba(52,51,82,0.10);
 }
 
 .emotion-8:focus {
@@ -128,7 +128,7 @@ exports[`<OptionButton /> UI snapshots radio unselected, with icon node prop 1`]
 .emotion-8 {
   background-color: #ffffff;
   border: 1px solid #ededf0;
-  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.06);
+  box-shadow: 0px 8px 24px rgba(52,51,82,0.05);
   cursor: pointer;
   -webkit-transition: box-shadow 200ms;
   transition: box-shadow 200ms;
@@ -139,7 +139,7 @@ exports[`<OptionButton /> UI snapshots radio unselected, with icon node prop 1`]
 }
 
 .emotion-8:hover {
-  box-shadow: 0 1px 3px 0 rgba(51,46,84,0.15);
+  box-shadow: 0px 8px 24px rgba(52,51,82,0.10);
 }
 
 .emotion-8:focus {


### PR DESCRIPTION
### What and Why

1. Updates our `clickable` and `clickableHover` styles to match what design has in Figma. 
1. Updates our `border-radius` styling for the Dropdown component, which previously had no `border-radius`.
    - Our Mobile dropdown will always have `border-radius: 4px` since we rely on native select dropdown for functionality. 
    - Our Desktop dropdown will have `border-radius: 4px` *unless* it is open, at which point the following occurs:
        - The Dropdown select will have `border-radius: 4px 4px 0 0`, shorthand for setting the top-left and top-right border radius.
        - The last child of the Dropdown options will have `border-radius: 0 0 4px 4px`, shorthand for setting the bottom-left and bottom-right border radius. 
1. Updates our Dropdown component to accept an optional `borderRadius` prop, so that the above `border-radius` values are programmable, with `4px` as the default. 

**Clickable changes**

Before:

<img width="373" alt="Screen Shot 2020-09-09 at 2 30 40 PM" src="https://user-images.githubusercontent.com/13544620/92644504-168dad80-f2a9-11ea-9708-d1d594a60e04.png">

After:

<img width="379" alt="Screen Shot 2020-09-09 at 2 30 33 PM" src="https://user-images.githubusercontent.com/13544620/92644498-1392bd00-f2a9-11ea-96f8-969e99ba163d.png">

**Action button changes (as a result of `clickable` changes)``

Before:

![button-before](https://user-images.githubusercontent.com/13544620/92649195-43918e80-f2b0-11ea-8ede-a690e97cf397.gif)


After:

![button-after](https://user-images.githubusercontent.com/13544620/92649202-47251580-f2b0-11ea-8a43-88a0817ba7a0.gif)

**Dropdown changes**

Before:

<img width="524" alt="Screen Shot 2020-09-09 at 2 40 05 PM" src="https://user-images.githubusercontent.com/13544620/92645478-8486a480-f2aa-11ea-88c6-139cbe6b0586.png">

After:

<img width="519" alt="Screen Shot 2020-09-09 at 2 40 38 PM" src="https://user-images.githubusercontent.com/13544620/92645487-88b2c200-f2aa-11ea-8de2-9eb2951538d2.png">

### Next Steps

1. These `clickable` and `clickableHover` style changes will also be used in future PRs updating our `Accordion` and `OptionButton` component.
    - I plan on releasing all these changes together.