### PR TITLE
[Chromatic] Reconfigure master build logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,10 @@ aliases:
         run:
             name: Publish to Chromatic
             command: |
-                if [ "${CIRCLE_BRANCH}" != "master" ];
-                    yarn chromatic
+                if [ "${CIRCLE_BRANCH}" != "master" ]; then
+                    yarn chromatic ${CHROMATIC_PROJECT_TOKEN}
                 else
-                    yarn chromatic --auto-accept-changes
+                    yarn chromatic --auto-accept-changes ${CHROMATIC_PROJECT_TOKEN}
                 fi
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,16 @@ aliases:
                 if [[ ! -z "${CIRCLE_PULL_REQUEST}" ]]; then
                     git pull --ff-only origin "refs/pull/${CIRCLE_PULL_REQUEST//*pull\//}/merge"
                 fi
+    
+    - &publish-to-chromatic
+        run:
+            name: Publish to Chromatic
+            command: |
+                if [ "${CIRCLE_BRANCH}" != "master" ];
+                    yarn chromatic
+                else
+                    yarn chromatic --auto-accept-changes
+                fi
 
 jobs:
     build-js:
@@ -71,9 +81,7 @@ jobs:
             - run:
                 name: Build
                 command: yarn build
-            - run:
-                name: Publish to Chromatic
-                command: yarn run chromatic ${CHROMATIC_PROJECT_TOKEN}
+            - <<: *publish-to-chromatic
 
     test-js:
         <<: *defaults

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "publish-package": "run-s build && yarn publish",
     "heroku-postbuild": "yarn run build:icons && yarn run build:icons:index && yarn run build-storybook",
     "tsc": "tsc",
-    "chromatic": "chromatic --skip '@(master|dependabot/npm_and_yarn/eslint**|dependabot/npm_and_yarn/typescript-eslint/**|dependabot/npm_and_yarn/@types/**|dependabot/npm_and_yarn/rollup**|dependabot/npm_and_yarn/@rollup/**|dependabot/npm_and_yarn/enzyme**|dependabot/npm_and_yarn/jest**)' --project-token"
+    "chromatic": "chromatic --skip '@(dependabot/npm_and_yarn/eslint**|dependabot/npm_and_yarn/typescript-eslint/**|dependabot/npm_and_yarn/@types/**|dependabot/npm_and_yarn/rollup**|dependabot/npm_and_yarn/@rollup/**|dependabot/npm_and_yarn/enzyme**|dependabot/npm_and_yarn/jest**)' --project-token"
   },
   "repository": {
     "type": "git",

--- a/stories/carousel/index.stories.tsx
+++ b/stories/carousel/index.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from '@storybook/addon-docs/blocks';
 import { Carousel } from 'src/shared-components';
 import { text, select, number, boolean } from '@storybook/addon-knobs';
-import { COLORS, SPACER } from 'src/constants';
+import { ANIMATION, COLORS, SPACER } from 'src/constants';
 import type { Meta } from '@storybook/react';
 
 const Card = styled(Carousel.Card)`
@@ -115,6 +115,10 @@ export default {
   title: 'Components/Carousel',
   component: Carousel,
   parameters: {
+    /**
+     * There is visual jank when this component loads--this reduces brittleness in Chromatic
+     */
+    chromatic: { delay: parseInt(ANIMATION.defaultTiming, 10) },
     docs: {
       page: () => (
         <React.Fragment>


### PR DESCRIPTION
I got a little too cute by adding `master` to the `skip` glob in the `chromatic` build script. This PR updates the logic to account for [the squash merge creating a new git commit](https://www.chromatic.com/docs/ci#github-squash-rebase-merge-and-the-master-branch), which means we just need to auto-accept the `master` build changes when they happen.