### PR TITLE
[Hotfixes] -  Verification messages animation and modal

### DIFF
--- a/src/shared-components/field/__snapshots__/test.tsx.snap
+++ b/src/shared-components/field/__snapshots__/test.tsx.snap
@@ -103,12 +103,7 @@ exports[`<Field /> UI Snapshot renders with default props 1`] = `
     />
     <ul
       className="emotion-2 emotion-3"
-    >
-      <li
-        in={true}
-        onExited={[Function]}
-      />
-    </ul>
+    />
   </div>
 </div>
 `;
@@ -396,12 +391,7 @@ exports[`<Field /> UI Snapshot renders with label and labelFor props 1`] = `
     />
     <ul
       className="emotion-4 emotion-5"
-    >
-      <li
-        in={true}
-        onExited={[Function]}
-      />
-    </ul>
+    />
   </div>
 </div>
 `;

--- a/src/shared-components/field/__snapshots__/test.tsx.snap
+++ b/src/shared-components/field/__snapshots__/test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Field /> UI Snapshot renders with default props 1`] = `
-.emotion-4 {
+.emotion-6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12,11 +12,11 @@ exports[`<Field /> UI Snapshot renders with default props 1`] = `
   margin-bottom: 22px;
 }
 
-.emotion-2 {
+.emotion-4 {
   position: relative;
 }
 
-.emotion-2 svg.radiance-field-input-icon {
+.emotion-4 svg.radiance-field-input-icon {
   opacity: 0;
   position: absolute;
   top: 20px;
@@ -82,11 +82,16 @@ exports[`<Field /> UI Snapshot renders with default props 1`] = `
   box-shadow: none;
 }
 
+.emotion-2 {
+  list-style-type: none;
+  margin: 0;
+}
+
 <div
-  className="emotion-4 emotion-5"
+  className="emotion-6 emotion-7"
 >
   <div
-    className="emotion-2 emotion-3"
+    className="emotion-4 emotion-5"
   >
     <svg
       className="radiance-field-input-icon"
@@ -96,6 +101,14 @@ exports[`<Field /> UI Snapshot renders with default props 1`] = `
       className="emotion-0 emotion-1"
       disabled={false}
     />
+    <ul
+      className="emotion-2 emotion-3"
+    >
+      <li
+        in={true}
+        onExited={[Function]}
+      />
+    </ul>
   </div>
 </div>
 `;
