### PR TITLE
Fix tooltip carrot svg

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "bundle.js": {
-    "bundled": 821210,
-    "minified": 752704,
-    "gzipped": 90160
+    "bundled": 821240,
+    "minified": 752728,
+    "gzipped": 90152
   },
   "bundle.umd.js": {
-    "bundled": 830884,
-    "minified": 728265,
-    "gzipped": 86275
+    "bundled": 830916,
+    "minified": 728289,
+    "gzipped": 86272
   },
   "constants/zScale/index.js": {
     "bundled": 234,
@@ -1326,9 +1326,9 @@
     }
   },
   "icons/icons/svgs/Arrow.js": {
-    "bundled": 435,
-    "minified": 364,
-    "gzipped": 288,
+    "bundled": 465,
+    "minified": 388,
+    "gzipped": 301,
     "treeshaked": {
       "rollup": {
         "code": 84,

--- a/src/icons/icons/svgs/Arrow.tsx
+++ b/src/icons/icons/svgs/Arrow.tsx
@@ -3,12 +3,16 @@ import * as React from 'react';
 function SvgArrow(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
-      data-name="Layer 1"
-      xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 46.29 32.92"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      <path d="M27.07 30.75a4.63 4.63 0 01-7.85 0L0 0h46.27z" fill="#332e54" />
+      <path
+        className="arrow_svg__cls-1"
+        d="M27.07 30.75a4.63 4.63 0 01-7.85 0L0 0h46.27z"
+        fill="currentColor"
+      />
     </svg>
   );
 }

--- a/src/shared-components/tooltip/__snapshots__/test.tsx.snap
+++ b/src/shared-components/tooltip/__snapshots__/test.tsx.snap
@@ -96,7 +96,6 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
       >
         <svg
           className="emotion-4"
-          data-name="Layer 1"
           fill="#332e54"
           height={16}
           viewBox="0 0 46.29 32.92"
@@ -104,8 +103,9 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
+            className="arrow_svg__cls-1"
             d="M27.07 30.75a4.63 4.63 0 01-7.85 0L0 0h46.27z"
-            fill="#332e54"
+            fill="currentColor"
           />
         </svg>
       </div>

--- a/src/svgs/icons/arrow.svg
+++ b/src/svgs/icons/arrow.svg
@@ -1,1 +1,4 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 46.29 32.92"><defs><style>.cls-1{fill:#332e54;}</style></defs><title>arrow2</title><path class="cls-1" d="M27.8,39.8a4.63,4.63,0,0,1-7.85,0L.73,9.05H47Z" transform="translate(-0.73 -9.05)"/></svg>
+<svg viewBox="0 0 46.29 32.92" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Arrow</title>
+  <path class="cls-1" d="M27.8,39.8a4.63,4.63,0,0,1-7.85,0L.73,9.05H47Z" transform="translate(-0.73 -9.05)" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
- This icon is not part of the Figma Radiance: https://www.figma.com/file/RZIO3wuO5Uk7sPZoXstAuXIA/Radiance-UI?node-id=2300%3A9919 . It was created when the tooltip component was overhauled so it doesn't follow the same structure as other formal Radiance Icons and had the hardcoded primary hex color

- This PR cleans up the svg a bit fixes the color bug and tries to replicate the same format as other svgs. 

Can be merged to secondary theme PR or later to master
