### PR TITLE
[Theming] Apply distinct secondary Display, Heading, and Title font

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "bundle.js": {
-    "bundled": 822671,
-    "minified": 754102,
-    "gzipped": 90261
+    "bundled": 827878,
+    "minified": 759096,
+    "gzipped": 90513
   },
   "bundle.umd.js": {
-    "bundled": 832355,
-    "minified": 729820,
-    "gzipped": 86374
+    "bundled": 837576,
+    "minified": 734730,
+    "gzipped": 86642
   },
   "icons/icons/arrow.js": {
     "bundled": 209,
@@ -640,16 +640,16 @@
     }
   },
   "shared-components/typography/index.js": {
-    "bundled": 54171,
-    "minified": 53066,
-    "gzipped": 3538,
+    "bundled": 59378,
+    "minified": 58060,
+    "gzipped": 3862,
     "treeshaked": {
       "rollup": {
-        "code": 2892,
+        "code": 3046,
         "import_statements": 119
       },
       "webpack": {
-        "code": 4078
+        "code": 4232
       }
     }
   },

--- a/src/shared-components/typography/index.ts
+++ b/src/shared-components/typography/index.ts
@@ -4,11 +4,19 @@ import round from 'lodash.round';
 import { withDeprecationWarning } from '../../utils';
 import { ThemeType } from '../../constants';
 
+/**
+ * We use theme.FONTS.baseFont for all primary styles, but use a
+ * different secondary font for Display, Heading, and Title styles
+ */
+const setSecondaryHeadingFont = (theme: ThemeType) =>
+  theme.__type === 'secondary' ? `font-family: ${theme.FONTS.headerFont};` : '';
+
 const displayStyle = (theme: ThemeType) => `
   color: ${theme.COLORS.primary};
   font-size: ${theme.TYPOGRAPHY.fontSize.display};
   font-weight: ${theme.TYPOGRAPHY.fontWeight.bold};
   line-height: ${round(48 / 36, 2)};
+  ${setSecondaryHeadingFont(theme)}
 `;
 
 const headingStyle = (theme: ThemeType) => `
@@ -16,6 +24,7 @@ const headingStyle = (theme: ThemeType) => `
   font-size: ${theme.TYPOGRAPHY.fontSize.heading};
   font-weight: ${theme.TYPOGRAPHY.fontWeight.bold};
   line-height: ${round(40 / 24, 2)};
+  ${setSecondaryHeadingFont(theme)}
 `;
 
 const titleStyle = (theme: ThemeType) => `
@@ -23,6 +32,7 @@ const titleStyle = (theme: ThemeType) => `
   font-size: ${theme.TYPOGRAPHY.fontSize.title};
   line-height: ${round(32 / 20, 2)};
   font-weight: ${theme.TYPOGRAPHY.fontWeight.bold};
+  ${setSecondaryHeadingFont(theme)}
 `;
 
 export const baseBodyStyles = (theme: ThemeType) => `

--- a/src/utils/injectGlobalStyles/style.ts
+++ b/src/utils/injectGlobalStyles/style.ts
@@ -1,6 +1,6 @@
 import 'focus-visible';
 
-import { ThemeType, TYPOGRAPHY_CONSTANTS } from '../../constants';
+import { ThemeType } from '../../constants';
 import { baseBodyStyles } from '../../shared-components/typography';
 
 /**
@@ -216,7 +216,7 @@ export const brandStyles = (theme: ThemeType) => `
     ${baseBodyStyles(theme)}
     background-color: ${theme.COLORS.white};
     font-family: ${theme.FONTS.baseFont};
-    font-weight: ${TYPOGRAPHY_CONSTANTS.fontWeight.normal};
+    font-weight: ${theme.TYPOGRAPHY.fontWeight.normal};
     margin: 0;
     transition-timing-function: ease-in-out;
   }


### PR DESCRIPTION
We use `larssiet` for all the `styles` in `src/shared-components/typography/index.ts`. However, we want to use a different font for `Display`, `Heading`, and `Title` for our secondary theme:

![image](https://user-images.githubusercontent.com/13544620/101084104-1a149600-3573-11eb-8d7c-27ec2f33ffc5.png)

These changes set the `font-family` on the class, giving it higher precedence than `body`. 

This also removes the direct `TYPOGRAPHY_CONSTANTS` import in `injectGlobalStyles`, which has no impact on output. 