### PR TITLE
[Option Button] Add 4px border-radius

### DIFF
--- a/src/shared-components/optionButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/optionButton/__snapshots__/test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`<OptionButton /> UI snapshots checkbox selected, without custom icon 1`] = `
 .emotion-8 {
+  border-radius: 4px;
   background-color: #ffffff;
   border: 1px solid #ededf0;
   box-shadow: 0px 8px 24px rgba(52,51,82,0.05);
@@ -126,6 +127,7 @@ exports[`<OptionButton /> UI snapshots checkbox selected, without custom icon 1`
 
 exports[`<OptionButton /> UI snapshots radio unselected, with icon node prop 1`] = `
 .emotion-8 {
+  border-radius: 4px;
   background-color: #ffffff;
   border: 1px solid #ededf0;
   box-shadow: 0px 8px 24px rgba(52,51,82,0.05);

--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -13,6 +13,7 @@ import {
 import CheckmarkIcon from '../../svgs/icons/checkmark-icon.svg';
 
 type OptionButtonProps = {
+  borderRadius?: string;
   buttonType?: 'primary' | 'secondary';
   icon?: React.ReactNode;
   text: string;
@@ -24,6 +25,7 @@ type OptionButtonProps = {
 };
 
 const OptionButton = ({
+  borderRadius = '4px',
   buttonType = 'primary',
   icon,
   text,
@@ -34,6 +36,7 @@ const OptionButton = ({
   ...rest
 }: OptionButtonProps) => (
   <ClickableContainer
+    borderRadius={borderRadius}
     onClick={onClick}
     type="button"
     role={optionType}

--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -70,8 +70,8 @@ const OptionButton = ({
   </ClickableContainer>
 );
 
-/* eslint-disable react/require-default-props */
 OptionButton.propTypes = {
+  borderRadius: PropTypes.string,
   buttonType: PropTypes.oneOf(['primary', 'secondary']),
   icon: PropTypes.node,
   text: PropTypes.string.isRequired,
@@ -80,6 +80,5 @@ OptionButton.propTypes = {
   optionType: PropTypes.oneOf(['radio', 'checkbox']).isRequired,
   selected: PropTypes.bool,
 };
-/* eslint-enable react/require-default-props */
 
 export default OptionButton;

--- a/src/shared-components/optionButton/style.ts
+++ b/src/shared-components/optionButton/style.ts
@@ -36,8 +36,10 @@ const getTypeColor = (buttonType: BaseIconWrapperStylesProps['buttonType']) => {
 };
 
 export const ClickableContainer = styled.button<{
+  borderRadius: string;
   containerType: ContainerType;
 }>`
+  border-radius: ${({ borderRadius }) => borderRadius};
   ${({ containerType }) => containerStyles(containerType)};
   padding: ${SPACER.large};
   margin-bottom: ${SPACER.medium};
@@ -82,16 +84,16 @@ const getBaseIconWrapperStyles = ({
   }
 
   ${selected &&
-    css`
-      background: ${getTypeColor(buttonType)};
-      border-color: ${getTypeColor(buttonType)};
+  css`
+    background: ${getTypeColor(buttonType)};
+    border-color: ${getTypeColor(buttonType)};
 
-      svg {
-        opacity: 1;
-        color: ${COLORS.white};
-        fill: ${COLORS.white};
-      }
-    `};
+    svg {
+      opacity: 1;
+      color: ${COLORS.white};
+      fill: ${COLORS.white};
+    }
+  `};
 `;
 
 export const CheckmarkWrapper = styled.div<BaseIconWrapperStylesProps>`


### PR DESCRIPTION
This PR adds `border-radius: 4px` by default to our `OptionButton`.

#338 updated the `box-shadow` styling that applies to this component, so the requirement of updating the `box-shadow` styling is already satisfied.

**Before**:

<img width="376" alt="Screen Shot 2020-09-16 at 3 19 10 PM" src="https://user-images.githubusercontent.com/13544620/93388459-5bc55880-f830-11ea-9585-5c69927f6d82.png">

**After**:

<img width="387" alt="Screen Shot 2020-09-16 at 3 18 15 PM" src="https://user-images.githubusercontent.com/13544620/93388448-5962fe80-f830-11ea-9807-2861f5f0c75b.png">


