### PR TITLE
[Colors] Add 'transparent' color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radiance-ui",
-  "version": "13.0.0-alpha.4",
+  "version": "13.0.0-beta.0",
   "description": "Curology's React based component library",
   "main": "dist/bundle.js",
   "module": "dist/bundle-es/index.js",

--- a/src/constants/colors/primary.ts
+++ b/src/constants/colors/primary.ts
@@ -54,6 +54,7 @@ const PRIMARY_COLORS = {
 
   black: COLORS.black,
   white: COLORS.white,
+  transparent: 'transparent',
 } as const;
 
 export const PRIMARY_COLORS_PROP_TYPES = PropTypes.oneOf(

--- a/src/constants/colors/secondary.ts
+++ b/src/constants/colors/secondary.ts
@@ -54,6 +54,7 @@ const SECONDARY_COLORS = {
 
   black: COLORS.black,
   white: COLORS.white,
+  transparent: 'transparent',
 } as const;
 
 export const SECONDARY_COLORS_PROP_TYPES = PropTypes.oneOf(


### PR DESCRIPTION
- Adds `'transparent'` to our theme colors to support consumer app usage, OK'd by design. 