### PR TITLE
[Chromatic] Ignore "epic/**" branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "publish-package": "run-s build && yarn publish",
     "heroku-postbuild": "yarn run build:icons && yarn run build:icons:index && yarn run build-storybook",
     "tsc": "tsc",
-    "chromatic": "chromatic --skip '@(master|dependabot/npm_and_yarn/eslint**|dependabot/npm_and_yarn/typescript-eslint/**|dependabot/npm_and_yarn/@types/**|dependabot/npm_and_yarn/rollup**|dependabot/npm_and_yarn/@rollup/**|dependabot/npm_and_yarn/enzyme**|dependabot/npm_and_yarn/jest**)' --project-token"
+    "chromatic": "chromatic --skip '@(master|epic/**|dependabot/npm_and_yarn/eslint**|dependabot/npm_and_yarn/typescript-eslint/**|dependabot/npm_and_yarn/@types/**|dependabot/npm_and_yarn/rollup**|dependabot/npm_and_yarn/@rollup/**|dependabot/npm_and_yarn/enzyme**|dependabot/npm_and_yarn/jest**)' --project-token"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Since we'll be merging into `epic/add-theming-functionality` as our long-standing branch, we don't want to rebuild all squashed merges into the branch on Chromatic.