### PR TITLE
[Theming] Replace primaryTint3 with textDisabled in Tab

### DIFF
--- a/src/shared-components/tabs/style.ts
+++ b/src/shared-components/tabs/style.ts
@@ -32,7 +32,7 @@ export const TabItem = styled.button<{ active: boolean }>`
   border-radius: ${SPACER.xsmall};
 
   color: ${({ active, theme }) =>
-    active ? theme.COLORS.primary : theme.COLORS.primaryTint3};
+    active ? theme.COLORS.primary : theme.COLORS.textDisabled};
 
   &:hover {
     color: ${({ theme }) => theme.COLORS.primary};


### PR DESCRIPTION
Updates the inactive usage. Same value for Primary theme but achieves parity for Secondary theme:

<img width="224" alt="Screen Shot 2020-12-03 at 12 12 42 PM" src="https://user-images.githubusercontent.com/13544620/101070612-2db70100-3561-11eb-86e0-fb17e2f41d76.png">
