### PR TITLE
[Bugfix] Restore DesktopDropdown Options Prop Threading

### DIFF
--- a/src/shared-components/dropdown/index.tsx
+++ b/src/shared-components/dropdown/index.tsx
@@ -27,7 +27,6 @@ const Dropdown = ({
   optionsContainerMaxHeight = '250px',
   textAlign = 'left',
   value,
-  ...rest
 }: DropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const touchSupported = 'ontouchstart' in document.documentElement;
@@ -79,14 +78,15 @@ const Dropdown = ({
   return (
     <DesktopDropdown
       borderRadius={borderRadius}
+      closeDropdown={closeDropdown}
+      currentOption={currentOption}
       isOpen={isOpen}
       onOptionClick={onOptionClick}
-      closeDropdown={closeDropdown}
       onSelectClick={onSelectClick}
-      currentOption={currentOption}
+      options={options}
       optionsContainerMaxHeight={optionsContainerMaxHeight}
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      {...rest}
+      textAlign={textAlign}
+      value={value}
     />
   );
 };


### PR DESCRIPTION
#338 renamed the prop spreading from `props` to `rest`, but because of how we were destructuring the props (e.g. `Dropdown = (props) => {}`, which then destructured in the body) I accidentally removed how we were passing down `options` to the `DesktopDropdown` component. (You can test this live on http://radiance-ui.curology.com/, the desktop dropdown has no options). 

I had actually been previously under the impression that we could spread additional properties to `DesktopDropdown` but not `MobileDropdown`, but checking the definition of `DesktopDropdown` it's clear there's no prop spreading in place, so we can be specific with the props we pass down to it. 

This PR restores the `DesktopDropdown` functionality.