### PR TITLE
Fix Arrow svg to support theme

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "bundle.js": {
-    "bundled": 820389,
-    "minified": 751954,
-    "gzipped": 89976
+    "bundled": 820384,
+    "minified": 751949,
+    "gzipped": 89948
   },
   "bundle.umd.js": {
-    "bundled": 830035,
-    "minified": 728037,
-    "gzipped": 86119
+    "bundled": 830030,
+    "minified": 728032,
+    "gzipped": 86094
   },
   "icons/icons/crossIcon.js": {
     "bundled": 233,
@@ -1620,9 +1620,9 @@
     }
   },
   "icons/icons/svgs/Arrow.js": {
-    "bundled": 435,
-    "minified": 364,
-    "gzipped": 288,
+    "bundled": 430,
+    "minified": 359,
+    "gzipped": 281,
     "treeshaked": {
       "rollup": {
         "code": 84,

--- a/src/icons/icons/svgs/Arrow.tsx
+++ b/src/icons/icons/svgs/Arrow.tsx
@@ -3,12 +3,15 @@ import * as React from 'react';
 function SvgArrow(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
-      data-name="Layer 1"
-      xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 46.29 32.92"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
-      <path d="M27.07 30.75a4.63 4.63 0 01-7.85 0L0 0h46.27z" fill="#332e54" />
+      <path
+        d="M27.07 30.75a4.63 4.63 0 01-7.85 0L0 0h46.27z"
+        fill="currentColor"
+      />
     </svg>
   );
 }

--- a/src/shared-components/tooltip/__snapshots__/test.tsx.snap
+++ b/src/shared-components/tooltip/__snapshots__/test.tsx.snap
@@ -96,7 +96,6 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
       >
         <svg
           className="emotion-4"
-          data-name="Layer 1"
           fill="#332e54"
           height={16}
           viewBox="0 0 46.29 32.92"
@@ -105,7 +104,7 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
         >
           <path
             d="M27.07 30.75a4.63 4.63 0 01-7.85 0L0 0h46.27z"
-            fill="#332e54"
+            fill="currentColor"
           />
         </svg>
       </div>

--- a/src/svgs/icons/arrow.svg
+++ b/src/svgs/icons/arrow.svg
@@ -1,1 +1,4 @@
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 46.29 32.92"><defs><style>.cls-1{fill:#332e54;}</style></defs><title>arrow2</title><path class="cls-1" d="M27.8,39.8a4.63,4.63,0,0,1-7.85,0L.73,9.05H47Z" transform="translate(-0.73 -9.05)"/></svg>
+<svg viewBox="0 0 46.29 32.92" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Arrow</title>
+  <path d="M27.8,39.8a4.63,4.63,0,0,1-7.85,0L.73,9.05H47Z" transform="translate(-0.73 -9.05)" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
context #579
I branched that of secondary-theme PR so it was not clean this merges to master directly, besides I removed one unnecessary class in the svg path
