### PR TITLE
[README] Add Chromatic Callout and Fix CircleCI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ people (mostly within the Curology organization). Once approved, merge your PR(s
 6. On GitHub, tag a release with the proper version and details. You can
    do that
    [here](https://github.com/PocketDerm/radiance-ui/releases/new).
+
+## Thanks
+
+<a href="https://www.chromatic.com/"><img src="https://user-images.githubusercontent.com/321738/84662277-e3db4f80-af1b-11ea-88f5-91d67a5e59f6.png" width="153" height="30" alt="Chromatic" /></a>
+
+Thanks to [Chromatic](https://www.chromatic.com/) for providing the visual testing platform that helps us review UI changes and catch visual regressions!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ✨ Radiance UI
 
-[![CircleCI](https://circleci.com/gh/PocketDerm/radiance-ui.svg?style=svg)](https://circleci.com/gh/PocketDerm/radiance-ui)
+[![CircleCI](https://circleci.com/gh/curology/radiance-ui.svg?style=svg)](https://circleci.com/gh/curology/radiance-ui)
 
 Curology's React based component library
 


### PR DESCRIPTION
### What & Why

Chromatic has upped our repo from the Free plan to the Open Source Free Plan, so let's thank them in our README!

### Other 

Changing the org name from `PocketDerm` to `curology` broke the CircleCI badge, so this PR also fixes it. 