@@ -169,6 +182,11 @@ exports[`<Field /> UI Snapshot renders with errorMessage, hintMessage and hideMe
   box-shadow: none;
 }
 
+.emotion-6 {
+  list-style-type: none;
+  margin: 0;
+}
+
 .emotion-8 {
   position: relative;
 }
@@ -207,11 +225,6 @@ exports[`<Field /> UI Snapshot renders with errorMessage, hintMessage and hideMe
   transition: all 350ms ease-in-out;
   opacity: 0;
   max-height: 0;
-}
-
-.emotion-6 {
-  list-style-type: none;
-  margin: 0;
 }
 
 .emotion-4 {
@@ -268,7 +281,7 @@ exports[`<Field /> UI Snapshot renders with errorMessage, hintMessage and hideMe
 `;
 
 exports[`<Field /> UI Snapshot renders with label and labelFor props 1`] = `
-.emotion-6 {
+.emotion-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -279,11 +292,11 @@ exports[`<Field /> UI Snapshot renders with label and labelFor props 1`] = `
   margin-bottom: 22px;
 }
 
-.emotion-4 {
+.emotion-6 {
   position: relative;
 }
 
-.emotion-4 svg.radiance-field-input-icon {
+.emotion-6 svg.radiance-field-input-icon {
   opacity: 0;
   position: absolute;
   top: 20px;
@@ -349,6 +362,11 @@ exports[`<Field /> UI Snapshot renders with label and labelFor props 1`] = `
   box-shadow: none;
 }
 
+.emotion-4 {
+  list-style-type: none;
+  margin: 0;
+}
+
 .emotion-0 {
   color: #524D6E;
   font-size: 0.75rem;
@@ -356,7 +374,7 @@ exports[`<Field /> UI Snapshot renders with label and labelFor props 1`] = `
 }
 
 <div
-  className="emotion-6 emotion-7"
+  className="emotion-8 emotion-9"
 >
   <label
     className="emotion-0 emotion-1"
@@ -366,7 +384,7 @@ exports[`<Field /> UI Snapshot renders with label and labelFor props 1`] = `
     Test Label
   </label>
   <div
-    className="emotion-4 emotion-5"
+    className="emotion-6 emotion-7"
   >
     <svg
       className="radiance-field-input-icon"
@@ -376,6 +394,14 @@ exports[`<Field /> UI Snapshot renders with label and labelFor props 1`] = `
       className="emotion-2 emotion-3"
       disabled={false}
     />
+    <ul
+      className="emotion-4 emotion-5"
+    >
+      <li
+        in={true}
+        onExited={[Function]}
+      />
+    </ul>
   </div>
 </div>
 `;

--- a/src/shared-components/immersiveModal/index.tsx
+++ b/src/shared-components/immersiveModal/index.tsx
@@ -106,6 +106,10 @@ export const ImmersiveModal = ({
   }, 100);
 
   const handleCloseIntent = () => {
+    if (isClosing) {
+      return;
+    }
+
     setIsClosing(true);
     setShowMobileHeaderBar(false);
     setTimeout(onClose, 450);

--- a/src/shared-components/verificationMessages/index.tsx
+++ b/src/shared-components/verificationMessages/index.tsx
@@ -59,7 +59,7 @@ export const VerificationMessages = ({
             </HelperTransition>
           ))
       ) : (
-        <li />
+        <React.Fragment />
       )}
     </TransitionGroup>
   );

--- a/src/shared-components/verificationMessages/index.tsx
+++ b/src/shared-components/verificationMessages/index.tsx
@@ -38,28 +38,29 @@ export const VerificationMessages = ({
   type = 'error',
 }: VerificationMessagesProps) => {
   const messageKeys = Object.keys(messages);
-
-  if (messageKeys.length === 0) {
-    return null;
-  }
+  const showMessages = messageKeys.length > 0;
 
   return (
     <TransitionGroup component={centered ? CenteredMessageList : MessageList}>
-      {messageKeys
-        .filter((key) => {
-          const message = messages[key];
-          if (!Array.isArray(message)) {
-            return true;
-          }
-          return message.length > 0;
-        })
-        .map((key) => (
-          <HelperTransition key={key}>
-            <MessageItem type={type}>
-              {formatMessage(messages[key])}
-            </MessageItem>
-          </HelperTransition>
-        ))}
+      {showMessages ? (
+        messageKeys
+          .filter((key) => {
+            const message = messages[key];
+            if (!Array.isArray(message)) {
+              return true;
+            }
+            return message.length > 0;
+          })
+          .map((key) => (
+            <HelperTransition key={key}>
+              <MessageItem type={type}>
+                {formatMessage(messages[key])}
+              </MessageItem>
+            </HelperTransition>
+          ))
+      ) : (
+        <li />
+      )}
     </TransitionGroup>
   );
 };


### PR DESCRIPTION
- Modal: this is pending fixes explained here: https://app.asana.com/0/1173345595414308/1197707937611097/f   
- VerificationMessages: While updating Radiance in Curology, I was checking the snapshot differences and something didnt look right. So I tested the email field in the login page comparing side y side with Production (old radiance) and noticed the initial error animation was lost. Bug was introduced here: https://github.com/curology/radiance-ui/pull/421/files#diff-e9498b132d50a72d80dfb59c0cc8e675150eaeb28909ea7819c319d3f10f8756. If no error messages I returned null but we need the Transition structure present for the inital animation to work. So this fix revert back that functionality to the way it was in the old JS file.

BUG no animation
![Screen Recording 2020-10-22 at 16 28 02](https://user-images.githubusercontent.com/11194969/96921464-f09d2080-1484-11eb-91d7-7341f8ab9aa2.gif)


FIX animation restored
![Screen Recording 2020-10-22 at 16 30 00](https://user-images.githubusercontent.com/11194969/96921485-fb57b580-1484-11eb-983b-bedcbda11eaf.gif)
