### PR TITLE
[ImmersiveModal] Fix PropTypes

### DIFF
--- a/src/shared-components/immersiveModal/index.tsx
+++ b/src/shared-components/immersiveModal/index.tsx
@@ -238,5 +238,5 @@ ImmersiveModal.propTypes = {
   footerContent: PropTypes.node,
   headerImage: PropTypes.node,
   onClose: PropTypes.func.isRequired,
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };


### PR DESCRIPTION
Fixes error in consumer app when non-string is used for title:

<img width="556" alt="Screen Shot 2020-11-11 at 8 49 58 AM" src="https://user-images.githubusercontent.com/13544620/98826266-18840200-23fb-11eb-903f-df43d7cf5e4e.png">
