### PR TITLE
[a11y] Other Focus States

### DIFF
--- a/docs/banner.md
+++ b/docs/banner.md
@@ -12,6 +12,14 @@ import { Banner } from 'radiance-ui';
   }
 />
 <Banner
+  onClick={() => alert('clicked!')}
+  content={
+    <React.Fragment>
+      <strong>Clickable banner</strong> This is a banner with an onClick prop
+    </React.Fragment>
+  }
+/>
+<Banner
   content={
     <React.Fragment>
       <strong>Success banner:</strong> This is the banner content

--- a/docs/immersiveModal.md
+++ b/docs/immersiveModal.md
@@ -24,11 +24,13 @@ const [openModal, setOpenModal] = useState(false);
 {
   openModal && (
     <ImmersiveModal
-      onClose={(): void => setOpenModal(false)}
+      onClose={() => setOpenModal(false)}
       headerImage={<img src={headerImage} alt="header" />}
       footerContent={
         <Button.Container>
-          <Button isFullWidth>cta content</Button>
+          <Button isFullWidth onClick={() => setOpenModal(false)}>
+            cta content
+          </Button>
         </Button.Container>
       }
       title="Immersive modal title"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radiance-ui",
-  "version": "12.0.0-beta.2",
+  "version": "11.1.0",
   "description": "Curology's React based component library",
   "main": "dist/bundle.js",
   "module": "dist/bundle-es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radiance-ui",
-  "version": "11.1.0",
+  "version": "12.0.0-beta.1",
   "description": "Curology's React based component library",
   "main": "dist/bundle.js",
   "module": "dist/bundle-es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radiance-ui",
-  "version": "12.0.0-beta.1",
+  "version": "12.0.0-beta.2",
   "description": "Curology's React based component library",
   "main": "dist/bundle.js",
   "module": "dist/bundle-es/index.js",

--- a/src/constants/boxShadows/index.ts
+++ b/src/constants/boxShadows/index.ts
@@ -14,7 +14,6 @@ export const BASE_CONFIG = {
   message: `0 12px 20px 0 ${transparentize(boxShadowColor, 0.05)}`,
   focus: `0px 0px 0px 2px ${COLORS.white}, 0px 0px 0px 4px ${COLORS.primary}`,
   focusInner: `inset 0px 0px 0px 2px ${COLORS.primary}`,
-  focusSecondary: `0 0 2px 2px ${transparentize(COLORS.secondary, 0.5)}`,
 };
 
 export const OLD_BASE_CONFIG = {

--- a/src/shared-components/banner/__snapshots__/test.tsx.snap
+++ b/src/shared-components/banner/__snapshots__/test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Banner UI snapshots renders error type and text 1`] = `
   background: transparent;
   border: none;
   width: 100%;
-  cursor: pointer;
+  cursor: inherit;
   position: relative;
   margin: 0 auto 0.5rem;
   padding: 1rem;
@@ -115,7 +115,7 @@ exports[`Banner UI snapshots renders info type and text 1`] = `
   background: transparent;
   border: none;
   width: 100%;
-  cursor: pointer;
+  cursor: inherit;
   position: relative;
   margin: 0 auto 0.5rem;
   padding: 1rem;
@@ -163,7 +163,7 @@ exports[`Banner UI snapshots renders success type and text 1`] = `
   background: transparent;
   border: none;
   width: 100%;
-  cursor: pointer;
+  cursor: inherit;
   position: relative;
   margin: 0 auto 0.5rem;
   padding: 1rem;

--- a/src/shared-components/banner/__snapshots__/test.tsx.snap
+++ b/src/shared-components/banner/__snapshots__/test.tsx.snap
@@ -33,6 +33,9 @@ exports[`Banner UI snapshots renders error type and text 1`] = `
 }
 
 .emotion-6 {
+  background: transparent;
+  border: none;
+  width: 100%;
   cursor: pointer;
   position: relative;
   margin: 0 auto 0.5rem;
@@ -42,15 +45,20 @@ exports[`Banner UI snapshots renders error type and text 1`] = `
   box-shadow: 0px 8px 24px rgba(189,32,15,0.05);
 }
 
+.emotion-6:focus {
+  outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
+}
+
 @media (min-width:768px) {
   .emotion-6 {
     margin: 0 auto 1rem;
   }
 }
 
-<div
+<button
   className="emotion-6 emotion-7"
-  onClick={[Function]}
+  tabIndex={-1}
 >
   <div
     className="emotion-4 emotion-5"
@@ -68,7 +76,7 @@ exports[`Banner UI snapshots renders error type and text 1`] = `
       Error banner
     </div>
   </div>
-</div>
+</button>
 `;
 
 exports[`Banner UI snapshots renders info type and text 1`] = `
@@ -104,6 +112,9 @@ exports[`Banner UI snapshots renders info type and text 1`] = `
 }
 
 .emotion-6 {
+  background: transparent;
+  border: none;
+  width: 100%;
   cursor: pointer;
   position: relative;
   margin: 0 auto 0.5rem;
@@ -113,15 +124,20 @@ exports[`Banner UI snapshots renders info type and text 1`] = `
   box-shadow: 0px 8px 24px rgba(51,46,84,0.05);
 }
 
+.emotion-6:focus {
+  outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
+}
+
 @media (min-width:768px) {
   .emotion-6 {
     margin: 0 auto 1rem;
   }
 }
 
-<div
+<button
   className="emotion-6 emotion-7"
-  onClick={[Function]}
+  tabIndex={-1}
 >
   <div
     className="emotion-4 emotion-5"
@@ -139,11 +155,14 @@ exports[`Banner UI snapshots renders info type and text 1`] = `
       Default banner
     </div>
   </div>
-</div>
+</button>
 `;
 
 exports[`Banner UI snapshots renders success type and text 1`] = `
 .emotion-6 {
+  background: transparent;
+  border: none;
+  width: 100%;
   cursor: pointer;
   position: relative;
   margin: 0 auto 0.5rem;
@@ -151,6 +170,11 @@ exports[`Banner UI snapshots renders success type and text 1`] = `
   border-radius: 0.5rem;
   background-color: #2B6E33;
   box-shadow: 0px 8px 24px rgba(43,110,51,0.05);
+}
+
+.emotion-6:focus {
+  outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 @media (min-width:768px) {
@@ -190,9 +214,9 @@ exports[`Banner UI snapshots renders success type and text 1`] = `
   margin: -3px 0 0 1rem;
 }
 
-<div
+<button
   className="emotion-6 emotion-7"
-  onClick={[Function]}
+  tabIndex={-1}
 >
   <div
     className="emotion-4 emotion-5"
@@ -210,5 +234,5 @@ exports[`Banner UI snapshots renders success type and text 1`] = `
       Success Banner
     </div>
   </div>
-</div>
+</button>
 `;

--- a/src/shared-components/banner/index.tsx
+++ b/src/shared-components/banner/index.tsx
@@ -23,15 +23,19 @@ export type BannerType = 'default' | 'success' | 'error' | 'danger';
 
 type BannerProps = {
   content: React.ReactNode;
-  type: BannerType;
-  onClick: () => void;
+  type?: BannerType;
+  onClick?: () => void;
 };
 
-const Banner = ({ content, type, onClick }: BannerProps) => {
+const Banner = ({ content, type = 'default', onClick }: BannerProps) => {
   const Icon = bannerIconMapping[type];
 
   return (
-    <BannerContainer bannerType={type} onClick={onClick}>
+    <BannerContainer
+      bannerType={type}
+      onClick={onClick}
+      tabIndex={onClick ? 0 : -1}
+    >
       <MainContainer>
         <IconContainer>
           <Icon fill={COLORS.white} />
@@ -46,11 +50,6 @@ Banner.propTypes = {
   content: PropTypes.node.isRequired,
   type: PropTypes.oneOf(['default', 'success', 'error']),
   onClick: PropTypes.func,
-};
-
-Banner.defaultProps = {
-  type: 'default',
-  onClick: (): void => undefined,
 };
 
 export default Banner;

--- a/src/shared-components/banner/style.ts
+++ b/src/shared-components/banner/style.ts
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
+import { buttonReset } from 'src/utils/styles/buttonReset';
 
 import {
+  BOX_SHADOWS,
   COLORS,
   MEDIA_QUERIES,
   SPACER,
@@ -25,7 +27,17 @@ const errorAlertStyles = css`
   box-shadow: 0px 8px 24px rgba(189, 32, 15, 0.05);
 `;
 
-export const BannerContainer = styled.div<{ bannerType: BannerType }>`
+/**
+ * width: 100% to match previous <div> behavior
+ */
+export const BannerContainer = styled.button<{ bannerType: BannerType }>`
+  ${buttonReset}
+  width: 100%;
+  &:focus {
+    outline: none;
+    box-shadow: ${BOX_SHADOWS.focus};
+  }
+
   cursor: pointer;
   position: relative;
   margin: 0 auto ${SPACER.small};

--- a/src/shared-components/banner/style.ts
+++ b/src/shared-components/banner/style.ts
@@ -27,9 +27,6 @@ const errorAlertStyles = css`
   box-shadow: 0px 8px 24px rgba(189, 32, 15, 0.05);
 `;
 
-/**
- * width: 100% to match previous <div> behavior
- */
 export const BannerContainer = styled.button<{
   bannerType: BannerType;
   onClick?: () => void;

--- a/src/shared-components/banner/style.ts
+++ b/src/shared-components/banner/style.ts
@@ -30,7 +30,10 @@ const errorAlertStyles = css`
 /**
  * width: 100% to match previous <div> behavior
  */
-export const BannerContainer = styled.button<{ bannerType: BannerType }>`
+export const BannerContainer = styled.button<{
+  bannerType: BannerType;
+  onClick?: () => void;
+}>`
   ${buttonReset}
   width: 100%;
   &:focus {
@@ -38,7 +41,7 @@ export const BannerContainer = styled.button<{ bannerType: BannerType }>`
     box-shadow: ${BOX_SHADOWS.focus};
   }
 
-  cursor: pointer;
+  cursor: ${({ onClick }) => (onClick ? `pointer` : `inherit`)};
   position: relative;
   margin: 0 auto ${SPACER.small};
   padding: ${SPACER.medium};

--- a/src/shared-components/banner/test.tsx
+++ b/src/shared-components/banner/test.tsx
@@ -36,7 +36,7 @@ describe('Banner UI snapshots', () => {
       <Banner content="Banner with click handler" onClick={spy} />,
     );
 
-    component.root.findByType('div').props.onClick();
+    component.root.findByType('button').props.onClick();
     jest.runAllTimers();
     expect(spy).toHaveBeenCalled();
   });

--- a/src/shared-components/button/components/textButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/textButton/__snapshots__/test.tsx.snap
@@ -36,6 +36,7 @@ exports[`<TextButton /> UI snapshots renders with disabled prop 1`] = `
 .emotion-2 {
   border-color: transparent;
   background-color: transparent;
+  border-radius: 0.25rem;
   color: #c3c0cd;
   cursor: not-allowed;
 }
@@ -48,7 +49,7 @@ exports[`<TextButton /> UI snapshots renders with disabled prop 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <button
@@ -68,6 +69,7 @@ exports[`<TextButton /> UI snapshots renders without any props 1`] = `
 .emotion-2 {
   border-color: transparent;
   background-color: transparent;
+  border-radius: 0.25rem;
   color: #332e54;
   cursor: pointer;
 }
@@ -80,7 +82,7 @@ exports[`<TextButton /> UI snapshots renders without any props 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-0 {

--- a/src/shared-components/button/components/textButton/style.ts
+++ b/src/shared-components/button/components/textButton/style.ts
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled';
 
-import { BOX_SHADOWS, COLORS } from '../../../../constants';
+import { BOX_SHADOWS, COLORS, SPACER } from '../../../../constants';
 
 export const BaseTextButton = styled.button<{ disabled: boolean }>`
   border-color: transparent;
   background-color: transparent;
+  border-radius: ${SPACER.xsmall};
 
   color: ${({ disabled }) =>
     `${disabled ? COLORS.textDisabled : COLORS.primary}`};
@@ -18,6 +19,6 @@ export const BaseTextButton = styled.button<{ disabled: boolean }>`
   &:active,
   &:focus {
     outline: none;
-    box-shadow: ${BOX_SHADOWS.focusSecondary};
+    box-shadow: ${BOX_SHADOWS.focus};
   }
 `;

--- a/src/shared-components/dialogModal/style.ts
+++ b/src/shared-components/dialogModal/style.ts
@@ -113,6 +113,6 @@ export const CrossIconContainer = styled.div`
   }
   &:focus {
     outline: none;
-    box-shadow: ${BOX_SHADOWS.focusSecondary};
+    box-shadow: ${BOX_SHADOWS.focus};
   }
 `;

--- a/src/shared-components/field/__snapshots__/test.js.snap
+++ b/src/shared-components/field/__snapshots__/test.js.snap
@@ -54,7 +54,7 @@ exports[`<Field /> UI Snapshot renders with label and labelFor 1`] = `
 .emotion-2:focus {
   outline: none;
   border-color: #332e54;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-2:active ~ .ez9grqt0,
@@ -175,7 +175,7 @@ exports[`<Field /> UI Snapshot renders with label prop 1`] = `
 .emotion-2:focus {
   outline: none;
   border-color: #332e54;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-2:active ~ .ez9grqt0,

--- a/src/shared-components/field/style.js
+++ b/src/shared-components/field/style.js
@@ -39,7 +39,7 @@ const inputStyles = css`
   &:focus {
     outline: none;
     border-color: ${COLORS.primary};
-    box-shadow: ${BOX_SHADOWS.focusSecondary};
+    box-shadow: ${BOX_SHADOWS.focus};
 
     ~ ${HintItem} {
       max-height: 24px;
@@ -80,7 +80,7 @@ export const Textarea = styled.textarea`
   width: 100%;
 `;
 
-const applyMessagesStyles = messagesType => css`
+const applyMessagesStyles = (messagesType) => css`
   svg.radiance-field-input-icon {
     opacity: 1;
   }
@@ -93,7 +93,7 @@ const applyMessagesStyles = messagesType => css`
       border-color: ${messagesType === 'success'
         ? COLORS.success
         : COLORS.error};
-      box-shadow: none;
+      box-shadow: ${BOX_SHADOWS.focus};
     }
   }
 `;

--- a/src/shared-components/immersiveModal/crossIconComponent/index.tsx
+++ b/src/shared-components/immersiveModal/crossIconComponent/index.tsx
@@ -5,7 +5,7 @@ import CrossIcon from '../../../svgs/icons/cross-icon.svg';
 import { CrossIconContainer } from '../style';
 
 type CrossIconComponentProps = {
-  showDesktopHeaderBar: boolean;
+  isVisible: boolean;
   onClick: () => void;
 };
 
@@ -17,13 +17,13 @@ type CrossIconComponentProps = {
  * CrossIcons present in the markup. (We keep both rendered for our transitions.)
  */
 const CrossIconComponent = ({
-  showDesktopHeaderBar,
+  isVisible,
   onClick,
 }: CrossIconComponentProps) => {
   const focusManager = useFocusManager();
 
   useEffect(() => {
-    if (showDesktopHeaderBar) {
+    if (isVisible) {
       focusManager.focusNext();
     } else {
       /**
@@ -32,13 +32,10 @@ const CrossIconComponent = ({
        */
       focusManager.focusPrevious({ wrap: false });
     }
-  }, [showDesktopHeaderBar]);
+  }, [isVisible]);
 
   return (
-    <CrossIconContainer
-      onClick={onClick}
-      tabIndex={showDesktopHeaderBar ? 0 : -1}
-    >
+    <CrossIconContainer onClick={onClick} tabIndex={isVisible ? 0 : -1}>
       <CrossIcon />
     </CrossIconContainer>
   );

--- a/src/shared-components/immersiveModal/crossIconComponent/index.tsx
+++ b/src/shared-components/immersiveModal/crossIconComponent/index.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect } from 'react';
+import { useFocusManager } from '@react-aria/focus';
+
+import CrossIcon from '../../../svgs/icons/cross-icon.svg';
+import { CrossIconContainer } from '../style';
+
+type CrossIconComponentProps = {
+  showDesktopHeaderBar: boolean;
+  onClick: () => void;
+};
+
+/**
+ * We wrap the Desktop-associated CrossIcon functionality as a React component
+ * in order to take advantage of @react-aria/focus useFocusManager hook.
+ *
+ * This allows us to automatically toggle focus state between the two separate
+ * CrossIcons present in the markup. (We keep both rendered for our transitions.)
+ */
+const CrossIconComponent = ({
+  showDesktopHeaderBar,
+  onClick,
+}: CrossIconComponentProps) => {
+  const focusManager = useFocusManager();
+
+  useEffect(() => {
+    if (showDesktopHeaderBar) {
+      focusManager.focusNext();
+    } else {
+      // This clause is setup to return the focus state from the Desktop-associated CrossIcon
+      // to the Mobile-associated This fires the first time the component renders. { wrap: false } keeps the
+      // focus state on the initial CrossIcon button we show.
+      focusManager.focusPrevious({ wrap: false });
+    }
+  }, [showDesktopHeaderBar]);
+
+  return (
+    <CrossIconContainer
+      onClick={onClick}
+      tabIndex={showDesktopHeaderBar ? 0 : -1}
+    >
+      <CrossIcon />
+    </CrossIconContainer>
+  );
+};
+
+export default CrossIconComponent;

--- a/src/shared-components/immersiveModal/crossIconComponent/index.tsx
+++ b/src/shared-components/immersiveModal/crossIconComponent/index.tsx
@@ -10,8 +10,8 @@ type CrossIconComponentProps = {
 };
 
 /**
- * We wrap the Desktop-associated CrossIcon functionality as a React component
- * in order to take advantage of @react-aria/focus useFocusManager hook.
+ * We wrap the second of the CrossIcons we render as a React component
+ * in order to use the @react-aria/focus useFocusManager hook.
  *
  * This allows us to automatically toggle focus state between the two separate
  * CrossIcons present in the markup. (We keep both rendered for our transitions.)
@@ -26,9 +26,10 @@ const CrossIconComponent = ({
     if (showDesktopHeaderBar) {
       focusManager.focusNext();
     } else {
-      // This clause is setup to return the focus state from the Desktop-associated CrossIcon
-      // to the Mobile-associated This fires the first time the component renders. { wrap: false } keeps the
-      // focus state on the initial CrossIcon button we show.
+      /**
+       * This clause returns focus to the initial CrossIcon when the second CrossIcon is in focus, and we scroll back up.
+       * However, it also triggers on the initial render, so { wrap: false } prevents the focus state from changing.
+       */
       focusManager.focusPrevious({ wrap: false });
     }
   }, [showDesktopHeaderBar]);

--- a/src/shared-components/immersiveModal/index.tsx
+++ b/src/shared-components/immersiveModal/index.tsx
@@ -38,7 +38,7 @@ const REACT_PORTAL_SECTION_ID = 'reactPortalSection';
 const MODAL_MOBILE_SCROLLING_ID = 'modal-mobile-scrolling-id';
 const MODAL_DESKTOP_SCROLLING_ID = 'modal-desktop-scrolling-id';
 
-const getHtmlRef = () => document.querySelector('html') || document.body;
+const getHtmlNode = () => document.querySelector('html') || document.body;
 const getDomNode = () =>
   (document.getElementById(REACT_PORTAL_SECTION_ID) as HTMLElement) ||
   document.body;
@@ -59,7 +59,7 @@ const ImmersiveModal = ({
   const [showMobileHeaderBar, setShowMobileHeaderBar] = useState(false);
   const [showDesktopHeaderBar, setShowDesktopHeaderBar] = useState(false);
 
-  const htmlNode = useRef<HTMLElement>(getHtmlRef());
+  const htmlNode = useRef<HTMLElement>(getHtmlNode());
   const domNode = useRef<HTMLElement>(getDomNode());
   const modalMobileScrollingElement = useRef<HTMLElement | null>(
     getModalMobileScrollingElement(),
@@ -94,7 +94,7 @@ const ImmersiveModal = ({
   };
 
   useEffect(() => {
-    htmlNode.current = getHtmlRef();
+    htmlNode.current = getHtmlNode();
     domNode.current = getDomNode();
     modalMobileScrollingElement.current = getModalMobileScrollingElement();
     modalDesktopScrollingElement.current = getModalDesktopScrollingElement();

--- a/src/shared-components/immersiveModal/index.tsx
+++ b/src/shared-components/immersiveModal/index.tsx
@@ -5,8 +5,6 @@ import { Transition } from 'react-transition-group';
 import throttle from 'lodash.throttle';
 import { FocusScope } from '@react-aria/focus';
 
-import keyboardKeys from '../../constants/keyboardKeys';
-import keyPressMatch from '../../utils/keyPressMatch';
 import OffClickWrapper from '../offClickWrapper';
 import CrossIcon from '../../svgs/icons/cross-icon.svg';
 import {
@@ -87,12 +85,6 @@ const ImmersiveModal = ({
     setTimeout(onClose, 450);
   };
 
-  const handleEscapeKey = (event: KeyboardEvent) => {
-    if (keyPressMatch(event, keyboardKeys.escape)) {
-      handleCloseIntent();
-    }
-  };
-
   useEffect(() => {
     htmlNode.current = getHtmlNode();
     domNode.current = getDomNode();
@@ -115,10 +107,6 @@ const ImmersiveModal = ({
       );
     }
 
-    document
-      .getElementsByTagName('body')[0]
-      .addEventListener('keydown', handleEscapeKey);
-
     return () => {
       htmlNode.current.classList.remove('no-scroll');
 
@@ -135,10 +123,6 @@ const ImmersiveModal = ({
           handleScroll,
         );
       }
-
-      document
-        .getElementsByTagName('body')[0]
-        .removeEventListener('keydown', handleEscapeKey);
     };
   }, []);
 
@@ -189,7 +173,7 @@ const ImmersiveModal = ({
                     >
                       {title}
                       <CrossIconComponent
-                        showDesktopHeaderBar={showDesktopHeaderBar}
+                        isVisible={showDesktopHeaderBar}
                         onClick={handleCloseIntent}
                       />
                     </DesktopHeaderBar>

--- a/src/shared-components/immersiveModal/index.tsx
+++ b/src/shared-components/immersiveModal/index.tsx
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { Transition } from 'react-transition-group';
 import throttle from 'lodash.throttle';
+import { FocusScope } from '@react-aria/focus';
 
 import keyboardKeys from '../../constants/keyboardKeys';
 import keyPressMatch from '../../utils/keyPressMatch';
@@ -22,6 +23,7 @@ import {
   ModalFooter,
   MainModalContentContainer,
 } from './style';
+import CrossIconComponent from './crossIconComponent';
 
 type ImmersiveModalProps = {
   children: React.ReactNode;
@@ -29,186 +31,169 @@ type ImmersiveModalProps = {
   footerContent?: React.ReactNode;
   onClose: () => void;
   title?: string;
+  [key: string]: unknown;
 };
 
-type ImmersiveModalState = {
-  isClosing: boolean;
-  showMobileHeaderBar: boolean;
-  showDesktopHeaderBar: boolean;
-};
+const REACT_PORTAL_SECTION_ID = 'reactPortalSection';
+const MODAL_MOBILE_SCROLLING_ID = 'modal-mobile-scrolling-id';
+const MODAL_DESKTOP_SCROLLING_ID = 'modal-desktop-scrolling-id';
 
-const reactPortalSectionId = '#reactPortalSection';
+const getHtmlRef = () => document.querySelector('html') || document.body;
+const getDomNode = () =>
+  (document.getElementById(REACT_PORTAL_SECTION_ID) as HTMLElement) ||
+  document.body;
+const getModalMobileScrollingElement = () =>
+  document.getElementById(MODAL_MOBILE_SCROLLING_ID) as HTMLElement;
+const getModalDesktopScrollingElement = () =>
+  document.getElementById(MODAL_DESKTOP_SCROLLING_ID) as HTMLElement;
 
-class ImmersiveModal extends React.Component<
-  ImmersiveModalProps,
-  ImmersiveModalState
-> {
-  static propTypes = {
-    children: PropTypes.node.isRequired,
-    headerImage: PropTypes.node,
-    footerContent: PropTypes.node,
-    onClose: PropTypes.func.isRequired,
-    title: PropTypes.string,
-  };
+const ImmersiveModal = ({
+  children,
+  footerContent = null,
+  headerImage = null,
+  onClose,
+  title = '',
+  ...rest
+}: ImmersiveModalProps) => {
+  const [isClosing, setIsClosing] = useState(false);
+  const [showMobileHeaderBar, setShowMobileHeaderBar] = useState(false);
+  const [showDesktopHeaderBar, setShowDesktopHeaderBar] = useState(false);
 
-  static defaultProps = {
-    headerImage: null,
-    footerContent: null,
-    title: '',
-  };
+  const htmlNode = useRef<HTMLElement>(getHtmlRef());
+  const domNode = useRef<HTMLElement>(getDomNode());
+  const modalMobileScrollingElement = useRef<HTMLElement | null>(
+    getModalMobileScrollingElement(),
+  );
+  const modalDesktopScrollingElement = useRef<HTMLElement | null>(
+    getModalDesktopScrollingElement(),
+  );
 
-  state = {
-    isClosing: false,
-    showMobileHeaderBar: false,
-    showDesktopHeaderBar: false,
-  };
-
-  htmlNode: HTMLElement;
-
-  domNode: HTMLElement;
-
-  modalMobileScrollingElement: HTMLElement | null = null;
-
-  modalDesktopScrollingElement: HTMLElement | null = null;
-
-  constructor(props: ImmersiveModalProps) {
-    super(props);
-
-    this.htmlNode = document.querySelector('html') || document.body;
-
-    this.domNode =
-      document.querySelector(reactPortalSectionId) || document.body;
-  }
-
-  componentDidMount(): void {
-    this.htmlNode.classList.add('no-scroll');
-
-    this.modalMobileScrollingElement = document.querySelector(
-      '#modal-mobile-scrolling-id',
-    );
-    this.modalDesktopScrollingElement = document.querySelector(
-      '#modal-desktop-scrolling-id',
-    );
-
-    if (this.modalMobileScrollingElement && this.modalDesktopScrollingElement) {
-      this.modalMobileScrollingElement.addEventListener(
-        'scroll',
-        this.handleScroll,
-      );
-      this.modalDesktopScrollingElement.addEventListener(
-        'scroll',
-        this.handleScroll,
-      );
+  const handleScroll = throttle(() => {
+    if (modalMobileScrollingElement.current) {
+      const shouldShowMobileHeaderBar =
+        modalMobileScrollingElement.current.scrollTop > 32;
+      setShowMobileHeaderBar(shouldShowMobileHeaderBar);
     }
-
-    document
-      .getElementsByTagName('body')[0]
-      .addEventListener('keydown', this.handleEscapeKey);
-  }
-
-  componentWillUnmount(): void {
-    this.htmlNode.classList.remove('no-scroll');
-
-    if (this.modalMobileScrollingElement && this.modalDesktopScrollingElement) {
-      this.modalMobileScrollingElement.removeEventListener(
-        'scroll',
-        this.handleScroll,
-      );
-      this.modalDesktopScrollingElement.removeEventListener(
-        'scroll',
-        this.handleScroll,
-      );
-    }
-
-    document
-      .getElementsByTagName('body')[0]
-      .removeEventListener('keydown', this.handleEscapeKey);
-  }
-
-  handleScroll = throttle(() => {
-    if (this.modalMobileScrollingElement) {
-      const showMobileHeaderBar =
-        this.modalMobileScrollingElement.scrollTop > 32;
-      this.setState({ showMobileHeaderBar });
-    }
-    if (this.modalDesktopScrollingElement) {
-      const showDesktopHeaderBar =
-        this.modalDesktopScrollingElement.scrollTop > 32;
-      this.setState({ showDesktopHeaderBar });
+    if (modalDesktopScrollingElement.current) {
+      const shouldShowDesktopHeaderBar =
+        modalDesktopScrollingElement.current.scrollTop > 32;
+      setShowDesktopHeaderBar(shouldShowDesktopHeaderBar);
     }
   }, 100);
 
-  handleCloseIntent = (): void => {
-    const { onClose } = this.props;
-    this.setState({ isClosing: true, showMobileHeaderBar: false });
-
+  const handleCloseIntent = () => {
+    setIsClosing(true);
+    setShowMobileHeaderBar(false);
     setTimeout(onClose, 450);
   };
 
-  handleEscapeKey = (event: KeyboardEvent): void => {
+  const handleEscapeKey = (event: KeyboardEvent) => {
     if (keyPressMatch(event, keyboardKeys.escape)) {
-      this.handleCloseIntent();
+      handleCloseIntent();
     }
   };
 
-  render(): JSX.Element {
-    const {
-      children,
-      headerImage,
-      footerContent,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      onClose,
-      title,
-      ...rest
-    } = this.props;
+  useEffect(() => {
+    htmlNode.current = getHtmlRef();
+    domNode.current = getDomNode();
+    modalMobileScrollingElement.current = getModalMobileScrollingElement();
+    modalDesktopScrollingElement.current = getModalDesktopScrollingElement();
 
-    const { isClosing, showMobileHeaderBar, showDesktopHeaderBar } = this.state;
+    htmlNode.current.classList.add('no-scroll');
 
-    return ReactDOM.createPortal(
-      <Transition
-        timeout={{
-          appear: 0,
-          enter: 0,
-          exit: 350,
-        }}
-        in={!isClosing}
-        unmountOnExit
-        appear
-      >
-        {(transitionState): JSX.Element => (
-          <React.Fragment>
-            <MobileHeaderBar showMobileHeaderBar={showMobileHeaderBar}>
-              {title}
-              <CrossIconContainer onClick={this.handleCloseIntent}>
-                <CrossIcon />
-              </CrossIconContainer>
-            </MobileHeaderBar>
-            {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-            <Overlay className={transitionState} {...rest}>
-              <ModalContainer
-                className={transitionState}
-                id="modal-mobile-scrolling-id"
+    if (
+      modalMobileScrollingElement.current &&
+      modalDesktopScrollingElement.current
+    ) {
+      modalMobileScrollingElement.current.addEventListener(
+        'scroll',
+        handleScroll,
+      );
+      modalDesktopScrollingElement.current.addEventListener(
+        'scroll',
+        handleScroll,
+      );
+    }
+
+    document
+      .getElementsByTagName('body')[0]
+      .addEventListener('keydown', handleEscapeKey);
+
+    return () => {
+      htmlNode.current.classList.remove('no-scroll');
+
+      if (
+        modalMobileScrollingElement.current &&
+        modalDesktopScrollingElement.current
+      ) {
+        modalMobileScrollingElement.current.removeEventListener(
+          'scroll',
+          handleScroll,
+        );
+        modalDesktopScrollingElement.current.removeEventListener(
+          'scroll',
+          handleScroll,
+        );
+      }
+
+      document
+        .getElementsByTagName('body')[0]
+        .removeEventListener('keydown', handleEscapeKey);
+    };
+  }, []);
+
+  return ReactDOM.createPortal(
+    <Transition
+      timeout={{
+        appear: 0,
+        enter: 0,
+        exit: 350,
+      }}
+      in={!isClosing}
+      unmountOnExit
+      appear
+    >
+      {(transitionState): JSX.Element => (
+        <React.Fragment>
+          <MobileHeaderBar showMobileHeaderBar={showMobileHeaderBar}>
+            {title}
+            <CrossIconContainer onClick={handleCloseIntent}>
+              <CrossIcon />
+            </CrossIconContainer>
+          </MobileHeaderBar>
+          {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+          <Overlay className={transitionState} {...rest}>
+            <ModalContainer
+              className={transitionState}
+              id={MODAL_MOBILE_SCROLLING_ID}
+            >
+              <OffClickWrapper
+                onOffClick={handleCloseIntent}
+                className="modal-offclick-wrapper"
               >
-                <OffClickWrapper
-                  onOffClick={this.handleCloseIntent}
-                  className="modal-offclick-wrapper"
-                >
-                  <MobileTopOverlay onClick={this.handleCloseIntent} />
+                <MobileTopOverlay onClick={handleCloseIntent} />
+                <FocusScope contain restoreFocus autoFocus>
                   <MainModalContentContainer
-                    id="modal-desktop-scrolling-id"
+                    id={MODAL_DESKTOP_SCROLLING_ID}
                     hasHeaderImage={!!headerImage}
                   >
+                    <CrossIconContainer
+                      onClick={handleCloseIntent}
+                      tabIndex={showDesktopHeaderBar ? -1 : 0}
+                    >
+                      <CrossIcon />
+                    </CrossIconContainer>
+
                     <DesktopHeaderBar
                       showDesktopHeaderBar={showDesktopHeaderBar}
                     >
                       {title}
-                      <CrossIconContainer onClick={this.handleCloseIntent}>
-                        <CrossIcon />
-                      </CrossIconContainer>
+                      <CrossIconComponent
+                        showDesktopHeaderBar={showDesktopHeaderBar}
+                        onClick={handleCloseIntent}
+                      />
                     </DesktopHeaderBar>
-                    <CrossIconContainer onClick={this.handleCloseIntent}>
-                      <CrossIcon />
-                    </CrossIconContainer>
+
                     {headerImage && (
                       <HeaderImageContainer>{headerImage}</HeaderImageContainer>
                     )}
@@ -222,15 +207,23 @@ class ImmersiveModal extends React.Component<
                       )}
                     </ContentWithFooterContainer>
                   </MainModalContentContainer>
-                </OffClickWrapper>
-              </ModalContainer>
-            </Overlay>
-          </React.Fragment>
-        )}
-      </Transition>,
-      this.domNode,
-    );
-  }
-}
+                </FocusScope>
+              </OffClickWrapper>
+            </ModalContainer>
+          </Overlay>
+        </React.Fragment>
+      )}
+    </Transition>,
+    domNode.current,
+  );
+};
+
+ImmersiveModal.propTypes = {
+  children: PropTypes.node.isRequired,
+  headerImage: PropTypes.node,
+  footerContent: PropTypes.node,
+  onClose: PropTypes.func.isRequired,
+  title: PropTypes.string,
+};
 
 export default ImmersiveModal;

--- a/src/shared-components/immersiveModal/style.ts
+++ b/src/shared-components/immersiveModal/style.ts
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
+import { buttonReset } from 'src/utils/styles/buttonReset';
 
 import Typography from '../typography';
 import {
+  BOX_SHADOWS,
   COLORS,
   MEDIA_QUERIES,
   SPACER,
@@ -38,7 +40,9 @@ export const Overlay = styled.div`
   }
 `;
 
-export const CrossIconContainer = styled.div`
+export const CrossIconContainer = styled.button`
+  ${buttonReset};
+  padding: 0;
   position: absolute;
   top: 8px;
   right: 12px;
@@ -57,6 +61,11 @@ export const CrossIconContainer = styled.div`
   ${MEDIA_QUERIES.mdUp} {
     top: 16px;
     right: 16px;
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: ${BOX_SHADOWS.focus};
   }
 `;
 

--- a/src/shared-components/optionButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/optionButton/__snapshots__/test.tsx.snap
@@ -21,7 +21,7 @@ exports[`<OptionButton /> UI snapshots checkbox selected, without custom icon 1`
 
 .emotion-8:focus {
   outline: none;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-6 {
@@ -146,7 +146,7 @@ exports[`<OptionButton /> UI snapshots radio unselected, with icon node prop 1`]
 
 .emotion-8:focus {
   outline: none;
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-6 {

--- a/src/shared-components/optionButton/style.ts
+++ b/src/shared-components/optionButton/style.ts
@@ -48,7 +48,7 @@ export const ClickableContainer = styled.button<{
 
   :focus {
     outline: none;
-    box-shadow: ${BOX_SHADOWS.focusSecondary};
+    box-shadow: ${BOX_SHADOWS.focus};
   }
 `;
 

--- a/src/shared-components/selectorButton/__snapshots__/test.js.snap
+++ b/src/shared-components/selectorButton/__snapshots__/test.js.snap
@@ -95,7 +95,6 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 .emotion-3:active,
 .emotion-3:focus {
   outline: none;
-  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -230,7 +229,6 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 .emotion-3:active,
 .emotion-3:focus {
   outline: none;
-  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -361,7 +359,6 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for check
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
-  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -491,7 +488,6 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for radio
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
-  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -621,7 +617,6 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for checkbox
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
-  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -739,7 +734,6 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for radio bu
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
-  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-6 {
@@ -875,7 +869,6 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
 .emotion-3:active,
 .emotion-3:focus {
   outline: none;
-  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -1009,7 +1002,6 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
 .emotion-3:active,
 .emotion-3:focus {
   outline: none;
-  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -1132,7 +1124,6 @@ exports[`<SelectorButton /> UI snapshots when children is a node 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
-  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-6 {
@@ -1256,7 +1247,6 @@ exports[`<SelectorButton /> UI snapshots when children is undefined 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
-  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -1375,7 +1365,6 @@ exports[`<SelectorButton /> UI snapshots when is checkbox 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
-  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div

--- a/src/shared-components/selectorButton/__snapshots__/test.js.snap
+++ b/src/shared-components/selectorButton/__snapshots__/test.js.snap
@@ -61,7 +61,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 }
 
 .emotion-9:focus .emotion-6 {
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
   border-radius: 4px;
 }
 
@@ -95,6 +95,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 .emotion-3:active,
 .emotion-3:focus {
   outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -157,7 +158,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 }
 
 .emotion-9:focus .emotion-6 {
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
   border-radius: 100%;
 }
 
@@ -229,6 +230,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 .emotion-3:active,
 .emotion-3:focus {
   outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -325,7 +327,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for check
 }
 
 .emotion-8:focus .emotion-5 {
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
   border-radius: 4px;
 }
 
@@ -359,6 +361,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for check
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -420,7 +423,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for radio
 }
 
 .emotion-8:focus .emotion-5 {
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
   border-radius: 100%;
 }
 
@@ -488,6 +491,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for radio
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -583,7 +587,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for checkbox
 }
 
 .emotion-8:focus .emotion-5 {
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
   border-radius: 4px;
 }
 
@@ -617,6 +621,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for checkbox
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -673,7 +678,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for radio bu
 }
 
 .emotion-8:focus .emotion-5 {
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
   border-radius: 100%;
 }
 
@@ -734,6 +739,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for radio bu
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-6 {
@@ -797,7 +803,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
 }
 
 .emotion-9:focus .emotion-6 {
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
   border-radius: 100%;
 }
 
@@ -869,6 +875,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
 .emotion-3:active,
 .emotion-3:focus {
   outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -930,7 +937,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
 }
 
 .emotion-9:focus .emotion-6 {
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
   border-radius: 100%;
 }
 
@@ -1002,6 +1009,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
 .emotion-3:active,
 .emotion-3:focus {
   outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -1063,7 +1071,7 @@ exports[`<SelectorButton /> UI snapshots when children is a node 1`] = `
 }
 
 .emotion-8:focus .emotion-5 {
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
   border-radius: 100%;
 }
 
@@ -1124,6 +1132,7 @@ exports[`<SelectorButton /> UI snapshots when children is a node 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 .emotion-6 {
@@ -1186,7 +1195,7 @@ exports[`<SelectorButton /> UI snapshots when children is undefined 1`] = `
 }
 
 .emotion-6:focus .emotion-5 {
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
   border-radius: 100%;
 }
 
@@ -1247,6 +1256,7 @@ exports[`<SelectorButton /> UI snapshots when children is undefined 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div
@@ -1331,7 +1341,7 @@ exports[`<SelectorButton /> UI snapshots when is checkbox 1`] = `
 }
 
 .emotion-8:focus .emotion-5 {
-  box-shadow: 0 0 2px 2px rgba(166,161,226,0.5);
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
   border-radius: 4px;
 }
 
@@ -1365,6 +1375,7 @@ exports[`<SelectorButton /> UI snapshots when is checkbox 1`] = `
 .emotion-2:active,
 .emotion-2:focus {
   outline: none;
+  box-shadow: 0px 0px 0px 2px #ffffff,0px 0px 0px 4px #332e54;
 }
 
 <div

--- a/src/shared-components/selectorButton/style.js
+++ b/src/shared-components/selectorButton/style.js
@@ -20,7 +20,7 @@ export const OuterContainer = styled.div`
   :focus {
     outline: none;
     ${SelectorContainer} {
-      box-shadow: ${BOX_SHADOWS.focusSecondary};
+      box-shadow: ${BOX_SHADOWS.focus};
 
       ${({ selector }) => css`
         border-radius: ${selector === 'checkbox' ? '4px' : '100%'};
@@ -40,12 +40,12 @@ export const SelectorIcon = styled.div`
   `};
 `;
 
-const primarySelectorStyle = checked => css`
+const primarySelectorStyle = (checked) => css`
   background-color: ${checked ? COLORS.primary : 'transparent'};
   border-color: ${COLORS.primary};
 `;
 
-const secondarySelectorStyle = checked => css`
+const secondarySelectorStyle = (checked) => css`
   background-color: ${checked ? COLORS.secondary : 'transparent'};
   border-color: ${checked ? COLORS.secondary : COLORS.primary};
 `;
@@ -87,6 +87,7 @@ export const Selector = styled.div`
   &:active,
   &:focus {
     outline: none;
+    box-shadow: ${BOX_SHADOWS.focus};
   }
 `;
 

--- a/src/shared-components/selectorButton/style.js
+++ b/src/shared-components/selectorButton/style.js
@@ -87,7 +87,6 @@ export const Selector = styled.div`
   &:active,
   &:focus {
     outline: none;
-    box-shadow: ${BOX_SHADOWS.focus};
   }
 `;
 

--- a/stories/banner/index.tsx
+++ b/stories/banner/index.tsx
@@ -29,6 +29,15 @@ stories.add(
         type="success"
       />
       <Banner
+        onClick={() => alert('clicked!')}
+        content={
+          <React.Fragment>
+            <strong>Clickable banner</strong> This is a banner with an onClick
+            prop
+          </React.Fragment>
+        }
+      />
+      <Banner
         content={
           <React.Fragment>
             <strong>Error Banner:</strong> This is the banner content

--- a/stories/immersiveModal/immersiveModalExamples.tsx
+++ b/stories/immersiveModal/immersiveModalExamples.tsx
@@ -131,10 +131,12 @@ const ImmersiveModalExamples = (): JSX.Element => {
       </Button>
       {withButtons && (
         <ImmersiveModal
-          onClose={(): void => setWithButtons(false)}
+          onClose={() => setWithButtons(false)}
           footerContent={
             <Button.Container>
-              <Button isFullWidth>cta content</Button>
+              <Button isFullWidth onClick={() => setWithButtons(false)}>
+                cta content
+              </Button>
             </Button.Container>
           }
           title="Immersive modal title"


### PR DESCRIPTION
### What & Why

This PR contains the final changes made to our accessibility/keyboard focus states before cutting a major release. Many of changes are simply replacing `BOX_SHADOWS.focusSecondary` for `BOX_SHADOWS.focus` and then updating the snapshots. The below notes cover the other changes:

1. Remove `BOX_SHADOWS.focusSecondary`
    - `BOX_SHADOWS.focus` and `BOX_SHADOWS.focusInner` will be the preferred focus states going forward. 
1. Makes `Banner` a button instead of div. 
    - `Banner` optionally accepts an `onClick` prop. When it is present, we'll make it keyboard focusable. Otherwise, we'll treat it as a div. (No interactivity.)
    - Removes `defaultProps` in favor of ES6 defaults. 
1. Converts `src/shared-components/immersiveModal/index.tsx` to a function component.
    - If we want to keep the diff smaller, I am pretty sure I can set this back to the old class component code. I converted it because I thought I had to in order to take advantage of `useFocusManager`, but it became clear while working on it that concern was better separated into a separate component, which I've named `CrossIconComponent`. I'm open to changing it 😓 
        - My feeling is: if it works, might as well keep the newer code. 
        - I've left an additional comment on that specific diff with a `CHANGELOG` to make reviewing it easier.

### Components updated:

**Banner**: This was not scoped but since we allow onClick functionality we need to support it: 

![image](https://user-images.githubusercontent.com/13544620/94483177-1e51bb00-01a0-11eb-916f-b28711eb833f.png)

**DialogModal** close icon before and after:
 
<img width="70" alt="Screen Shot 2020-09-28 at 3 35 22 PM" src="https://user-images.githubusercontent.com/13544620/94483322-4ccf9600-01a0-11eb-811f-b7fbb2560ea2.png">

<img width="67" alt="Screen Shot 2020-09-28 at 3 35 31 PM" src="https://user-images.githubusercontent.com/13544620/94483324-4e995980-01a0-11eb-9103-a8927c9869a0.png">

**Field** before and after:

<img width="382" alt="Screen Shot 2020-09-28 at 3 36 45 PM" src="https://user-images.githubusercontent.com/13544620/94483431-78eb1700-01a0-11eb-93a8-f3f9a90cc81c.png">
<img width="385" alt="Screen Shot 2020-09-28 at 3 36 32 PM" src="https://user-images.githubusercontent.com/13544620/94483424-7688bd00-01a0-11eb-9844-2ff2eb77352b.png">

**ImmersiveModal**: same as DialogModal, but there was previously no outline. 

**OptionButton** before and after:

<img width="376" alt="Screen Shot 2020-09-28 at 3 38 59 PM" src="https://user-images.githubusercontent.com/13544620/94483609-c071a300-01a0-11eb-9f61-00c57ab7469c.png">

<img width="385" alt="Screen Shot 2020-09-28 at 3 38 41 PM" src="https://user-images.githubusercontent.com/13544620/94483582-b51e7780-01a0-11eb-8f07-0b93c715fca0.png">


**SelectorButton** (underlying component for Checkbox and RadioButton) befores and afters:

<img width="298" alt="Screen Shot 2020-09-28 at 3 39 29 PM" src="https://user-images.githubusercontent.com/13544620/94483691-db441780-01a0-11eb-8af1-43894acaa655.png">
<img width="282" alt="Screen Shot 2020-09-28 at 3 39 36 PM" src="https://user-images.githubusercontent.com/13544620/94483689-da12ea80-01a0-11eb-90fa-eb8839f6864d.png">
<img width="269" alt="Screen Shot 2020-09-28 at 3 39 22 PM" src="https://user-images.githubusercontent.com/13544620/94483694-dd0ddb00-01a0-11eb-8474-fd600ebeb70a.png">
<img width="253" alt="Screen Shot 2020-09-28 at 3 39 14 PM" src="https://user-images.githubusercontent.com/13544620/94483703-ded79e80-01a0-11eb-83cd-2deb0bf56fdf.png">

**TextButton**:

<img width="222" alt="Screen Shot 2020-09-28 at 3 38 23 PM" src="https://user-images.githubusercontent.com/13544620/94483546-aa63e280-01a0-11eb-8167-dd0d9f55731a.png">

### Other

I did not add transitions to components that did not already have them, so tabbing between the dedicated Buttons story is a very different experience than Checkbox/Option/Radio button components. I am okay with that, but this probably represents an area where Design and Eng might have a different understanding of behaviors, so I'm calling it out. cc @benkolde for visibility/FYI on the Design side.

### Release Notes

- We will be removing `BOX_SHADOWS.focusSecondary` and cutting a new major release after merging this in. We will need to replace it with `BOX_SHADOWS.focus` in direct `BOX_SHADOWS.focusSecondary` usages. 
    - It does not exist in our Design assets anymore, so we should not keep it around. 