### PR TITLE
[Theme] - Fix field placeholder color for secondary theme

### DIFF
--- a/src/shared-components/field/style.ts
+++ b/src/shared-components/field/style.ts
@@ -51,7 +51,7 @@ const inputStyles = (theme: ThemeType) => css`
   }
 
   &::placeholder {
-    color: ${theme.COLORS.primaryTint3};
+    color: ${theme.COLORS.textDisabled};
   }
 
   &[disabled] {


### PR DESCRIPTION
https://www.notion.so/curology/Input-fields-Review-disabled-text-instances-40622fc9f7d64e47833267d8c57b207c

This should not have any impact in primaryTheme since the color value is the same for tint3 and textDisabled

After Fix:

![image](https://user-images.githubusercontent.com/11194969/100906291-c9843680-34a7-11eb-8966-5ad7fec1c81a.png)
