### PR TITLE
[a11y] Update focus states

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,6 +36,7 @@
     "@typescript-eslint/naming-convention": "off",
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-use-before-define": "error",
+    "arrow-parens": "off",
     "no-shadow": "off",
     "no-use-before-define": "off",
     "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".tsx"] }],
@@ -56,7 +57,8 @@
         "emotion/jsx-import": "error",
         "emotion/no-vanilla": "error",
         "emotion/import-from-emotion": "error",
-        "emotion/styled-import": "error"
+        "emotion/styled-import": "error",
+        "react/jsx-props-no-spreading": "off"
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
     "@react-aria/focus": "^3.0.2",
+    "focus-visible": "^5.1.0",
     "lodash.round": "^4.0.4",
     "lodash.throttle": "^4.1.1",
     "lodash.uniqueid": "^4.0.1",

--- a/src/constants/boxShadows/index.ts
+++ b/src/constants/boxShadows/index.ts
@@ -12,6 +12,8 @@ export const BASE_CONFIG = {
   clickable: `0px 8px 24px rgba(52, 51, 82, 0.05)`,
   clickableHover: `0px 8px 24px rgba(52, 51, 82, 0.10)`,
   message: `0 12px 20px 0 ${transparentize(boxShadowColor, 0.05)}`,
+  focus: `0px 0px 0px 2px ${COLORS.white}, 0px 0px 0px 4px ${COLORS.primary}`,
+  focusInner: `inset 0px 0px 0px 2px ${COLORS.primary}`,
   focusSecondary: `0 0 2px 2px ${transparentize(COLORS.secondary, 0.5)}`,
 };
 

--- a/src/shared-components/accordion/__snapshots__/test.tsx.snap
+++ b/src/shared-components/accordion/__snapshots__/test.tsx.snap
@@ -53,7 +53,7 @@ exports[`<Accordion /> renders disabled accordion 1`] = `
 
 .emotion-4:focus {
   outline: none;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: inset 0px 0px 0px 2px #332e54;
 }
 
 .emotion-9:last-of-type .emotion-4:focus {
@@ -122,7 +122,7 @@ exports[`<Accordion /> renders no border accordion 1`] = `
 
 .emotion-4:focus {
   outline: none;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: inset 0px 0px 0px 2px #332e54;
 }
 
 .emotion-9:last-of-type .emotion-4:focus {
@@ -234,7 +234,7 @@ exports[`<Accordion /> renders regular accordion 1`] = `
 
 .emotion-4:focus {
   outline: none;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: inset 0px 0px 0px 2px #332e54;
 }
 
 .emotion-9:last-of-type .emotion-4:focus {

--- a/src/shared-components/accordion/style.ts
+++ b/src/shared-components/accordion/style.ts
@@ -72,7 +72,7 @@ export const TitleWrapper = styled.div<{
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   &:focus {
     outline: none;
-    box-shadow: ${BOX_SHADOWS.focusSecondary};
+    box-shadow: ${BOX_SHADOWS.focusInner};
   }
 
   ${AccordionBox}:last-of-type & {

--- a/src/shared-components/button/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/__snapshots__/test.tsx.snap
@@ -138,7 +138,7 @@ exports[`<Button /> UI snapshots renders with props 1`] = `
 .emotion-6:active,
 .emotion-6:focus {
   outline: none;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-6:visited,

--- a/src/shared-components/button/components/linkButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/linkButton/__snapshots__/test.tsx.snap
@@ -47,7 +47,7 @@ exports[`<LinkButton/> UI snapshots renders with props 1`] = `
 .emotion-4:active,
 .emotion-4:focus {
   outline: none;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-4:visited,

--- a/src/shared-components/button/components/roundButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/roundButton/__snapshots__/test.tsx.snap
@@ -163,7 +163,7 @@ exports[`<RoundButton /> UI snapshots renders with props 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-2:visited,

--- a/src/shared-components/button/style.ts
+++ b/src/shared-components/button/style.ts
@@ -62,16 +62,10 @@ const quaternaryStyles = (buttonColor: string) => css`
   background-color: transparent;
   color: ${textColorsAssociatedWithColors[buttonColor]
     ? textColorsAssociatedWithColors[buttonColor].tint2
-    : tinycolor(buttonColor)
-      .lighten(10)
-      .desaturate(50)
-      .toHexString()};
+    : tinycolor(buttonColor).lighten(10).desaturate(50).toHexString()};
   fill: ${textColorsAssociatedWithColors[buttonColor]
     ? textColorsAssociatedWithColors[buttonColor].tint2
-    : tinycolor(buttonColor)
-      .lighten(10)
-      .desaturate(50)
-      .toHexString()};
+    : tinycolor(buttonColor).lighten(10).desaturate(50).toHexString()};
 
   &:hover,
   &:focus,
@@ -81,10 +75,7 @@ const quaternaryStyles = (buttonColor: string) => css`
     background-color: transparent;
     color: ${textColorsAssociatedWithColors[buttonColor]
     ? textColorsAssociatedWithColors[buttonColor].tint2
-    : tinycolor(buttonColor)
-      .lighten(10)
-      .desaturate(50)
-      .toHexString()};
+    : tinycolor(buttonColor).lighten(10).desaturate(50).toHexString()};
   }
 `;
 
@@ -186,15 +177,15 @@ export const baseButtonStyles = ({
   &:active,
   &:focus {
     outline: none;
-    box-shadow: ${BOX_SHADOWS.focusSecondary};
+    box-shadow: ${BOX_SHADOWS.focus};
   }
 
   ${parseTheme(disabled, buttonType, !!isLoading, buttonColor)};
   ${isLoading && loadingStyles};
 
   ${!!textColor &&
-    !disabled &&
-    `
+  !disabled &&
+  `
     color: ${textColor};
     fill: ${textColor};
   `};

