### PR TITLE
[CI] Expand Build Step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,10 @@ jobs:
             - <<: *yarn-cache-restore
             - run:
                 name: Install
-                command: |
-                    yarn install
+                command: yarn install
+            - run:
+                name: Build
+                command: yarn build
             - <<: *yarn-cache-save
             - persist_to_workspace:
                 root: *root


### PR DESCRIPTION
Our `build` step in CI just installs dependencies, so it doesn't really test much. This PR adds our `yarn build` command to log the generated output as well.

### Looking Forward

We should incorporate some size checks into our CI pipeline to track how our dist bundle grows/shrinks with changes. It will also be easier to track dependency changes we're making to see if anything is inadvertently ballooning filesize. (See #342)