--- a/src/shared-components/carousel/arrow/__snapshots__/test.tsx.snap
+++ b/src/shared-components/carousel/arrow/__snapshots__/test.tsx.snap
@@ -275,7 +275,7 @@ exports[`<Arrow /> UI snapshots renders with bottom right alignment 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-2:visited,
@@ -547,7 +547,7 @@ exports[`<Arrow /> UI snapshots renders with props 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-2:hover {

--- a/src/shared-components/dropdown/__snapshots__/test.tsx.snap
+++ b/src/shared-components/dropdown/__snapshots__/test.tsx.snap
@@ -7,6 +7,10 @@ exports[`<MobileDropdown /> UI snapshots renders correctly 1`] = `
   text-align: left;
 }
 
+.emotion-3 > div:first-of-type:focus {
+  outline: none;
+}
+
 .emotion-0 {
   -webkit-appearance: none;
   -moz-appearance: none;

--- a/src/shared-components/dropdown/desktopDropdown.tsx
+++ b/src/shared-components/dropdown/desktopDropdown.tsx
@@ -7,6 +7,7 @@ import OffClickWrapper from '../offClickWrapper';
 import ChevronIcon from '../../svgs/icons/chevron-icon.svg';
 import {
   DropdownContainer,
+  DropdownFocusContainer,
   dropdownInputStyle,
   IconContainer,
   DropdownOptionsContainer,
@@ -65,7 +66,7 @@ const DesktopDropdown = ({
       `}
     >
       <DropdownContainer textAlign={textAlign}>
-        <div
+        <DropdownFocusContainer
           onClick={onSelectClick}
           onKeyDown={handleKeyDown}
           tabIndex={0}
@@ -85,7 +86,7 @@ const DesktopDropdown = ({
           <IconContainer>
             <ChevronIcon width={10} height={10} rotate={isOpen ? 90 : 0} />
           </IconContainer>
-        </div>
+        </DropdownFocusContainer>
 
         <DropdownOptionsContainer
           borderRadius={borderRadius}

--- a/src/shared-components/dropdown/style.ts
+++ b/src/shared-components/dropdown/style.ts
@@ -19,6 +19,12 @@ export const DropdownContainer = styled.div<{ textAlign: 'left' | 'center' }>`
   position: relative;
   width: 100%;
   text-align: ${({ textAlign }) => textAlign};
+
+  > div:first-of-type {
+    &:focus {
+      outline: none;
+    }
+  }
 `;
 
 export const dropdownInputStyle = ({
@@ -76,6 +82,15 @@ export const dropdownInputStyle = ({
     }
   `;
 };
+
+export const DropdownFocusContainer = styled.div`
+  &:focus {
+    > div:first-of-type {
+      box-shadow: ${BOX_SHADOWS.focusInner};
+      outline: none;
+    }
+  }
+`;
 
 export const IconContainer = styled.div`
   position: absolute;
@@ -153,8 +168,11 @@ export const DropdownOption = styled.li<{
   &:hover {
     background-color: ${COLORS.infoBackground};
   }
+
   &:focus {
+    outline: none;
     background-color: ${COLORS.infoBackground};
+    box-shadow: ${BOX_SHADOWS.focusInner};
   }
 
   ${({ selected }) =>

--- a/src/shared-components/dropdown/test.tsx
+++ b/src/shared-components/dropdown/test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { mount } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import DesktopDropdown from './desktopDropdown';
 import MobileDropdown from './mobileDropdown';
@@ -21,12 +21,7 @@ describe('<Dropdown />', () => {
         <Dropdown value="test1" options={options} onChange={() => null} />,
       );
       delete window.document.documentElement.ontouchstart;
-      expect(
-        wrapper
-          .children()
-          .first()
-          .name(),
-      ).toEqual('MobileDropdown');
+      expect(wrapper.children().first().name()).toEqual('MobileDropdown');
     });
   });
 
@@ -35,12 +30,7 @@ describe('<Dropdown />', () => {
       const wrapper = mount(
         <Dropdown value="test1" options={options} onChange={() => null} />,
       );
-      expect(
-        wrapper
-          .children()
-          .first()
-          .name(),
-      ).toEqual('DesktopDropdown');
+      expect(wrapper.children().first().name()).toEqual('DesktopDropdown');
     });
   });
 });
@@ -82,7 +72,7 @@ describe('<MobileDropdown />', () => {
 
 describe('<DesktopDropdown />', () => {
   it('renders the current option text', () => {
-    const wrapper = mount(
+    const wrapper = shallow(
       <DesktopDropdown
         borderRadius="4px"
         options={options}
@@ -94,18 +84,15 @@ describe('<DesktopDropdown />', () => {
       />,
     );
 
-    expect(
-      wrapper
-        .find('[role="button"]')
-        .text()
-        .includes('Test1'),
-    ).toEqual(true);
+    expect(wrapper.find('[role="button"]').text().includes('Test1')).toEqual(
+      true,
+    );
   });
 
   describe('onSelectClick callback', () => {
     it('should be invoked onClick', () => {
       const spy = jest.fn();
-      const wrapper = mount(
+      const wrapper = shallow(
         <DesktopDropdown
           borderRadius="4px"
           options={options}
@@ -138,10 +125,7 @@ describe('<DesktopDropdown />', () => {
         />,
       );
 
-      wrapper
-        .find('li')
-        .first()
-        .simulate('click');
+      wrapper.find('li').first().simulate('click');
 
       expect(spy).toHaveBeenCalled();
     });

--- a/src/shared-components/tabs/style.js
+++ b/src/shared-components/tabs/style.js
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { buttonReset } from 'src/utils/styles/buttonReset';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
 import { COLORS, SPACER, ANIMATION, MEDIA_QUERIES } from '../../constants';
@@ -18,7 +19,8 @@ export const TabsContainer = styled.div`
   }
 `;
 
-export const TabItem = styled.div`
+export const TabItem = styled.button`
+  ${buttonReset}
   ${TYPOGRAPHY_STYLE.button};
   display: flex;
   align-items: center;

--- a/src/shared-components/tabs/style.js
+++ b/src/shared-components/tabs/style.js
@@ -2,7 +2,13 @@ import styled from '@emotion/styled';
 import { buttonReset } from 'src/utils/styles/buttonReset';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { COLORS, SPACER, ANIMATION, MEDIA_QUERIES } from '../../constants';
+import {
+  BOX_SHADOWS,
+  COLORS,
+  SPACER,
+  ANIMATION,
+  MEDIA_QUERIES,
+} from '../../constants';
 
 export const TabsContainer = styled.div`
   display: flex;
@@ -29,11 +35,17 @@ export const TabItem = styled.button`
   margin: 0;
   padding: ${SPACER.medium} ${SPACER.large};
   transition: ${ANIMATION.defaultTiming};
+  border-radius: ${SPACER.xsmall};
 
   color: ${({ active }) => (active ? COLORS.primary : COLORS.primaryTint3)};
 
   &:hover {
     color: ${COLORS.primary};
     transition: ${ANIMATION.defaultTiming};
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: ${BOX_SHADOWS.focus};
   }
 `;

--- a/src/utils/injectGlobalStyles/style.ts
+++ b/src/utils/injectGlobalStyles/style.ts
@@ -17,10 +17,6 @@ const focusStyles = `
 .js-focus-visible :focus:not(.focus-visible) {
   outline: 0;
   box-shadow: none;
-}
-
-.focus-visible {
-  // TODO: Determine if we want to use this as non-browser fallback
 }`;
 
 export const resetStyles = `

--- a/src/utils/injectGlobalStyles/style.ts
+++ b/src/utils/injectGlobalStyles/style.ts
@@ -1,5 +1,27 @@
+import 'focus-visible';
 import { COLORS, FONTS, TYPOGRAPHY_CONSTANTS } from '../../constants';
 import { baseBodyStyles } from '../../shared-components/typography';
+
+/**
+ * Enables use of the .focus-visible polyfill.
+ *
+ * This will allow us to differentiate focus styling between mouse focus and keyboard focus.
+ *
+ * This *does not* apply to input tags. For more details, see {@link https://github.com/WICG/focus-visible/blob/fda80f8401807c1cbb702fb1a15b9635828bfc6d/README.md#how-it-works "How It Works" section}
+ *
+ * {@link https://github.com/WICG/focus-visible Github README}
+ *
+ * {@link https://wicg.github.io/focus-visible/demo/ W3C Playground}
+ */
+const focusStyles = `
+.js-focus-visible :focus:not(.focus-visible) {
+  outline: 0;
+  box-shadow: none;
+}
+
+.focus-visible {
+  // TODO: Determine if we want to use this as non-browser fallback
+}`;
 
 export const resetStyles = `
   html {
@@ -181,6 +203,8 @@ export const resetStyles = `
   [hidden] {
     display: none !important;
   }
+
+  ${focusStyles}
 `;
 
 export const brandStyles = `

--- a/src/utils/styles/buttonReset.ts
+++ b/src/utils/styles/buttonReset.ts
@@ -1,0 +1,4 @@
+export const buttonReset = `
+  background: transparent;
+  border: none;
+`;

--- a/stories/dropdown/mobileExample.js
+++ b/stories/dropdown/mobileExample.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-
 import MobileDropdown from 'src/shared-components/dropdown/mobileDropdown';
 
 const DropdownContainer = styled.div`
@@ -18,20 +17,23 @@ class MobileExample extends React.Component {
     { value: 3, label: 'Third option' },
   ];
 
-  onChange = event => {
+  onChange = (event) => {
     const { value, selectedOptions } = event.target;
 
     if (selectedOptions && selectedOptions.length) {
       this.setState({ value });
     }
-  }
+  };
 
   render() {
+    const { value } = this.state;
+
     return (
       <DropdownContainer>
         Select an option:
         <MobileDropdown
-          value={this.state.value}
+          borderRadius="4px"
+          value={value}
           options={this.options}
           onSelectChange={this.onChange}
         />

--- a/yarn.lock
+++ b/yarn.lock
@@ -6939,6 +6939,11 @@ focus-lock@^0.7.0:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.7.0.tgz#b2bfb0ca7beacc8710a1ff74275fe0dc60a1d88a"
   integrity sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw==
 
+focus-visible@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.1.0.tgz#4b9d40143b865f53eafbd93ca66672b3bf9e7b6a"
+  integrity sha512-nPer0rjtzdZ7csVIu233P2cUm/ks/4aVSI+5KUkYrYpgA7ujgC3p6J7FtFU+AIMWwnwYQOB/yeiOITxFeYIXiw==
+
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3191,14 +3191,6 @@
     "@typescript-eslint/typescript-estree" "4.2.0"
     debug "^4.1.1"
 
-"@typescript-eslint/scope-manager@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.1.1.tgz#bdb8526e82435f32b4ccd9dd4cec01af97b48850"
-  integrity sha512-0W8TTobCvIIQ2FsrYTffyZGAAFUyIbEHq5EYJb1m7Rpd005jrnOvKOo8ywCLhs/Bm17C+KsrUboBvBAARQVvyA==
-  dependencies:
-    "@typescript-eslint/types" "4.1.1"
-    "@typescript-eslint/visitor-keys" "4.1.1"
-
 "@typescript-eslint/scope-manager@4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.2.0.tgz#d10e6854a65e175b22a28265d372a97c8cce4bfc"
@@ -3207,29 +3199,10 @@
     "@typescript-eslint/types" "4.2.0"
     "@typescript-eslint/visitor-keys" "4.2.0"
 
-"@typescript-eslint/types@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.1.1.tgz#57500c4a86b28cb47094c1a62f1177ea279a09cb"
-  integrity sha512-zrBiqOKYerMTllKcn+BP+i1b7LW/EbMMYytroXMxUTvFPn1smkCu0D7lSAx29fTUO4jnwV0ljSvYQtn2vNrNxA==
-
 "@typescript-eslint/types@4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.2.0.tgz#6f6b094329e72040f173123832397c7c0b910fc8"
   integrity sha512-xkv5nIsxfI/Di9eVwN+G9reWl7Me9R5jpzmZUch58uQ7g0/hHVuGUbbn4NcxcM5y/R4wuJIIEPKPDb5l4Fdmwg==
-
-"@typescript-eslint/typescript-estree@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.1.1.tgz#2015a84d71303ecdb6f46efd807ac19a51aab490"
-  integrity sha512-2AUg5v0liVBsqbGxBphbJ0QbGqSRVaF5qPoTPWcxop+66vMdU1h4CCvHxTC47+Qb+Pr4l2RhXDd41JNpwcQEKw==
-  dependencies:
-    "@typescript-eslint/types" "4.1.1"
-    "@typescript-eslint/visitor-keys" "4.1.1"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.2.0":
   version "4.2.0"
@@ -3244,14 +3217,6 @@
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/visitor-keys@4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.1.1.tgz#bb05664bf4bea28dc120d1da94f3027d42ab0f6f"
-  integrity sha512-/EOOXbA2ferGLG6RmCHEQ0lTTLkOlXYDgblCmQk3tIU7mTPLm4gKhFMeeUSe+bcchTUsKeCk8xcpbop5Zr/8Rw==
-  dependencies:
-    "@typescript-eslint/types" "4.1.1"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.2.0":
   version "4.2.0"


### PR DESCRIPTION
### What and Why

This PR adds two new properties to our `BOX_SHADOWS` constants:

1. `focus`
1. `focusInner`. 

The behavior of `focus` is two separate box-shadows to simulate an outline with margin between the element and the outline. Here is the change of behavior in the `Button` component:

Before:

<img width="238" alt="Screen Shot 2020-09-23 at 4 34 30 PM" src="https://user-images.githubusercontent.com/13544620/94072134-bf183300-fdba-11ea-824f-87828636fcd9.png">

After:

<img width="244" alt="Screen Shot 2020-09-23 at 4 34 44 PM" src="https://user-images.githubusercontent.com/13544620/94072145-c3445080-fdba-11ea-8579-931ce9ad3fd5.png">

The behavior of `focusInner` is an `inset` box-shadow, such that the desired outline appears within the given element. Here is the change of behavior in the `Accordion` component:

Before:

<img width="442" alt="Screen Shot 2020-09-23 at 4 36 16 PM" src="https://user-images.githubusercontent.com/13544620/94072260-f4bd1c00-fdba-11ea-8ef7-0a9f9c94d81b.png">

After:

<img width="416" alt="Screen Shot 2020-09-23 at 4 36 08 PM" src="https://user-images.githubusercontent.com/13544620/94072317-0dc5cd00-fdbb-11ea-85b7-deb3b49a7db3.png">

This PR also adds a polyfill for `focus-visible`, a CSS pseudo-class that effectively allows us to apply custom styling to keyboard navigation that does not take effect for mouse navigation. ([MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible)). This allows us to more gracefully introduce accessibility styling, such as helpful keyboard focus states, and limit the styling to keyboard navigation, keeping the existing mouse behavior. 

This PR piggy-backs off of our existing global `resetStyles` usage, adding `focusStyles` to it, such that our usage is automatically opt-in without concerning ourselves with adding a third global usage, with `brandStyles` being the other global usage. We want `focus-visible` to apply regardless of brand. 

### Other

1. Adds a simple `src/utils/styles/buttonReset` export. Our transitioning from `div` to `button` use for accessibility means we write a lot of `background` and `border` overrides. 
1. Updates some `eslint` configuration to remove noisy rules. 
1. Fixes the mobile dropdown story, which did not reflect the border-radius changes made in #338. 
1. Cleans up outdated `yarn.lock` packages from `dependabot` PR merges. 
1. Updates Dropdown tests that were failing due to relying on a styled component to help apply the inset `box-shadow` to the DesktopDropdown component. Uses `shallow` instead of `mount`. Presumably, using a styled component instead of a div is creating some prop-forwarding issues that was resulting in there being two buttons we were finding/simulating clicking. I didn't investigate it deeper, because it will be obvious to us if click behavior breaks. 

### Next Steps

1. Update `toggle` component.
    - It uses a dependency that hasn't been updated in 3 years. I will update that component in a separate PR
    - We want to apply the `focus` styling to it. 
1. Update `alert` component
    - We want to apply the `focus` styling to it.

Once those two items are complete, I will release a new beta version of this library for QA, in anticipation of a new major release. 