### PR TITLE
[Theme] - Border Radius

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "bundle.js": {
-    "bundled": 836845,
-    "minified": 767704,
-    "gzipped": 89816
+    "bundled": 838982,
+    "minified": 769892,
+    "gzipped": 89891
   },
   "bundle.umd.js": {
-    "bundled": 846629,
-    "minified": 744007,
-    "gzipped": 85919
+    "bundled": 848766,
+    "minified": 746208,
+    "gzipped": 85979
   },
   "constants/zScale/index.js": {
     "bundled": 234,
@@ -402,30 +402,30 @@
     }
   },
   "shared-components/optionButton/index.js": {
-    "bundled": 2171,
-    "minified": 1454,
-    "gzipped": 638,
+    "bundled": 2027,
+    "minified": 1376,
+    "gzipped": 592,
     "treeshaked": {
       "rollup": {
-        "code": 550,
-        "import_statements": 408
+        "code": 507,
+        "import_statements": 365
       },
       "webpack": {
-        "code": 1548
+        "code": 1491
       }
     }
   },
   "shared-components/accordion/index.js": {
-    "bundled": 3250,
-    "minified": 1718,
-    "gzipped": 811,
+    "bundled": 3176,
+    "minified": 1691,
+    "gzipped": 784,
     "treeshaked": {
       "rollup": {
-        "code": 1451,
+        "code": 1424,
         "import_statements": 460
       },
       "webpack": {
-        "code": 2755
+        "code": 2728
       }
     }
   },
@@ -612,16 +612,16 @@
     }
   },
   "shared-components/toggle/style.js": {
-    "bundled": 7195,
-    "minified": 6897,
-    "gzipped": 2506,
+    "bundled": 6954,
+    "minified": 6692,
+    "gzipped": 2454,
     "treeshaked": {
       "rollup": {
-        "code": 777,
+        "code": 728,
         "import_statements": 79
       },
       "webpack": {
-        "code": 1824
+        "code": 1775
       }
     }
   },
@@ -1004,16 +1004,16 @@
     }
   },
   "shared-components/optionButton/style.js": {
-    "bundled": 38846,
-    "minified": 37616,
-    "gzipped": 4887,
+    "bundled": 39293,
+    "minified": 38049,
+    "gzipped": 4946,
     "treeshaked": {
       "rollup": {
-        "code": 2648,
+        "code": 2689,
         "import_statements": 226
       },
       "webpack": {
-        "code": 3806
+        "code": 3847
       }
     }
   },
@@ -1172,16 +1172,16 @@
     }
   },
   "shared-components/accordion/style.js": {
-    "bundled": 37649,
-    "minified": 36481,
-    "gzipped": 4918,
+    "bundled": 39770,
+    "minified": 38524,
+    "gzipped": 5065,
     "treeshaked": {
       "rollup": {
-        "code": 2754,
+        "code": 2801,
         "import_statements": 173
       },
       "webpack": {
-        "code": 3893
+        "code": 3940
       }
     }
   },
@@ -1424,16 +1424,16 @@
     }
   },
   "shared-components/button/style.js": {
-    "bundled": 35848,
-    "minified": 33966,
-    "gzipped": 6787,
+    "bundled": 35847,
+    "minified": 33965,
+    "gzipped": 6765,
     "treeshaked": {
       "rollup": {
-        "code": 4655,
+        "code": 4654,
         "import_statements": 261
       },
       "webpack": {
-        "code": 6048
+        "code": 6047
       }
     }
   },

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "bundle.js": {
-    "bundled": 822269,
-    "minified": 754083,
-    "gzipped": 88737
+    "bundled": 836845,
+    "minified": 767704,
+    "gzipped": 89816
   },
   "bundle.umd.js": {
-    "bundled": 831885,
-    "minified": 730500,
-    "gzipped": 84932
+    "bundled": 846629,
+    "minified": 744007,
+    "gzipped": 85919
   },
   "constants/zScale/index.js": {
     "bundled": 234,
@@ -318,16 +318,16 @@
     }
   },
   "constants/themes/primaryTheme.js": {
-    "bundled": 413,
-    "minified": 372,
-    "gzipped": 193,
+    "bundled": 517,
+    "minified": 470,
+    "gzipped": 216,
     "treeshaked": {
       "rollup": {
-        "code": 119,
-        "import_statements": 119
+        "code": 153,
+        "import_statements": 153
       },
       "webpack": {
-        "code": 1278
+        "code": 1361
       }
     }
   },
@@ -360,16 +360,16 @@
     }
   },
   "constants/themes/secondaryTheme.js": {
-    "bundled": 443,
-    "minified": 402,
-    "gzipped": 195,
+    "bundled": 553,
+    "minified": 506,
+    "gzipped": 220,
     "treeshaked": {
       "rollup": {
-        "code": 127,
-        "import_statements": 127
+        "code": 163,
+        "import_statements": 163
       },
       "webpack": {
-        "code": 1288
+        "code": 1373
       }
     }
   },
@@ -402,30 +402,30 @@
     }
   },
   "shared-components/optionButton/index.js": {
-    "bundled": 2111,
-    "minified": 1397,
-    "gzipped": 605,
+    "bundled": 2171,
+    "minified": 1454,
+    "gzipped": 638,
     "treeshaked": {
       "rollup": {
-        "code": 507,
-        "import_statements": 365
+        "code": 550,
+        "import_statements": 408
       },
       "webpack": {
-        "code": 1491
+        "code": 1548
       }
     }
   },
   "shared-components/accordion/index.js": {
-    "bundled": 3260,
-    "minified": 1712,
-    "gzipped": 797,
+    "bundled": 3250,
+    "minified": 1718,
+    "gzipped": 811,
     "treeshaked": {
       "rollup": {
-        "code": 1445,
+        "code": 1451,
         "import_statements": 460
       },
       "webpack": {
-        "code": 2749
+        "code": 2755
       }
     }
   },
@@ -612,16 +612,16 @@
     }
   },
   "shared-components/toggle/style.js": {
-    "bundled": 6954,
-    "minified": 6692,
-    "gzipped": 2454,
+    "bundled": 7195,
+    "minified": 6897,
+    "gzipped": 2506,
     "treeshaked": {
       "rollup": {
-        "code": 728,
+        "code": 777,
         "import_statements": 79
       },
       "webpack": {
-        "code": 1775
+        "code": 1824
       }
     }
   },
@@ -696,16 +696,16 @@
     }
   },
   "shared-components/callout/style.js": {
-    "bundled": 7419,
-    "minified": 7052,
-    "gzipped": 1584,
+    "bundled": 7730,
+    "minified": 7327,
+    "gzipped": 1616,
     "treeshaked": {
       "rollup": {
-        "code": 757,
+        "code": 808,
         "import_statements": 79
       },
       "webpack": {
-        "code": 1812
+        "code": 1863
       }
     }
   },
@@ -808,16 +808,16 @@
     }
   },
   "shared-components/button/components/textButton/style.js": {
-    "bundled": 1893,
-    "minified": 1718,
-    "gzipped": 1099,
+    "bundled": 1872,
+    "minified": 1664,
+    "gzipped": 1065,
     "treeshaked": {
       "rollup": {
-        "code": 541,
-        "import_statements": 79
+        "code": 539,
+        "import_statements": 36
       },
       "webpack": {
-        "code": 1580
+        "code": 1529
       }
     }
   },
@@ -878,16 +878,16 @@
     }
   },
   "shared-components/tabs/style.js": {
-    "bundled": 5321,
-    "minified": 5075,
-    "gzipped": 2374,
+    "bundled": 5463,
+    "minified": 5183,
+    "gzipped": 2418,
     "treeshaked": {
       "rollup": {
-        "code": 1088,
+        "code": 1129,
         "import_statements": 280
       },
       "webpack": {
-        "code": 2278
+        "code": 2317
       }
     }
   },
@@ -934,16 +934,16 @@
     }
   },
   "shared-components/dropdown/index.js": {
-    "bundled": 3810,
-    "minified": 1689,
-    "gzipped": 738,
+    "bundled": 3875,
+    "minified": 1746,
+    "gzipped": 772,
     "treeshaked": {
       "rollup": {
-        "code": 496,
-        "import_statements": 275
+        "code": 539,
+        "import_statements": 318
       },
       "webpack": {
-        "code": 1577
+        "code": 1634
       }
     }
   },
@@ -990,30 +990,30 @@
     }
   },
   "shared-components/indicator/style.js": {
-    "bundled": 2192,
-    "minified": 2020,
-    "gzipped": 1238,
+    "bundled": 2335,
+    "minified": 2127,
+    "gzipped": 1246,
     "treeshaked": {
       "rollup": {
-        "code": 673,
+        "code": 724,
         "import_statements": 125
       },
       "webpack": {
-        "code": 1736
+        "code": 1787
       }
     }
   },
   "shared-components/optionButton/style.js": {
-    "bundled": 38192,
-    "minified": 36977,
-    "gzipped": 4830,
+    "bundled": 38846,
+    "minified": 37616,
+    "gzipped": 4887,
     "treeshaked": {
       "rollup": {
-        "code": 2613,
+        "code": 2648,
         "import_statements": 226
       },
       "webpack": {
-        "code": 3771
+        "code": 3806
       }
     }
   },
@@ -1130,30 +1130,30 @@
     }
   },
   "shared-components/chip/style.js": {
-    "bundled": 7189,
-    "minified": 6672,
-    "gzipped": 2559,
+    "bundled": 7331,
+    "minified": 6780,
+    "gzipped": 2602,
     "treeshaked": {
       "rollup": {
-        "code": 1287,
+        "code": 1328,
         "import_statements": 125
       },
       "webpack": {
-        "code": 2352
+        "code": 2391
       }
     }
   },
   "shared-components/dialogModal/style.js": {
-    "bundled": 15595,
-    "minified": 15302,
-    "gzipped": 3482,
+    "bundled": 16487,
+    "minified": 16086,
+    "gzipped": 3590,
     "treeshaked": {
       "rollup": {
-        "code": 1765,
+        "code": 1913,
         "import_statements": 208
       },
       "webpack": {
-        "code": 2948
+        "code": 3096
       }
     }
   },
@@ -1172,30 +1172,30 @@
     }
   },
   "shared-components/accordion/style.js": {
-    "bundled": 36228,
-    "minified": 35101,
-    "gzipped": 4783,
+    "bundled": 37649,
+    "minified": 36481,
+    "gzipped": 4918,
     "treeshaked": {
       "rollup": {
-        "code": 2738,
+        "code": 2754,
         "import_statements": 173
       },
       "webpack": {
-        "code": 3877
+        "code": 3893
       }
     }
   },
   "shared-components/container/style.js": {
-    "bundled": 17851,
-    "minified": 17026,
-    "gzipped": 2935,
+    "bundled": 18030,
+    "minified": 17200,
+    "gzipped": 2980,
     "treeshaked": {
       "rollup": {
-        "code": 1336,
+        "code": 1366,
         "import_statements": 154
       },
       "webpack": {
-        "code": 2471
+        "code": 2501
       }
     }
   },
@@ -1242,16 +1242,16 @@
     }
   },
   "shared-components/dropdown/style.js": {
-    "bundled": 44460,
-    "minified": 43151,
-    "gzipped": 5791,
+    "bundled": 44173,
+    "minified": 42878,
+    "gzipped": 5760,
     "treeshaked": {
       "rollup": {
-        "code": 2689,
+        "code": 2672,
         "import_statements": 147
       },
       "webpack": {
-        "code": 3820
+        "code": 3803
       }
     }
   },
@@ -1298,16 +1298,16 @@
     }
   },
   "shared-components/field/style.js": {
-    "bundled": 34886,
-    "minified": 34137,
-    "gzipped": 4713,
+    "bundled": 35010,
+    "minified": 34257,
+    "gzipped": 4747,
     "treeshaked": {
       "rollup": {
-        "code": 2473,
+        "code": 2486,
         "import_statements": 207
       },
       "webpack": {
-        "code": 3652
+        "code": 3663
       }
     }
   },
@@ -1382,58 +1382,58 @@
     }
   },
   "shared-components/selectorButton/style.js": {
-    "bundled": 23705,
-    "minified": 22939,
-    "gzipped": 4160,
+    "bundled": 24389,
+    "minified": 23581,
+    "gzipped": 4282,
     "treeshaked": {
       "rollup": {
-        "code": 2150,
+        "code": 2200,
         "import_statements": 125
       },
       "webpack": {
-        "code": 3244
+        "code": 3294
       }
     }
   },
   "shared-components/tooltip/style.js": {
-    "bundled": 113225,
-    "minified": 111316,
-    "gzipped": 8178,
+    "bundled": 114239,
+    "minified": 112312,
+    "gzipped": 8317,
     "treeshaked": {
       "rollup": {
-        "code": 3205,
+        "code": 3251,
         "import_statements": 115
       },
       "webpack": {
-        "code": 4351
+        "code": 4393
       }
     }
   },
   "shared-components/alert/style.js": {
-    "bundled": 35092,
-    "minified": 34023,
-    "gzipped": 5126,
+    "bundled": 35406,
+    "minified": 34301,
+    "gzipped": 5122,
     "treeshaked": {
       "rollup": {
-        "code": 3065,
+        "code": 3108,
         "import_statements": 296
       },
       "webpack": {
-        "code": 4340
+        "code": 4381
       }
     }
   },
   "shared-components/button/style.js": {
-    "bundled": 35787,
-    "minified": 33909,
-    "gzipped": 6726,
+    "bundled": 35848,
+    "minified": 33966,
+    "gzipped": 6787,
     "treeshaked": {
       "rollup": {
-        "code": 4641,
+        "code": 4655,
         "import_statements": 261
       },
       "webpack": {
-        "code": 6036
+        "code": 6048
       }
     }
   },
@@ -1494,16 +1494,16 @@
     }
   },
   "shared-components/immersiveModal/style.js": {
-    "bundled": 101935,
-    "minified": 100645,
-    "gzipped": 7588,
+    "bundled": 109909,
+    "minified": 108201,
+    "gzipped": 7650,
     "treeshaked": {
       "rollup": {
-        "code": 4413,
+        "code": 4961,
         "import_statements": 314
       },
       "webpack": {
-        "code": 5710
+        "code": 6258
       }
     }
   },
@@ -1578,16 +1578,16 @@
     }
   },
   "shared-components/banner/style.js": {
-    "bundled": 14477,
-    "minified": 13873,
-    "gzipped": 3265,
+    "bundled": 14705,
+    "minified": 14067,
+    "gzipped": 3284,
     "treeshaked": {
       "rollup": {
-        "code": 1578,
+        "code": 1621,
         "import_statements": 188
       },
       "webpack": {
-        "code": 2701
+        "code": 2742
       }
     }
   },
@@ -1798,6 +1798,34 @@
       },
       "webpack": {
         "code": 1141
+      }
+    }
+  },
+  "constants/borderRadius/secondary.js": {
+    "bundled": 117,
+    "minified": 100,
+    "gzipped": 93,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
+      }
+    }
+  },
+  "constants/borderRadius/primary.js": {
+    "bundled": 120,
+    "minified": 103,
+    "gzipped": 100,
+    "treeshaked": {
+      "rollup": {
+        "code": 0,
+        "import_statements": 0
+      },
+      "webpack": {
+        "code": 951
       }
     }
   }

--- a/src/constants/borderRadius/index.ts
+++ b/src/constants/borderRadius/index.ts
@@ -1,0 +1,7 @@
+const BORDER_RADIUS = {
+  small: '4px',
+  medium: '8px',
+  large: '32px',
+} as const;
+
+export default BORDER_RADIUS;

--- a/src/constants/borderRadius/index.ts
+++ b/src/constants/borderRadius/index.ts
@@ -1,7 +1,0 @@
-const BORDER_RADIUS = {
-  small: '4px',
-  medium: '8px',
-  large: '32px',
-} as const;
-
-export default BORDER_RADIUS;

--- a/src/constants/borderRadius/primary.ts
+++ b/src/constants/borderRadius/primary.ts
@@ -1,0 +1,7 @@
+const PRIMARY_BORDER_RADIUS = {
+  small: '4px',
+  medium: '8px',
+  large: '32px',
+} as const;
+
+export default PRIMARY_BORDER_RADIUS;

--- a/src/constants/borderRadius/secondary.ts
+++ b/src/constants/borderRadius/secondary.ts
@@ -1,0 +1,7 @@
+const SECONDARY_BORDER_RADIUS = {
+  small: '0',
+  medium: '0',
+  large: '0',
+} as const;
+
+export default SECONDARY_BORDER_RADIUS;

--- a/src/constants/grid/index.ts
+++ b/src/constants/grid/index.ts
@@ -1,8 +1,10 @@
 import SPACER from '../spacer';
 
-export default {
+const GRID = {
   xsContentMaxWidth: '350px',
   smContentMaxWidth: '500px',
   xlContentMaxWidth: '1250px',
   standardPadding: SPACER.xlarge,
-};
+} as const;
+
+export default GRID;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 export { default as ANIMATION } from './animation';
+export { default as BORDER_RADIUS } from './borderRadius';
 export { default as BREAKPOINTS } from './breakpoints';
 export { default as GRID } from './grid';
 export { default as LAYOUT } from './layout';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,4 @@
 export { default as ANIMATION } from './animation';
-export { default as BORDER_RADIUS } from './borderRadius';
 export { default as BREAKPOINTS } from './breakpoints';
 export { default as GRID } from './grid';
 export { default as LAYOUT } from './layout';

--- a/src/constants/layout/index.ts
+++ b/src/constants/layout/index.ts
@@ -1,5 +1,7 @@
-export default {
+const LAYOUT = {
   desktopNavbarHeight: '75px',
   mobileNavbarHeight: '60px',
   backNavbarHeight: '70px',
-};
+} as const;
+
+export default LAYOUT;

--- a/src/constants/spacer/index.ts
+++ b/src/constants/spacer/index.ts
@@ -1,4 +1,4 @@
-export default {
+const SPACER = {
   x2small: '0.125rem', // 2px
   xsmall: '0.25rem', // 4px
   small: '0.5rem', // 8px
@@ -10,4 +10,6 @@ export default {
   x3large: '3rem', // 48px
   x4large: '3.5rem', // 56px
   x5large: '4rem', // 64px
-};
+} as const;
+
+export default SPACER;

--- a/src/constants/themes/primaryTheme.ts
+++ b/src/constants/themes/primaryTheme.ts
@@ -1,10 +1,12 @@
 import PRIMARY_COLORS from '../colors/primary';
+import PRIMARY_BORDER_RADIUS from '../borderRadius/primary';
 import PRIMARY_BOX_SHADOWS from '../boxShadows/primary';
 import PRIMARY_FONTS from '../fonts/primary';
 import { PRIMARY_TYPOGRAPHY } from '../typography/primary';
 
 export const primaryTheme = {
   __type: 'primary',
+  BORDER_RADIUS: PRIMARY_BORDER_RADIUS,
   BOX_SHADOWS: PRIMARY_BOX_SHADOWS,
   COLORS: PRIMARY_COLORS,
   FONTS: PRIMARY_FONTS,

--- a/src/constants/themes/secondaryTheme.ts
+++ b/src/constants/themes/secondaryTheme.ts
@@ -1,10 +1,12 @@
 import SECONDARY_COLORS from '../colors/secondary';
+import SECONDARY_BORDER_RADIUS from '../borderRadius/secondary';
 import SECONDARY_BOX_SHADOWS from '../boxShadows/secondary';
 import SECONDARY_FONTS from '../fonts/secondary';
 import { SECONDARY_TYPOGRAPHY } from '../typography/secondary';
 
 export const secondaryTheme = {
   __type: 'secondary',
+  BORDER_RADIUS: SECONDARY_BORDER_RADIUS,
   BOX_SHADOWS: SECONDARY_BOX_SHADOWS,
   COLORS: SECONDARY_COLORS,
   FONTS: SECONDARY_FONTS,

--- a/src/constants/themes/types.ts
+++ b/src/constants/themes/types.ts
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types';
 import { primaryTheme } from './primaryTheme';
 import { secondaryTheme } from './secondaryTheme';
 
+type BorderRadius =
+  | typeof primaryTheme['BORDER_RADIUS']
+  | typeof secondaryTheme['BORDER_RADIUS'];
+
 type BoxShadows =
   | typeof primaryTheme['BOX_SHADOWS']
   | typeof secondaryTheme['BOX_SHADOWS'];
@@ -24,6 +28,7 @@ export const COLORS_PROP_TYPES = PropTypes.oneOf([
 
 export type ThemeType = {
   __type: 'primary' | 'secondary';
+  BORDER_RADIUS: BorderRadius;
   BOX_SHADOWS: BoxShadows;
   COLORS: Colors;
   FONTS: Fonts;

--- a/src/constants/zScale/index.ts
+++ b/src/constants/zScale/index.ts
@@ -1,4 +1,4 @@
-export default {
+const Z_SCALE = {
   e0: 0,
   e2: 2,
   e3: 3,
@@ -12,4 +12,6 @@ export default {
    */
   // Todo this should use one of the above declarations, but hacking for now
   modal: 999999,
-};
+} as const;
+
+export default Z_SCALE;

--- a/src/shared-components/accordion/index.tsx
+++ b/src/shared-components/accordion/index.tsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState, useRef } from 'react';
 import { useTheme } from 'emotion-theming';
 
+import { ThemeType } from '../../constants';
 import { ChevronIcon } from '../../icons';
 import Thumbnails from './thumbnails';
 import {
@@ -14,9 +15,15 @@ import {
   Truncate,
 } from './style';
 
+export type BorderRadiusValues =
+  | valueof<ThemeType['BORDER_RADIUS']>
+  | '0.25rem'
+  | '0.5rem'
+  | '2rem';
+
 type AccordionProps = {
   /** Sets the border-radius of Accordion.Container, AccordionBox, and TitleWrapper */
-  borderRadius?: string;
+  borderRadius?: BorderRadiusValues;
   /** node(s) that will render only when expanded */
   children: React.ReactNode;
   /** when true, the accordion will be greyed out and the onClick prop will be disabled */

--- a/src/shared-components/accordion/index.tsx
+++ b/src/shared-components/accordion/index.tsx
@@ -4,6 +4,7 @@ import { useTheme } from 'emotion-theming';
 
 import { ChevronIcon } from '../../icons';
 import Thumbnails from './thumbnails';
+import { BORDER_RADIUS } from '../../constants';
 import {
   AccordionBox,
   ArrowWrapper,
@@ -41,7 +42,7 @@ type AccordionProps = {
  * The accordion component expands to reveal hidden information. They should be used when you need to fit a large amount of content but don't want to visually overwhelm the user.
  */
 export const Accordion = ({
-  borderRadius = '4px',
+  borderRadius = BORDER_RADIUS.small,
   children,
   disabled = false,
   isOpen,

--- a/src/shared-components/accordion/index.tsx
+++ b/src/shared-components/accordion/index.tsx
@@ -55,8 +55,6 @@ export const Accordion = ({
 
   const contentRef = useRef<HTMLDivElement>(null);
 
-  const borderRadiusValue = borderRadius || theme.BORDER_RADIUS.small;
-
   useEffect(() => {
     const nextHeight =
       isOpen && contentRef.current
@@ -82,7 +80,7 @@ export const Accordion = ({
             onClick(event);
           }
         }}
-        borderRadius={borderRadiusValue}
+        borderRadius={borderRadius}
         onKeyDown={handleKeyDown}
         disabled={!!disabled}
         role="button"

--- a/src/shared-components/accordion/index.tsx
+++ b/src/shared-components/accordion/index.tsx
@@ -4,7 +4,6 @@ import { useTheme } from 'emotion-theming';
 
 import { ChevronIcon } from '../../icons';
 import Thumbnails from './thumbnails';
-import { BORDER_RADIUS } from '../../constants';
 import {
   AccordionBox,
   ArrowWrapper,
@@ -42,7 +41,7 @@ type AccordionProps = {
  * The accordion component expands to reveal hidden information. They should be used when you need to fit a large amount of content but don't want to visually overwhelm the user.
  */
 export const Accordion = ({
-  borderRadius = BORDER_RADIUS.small,
+  borderRadius,
   children,
   disabled = false,
   isOpen,
@@ -55,6 +54,8 @@ export const Accordion = ({
   const [contentHeight, setContentHeight] = useState('0px');
 
   const contentRef = useRef<HTMLDivElement>(null);
+
+  const borderRadiusValue = borderRadius || theme.BORDER_RADIUS.small;
 
   useEffect(() => {
     const nextHeight =
@@ -81,7 +82,7 @@ export const Accordion = ({
             onClick(event);
           }
         }}
-        borderRadius={borderRadius}
+        borderRadius={borderRadiusValue}
         onKeyDown={handleKeyDown}
         disabled={!!disabled}
         role="button"

--- a/src/shared-components/accordion/style.ts
+++ b/src/shared-components/accordion/style.ts
@@ -56,13 +56,14 @@ export const ArrowWrapper = styled.div<{ rightAlign: boolean }>`
 `;
 
 export const TitleWrapper = styled.div<{
-  borderRadius: string;
+  borderRadius?: string;
   disabled: boolean;
   isOpen: boolean;
 }>`
   display: flex;
   justify-content: space-between;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  
   &:focus {
     outline: none;
     box-shadow: ${({ theme }) => theme.BOX_SHADOWS.focusInner};
@@ -70,12 +71,14 @@ export const TitleWrapper = styled.div<{
 
   ${AccordionBox}:last-of-type & {
     &:focus {
-      ${({ borderRadius, isOpen }) =>
-        !isOpen &&
-        `
-        border-bottom-left-radius: ${borderRadius}; 
-        border-bottom-right-radius: ${borderRadius};
-        `}}
+      ${({ borderRadius, isOpen, theme }) => {
+        if (!isOpen) {
+          const borderRadiusValue = borderRadius || theme.BORDER_RADIUS.small;
+          return `border-bottom-left-radius: ${borderRadiusValue}; 
+                  border-bottom-right-radius: ${borderRadiusValue};`;
+        }
+        return '';
+      }}}
     }
   }
 `;

--- a/src/shared-components/accordion/style.ts
+++ b/src/shared-components/accordion/style.ts
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 
 import { ANIMATION, BREAKPOINTS, SPACER, ThemeType } from '../../constants';
 
+import { BorderRadiusValues } from '.';
+
 export const Content = styled.div`
   padding: ${SPACER.medium};
   width: 100%;
@@ -56,7 +58,7 @@ export const ArrowWrapper = styled.div<{ rightAlign: boolean }>`
 `;
 
 export const TitleWrapper = styled.div<{
-  borderRadius?: string;
+  borderRadius?: BorderRadiusValues;
   disabled: boolean;
   isOpen: boolean;
 }>`
@@ -95,7 +97,7 @@ export const Truncate = styled.div`
  * component if opting out of default values.
  */
 export const Container = styled.div<{
-  borderRadius?: string;
+  borderRadius?: BorderRadiusValues;
 }>`
   box-shadow: ${({ theme }) => theme.BOX_SHADOWS.clickable};
   background-color: ${({ theme }) => theme.COLORS.white};

--- a/src/shared-components/accordion/style.ts
+++ b/src/shared-components/accordion/style.ts
@@ -1,6 +1,12 @@
 import styled from '@emotion/styled';
 
-import { ANIMATION, BREAKPOINTS, SPACER, ThemeType } from '../../constants';
+import {
+  ANIMATION,
+  BORDER_RADIUS,
+  BREAKPOINTS,
+  SPACER,
+  ThemeType,
+} from '../../constants';
 
 export const Content = styled.div`
   padding: ${SPACER.medium};
@@ -98,7 +104,7 @@ export const Container = styled.div<{
   background-color: ${({ theme }) => theme.COLORS.white};
   max-width: ${BREAKPOINTS.md}px;
 
-  ${({ borderRadius = '4px' }) => `
+  ${({ borderRadius = BORDER_RADIUS.small }) => `
     > div:first-of-type {
       border-top-left-radius: ${borderRadius};
       border-top-right-radius: ${borderRadius};

--- a/src/shared-components/accordion/style.ts
+++ b/src/shared-components/accordion/style.ts
@@ -1,12 +1,6 @@
 import styled from '@emotion/styled';
 
-import {
-  ANIMATION,
-  BORDER_RADIUS,
-  BREAKPOINTS,
-  SPACER,
-  ThemeType,
-} from '../../constants';
+import { ANIMATION, BREAKPOINTS, SPACER, ThemeType } from '../../constants';
 
 export const Content = styled.div`
   padding: ${SPACER.medium};
@@ -104,30 +98,34 @@ export const Container = styled.div<{
   background-color: ${({ theme }) => theme.COLORS.white};
   max-width: ${BREAKPOINTS.md}px;
 
-  ${({ borderRadius = BORDER_RADIUS.small }) => `
+  ${({ borderRadius, theme }) => {
+    const borderRadiusValue = borderRadius || theme.BORDER_RADIUS.small;
+
+    return `
     > div:first-of-type {
-      border-top-left-radius: ${borderRadius};
-      border-top-right-radius: ${borderRadius};
+      border-top-left-radius: ${borderRadiusValue};
+      border-top-right-radius: ${borderRadiusValue};
 
       ${TitleWrapper} {
-        border-top-left-radius: ${borderRadius};
-        border-top-right-radius: ${borderRadius};
+        border-top-left-radius: ${borderRadiusValue};
+        border-top-right-radius: ${borderRadiusValue};
       }
 
       ${AccordionBox} {
-        border-top-left-radius: ${borderRadius};
-        border-top-right-radius: ${borderRadius};
+        border-top-left-radius: ${borderRadiusValue};
+        border-top-right-radius: ${borderRadiusValue};
       }
     }
 
     > div:last-of-type {
-      border-bottom-left-radius: ${borderRadius};
-      border-bottom-right-radius: ${borderRadius};
+      border-bottom-left-radius: ${borderRadiusValue};
+      border-bottom-right-radius: ${borderRadiusValue};
 
       ${AccordionBox} {
-        border-bottom-left-radius: ${borderRadius};
-        border-bottom-right-radius: ${borderRadius};
+        border-bottom-left-radius: ${borderRadiusValue};
+        border-bottom-right-radius: ${borderRadiusValue};
       }
     }
-  `}
+  `;
+  }}
 `;

--- a/src/shared-components/alert/__snapshots__/test.tsx.snap
+++ b/src/shared-components/alert/__snapshots__/test.tsx.snap
@@ -41,7 +41,7 @@ exports[`Alert UI snapshots renders a default alert 1`] = `
   margin: 0 auto 0.5rem;
   padding: 0;
   width: 327px;
-  border-radius: 0.5rem;
+  border-radius: 8px;
   opacity: 1;
   -webkit-animation: animation-0 350ms 1;
   animation: animation-0 350ms 1;
@@ -251,7 +251,7 @@ exports[`Alert UI snapshots renders a sticky alert 1`] = `
   margin: 0 auto 0.5rem;
   padding: 0;
   width: 327px;
-  border-radius: 0.5rem;
+  border-radius: 8px;
   opacity: 1;
   -webkit-animation: animation-0 350ms 1;
   animation: animation-0 350ms 1;
@@ -461,7 +461,7 @@ exports[`Alert UI snapshots renders custom component passed in content prop 1`] 
   margin: 0 auto 0.5rem;
   padding: 0;
   width: 327px;
-  border-radius: 0.5rem;
+  border-radius: 8px;
   opacity: 1;
   -webkit-animation: animation-0 350ms 1;
   animation: animation-0 350ms 1;
@@ -724,7 +724,7 @@ exports[`Alert UI snapshots renders error alert 1`] = `
   margin: 0 auto 0.5rem;
   padding: 0;
   width: 327px;
-  border-radius: 0.5rem;
+  border-radius: 8px;
   opacity: 1;
   -webkit-animation: animation-0 350ms 1;
   animation: animation-0 350ms 1;
@@ -904,7 +904,7 @@ exports[`Alert UI snapshots renders success alert 1`] = `
   margin: 0 auto 0.5rem;
   padding: 0;
   width: 327px;
-  border-radius: 0.5rem;
+  border-radius: 8px;
   opacity: 1;
   -webkit-animation: animation-0 350ms 1;
   animation: animation-0 350ms 1;

--- a/src/shared-components/alert/style.ts
+++ b/src/shared-components/alert/style.ts
@@ -1,13 +1,7 @@
 import styled from '@emotion/styled';
 import { keyframes } from '@emotion/core';
 
-import {
-  MEDIA_QUERIES,
-  SPACER,
-  ANIMATION,
-  ThemeType,
-  BORDER_RADIUS,
-} from '../../constants';
+import { MEDIA_QUERIES, SPACER, ANIMATION, ThemeType } from '../../constants';
 
 import { AlertType } from '.';
 
@@ -63,7 +57,7 @@ export const AlertContainer = styled.button<{
   margin: 0 auto ${SPACER.small};
   padding: 0;
   width: 327px;
-  border-radius: ${BORDER_RADIUS.medium};
+  border-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
   opacity: ${({ exiting }) => (exiting ? '0' : '1')};
   animation: ${fadeInMobile} ${ANIMATION.defaultTiming} 1;
   transition: ${ANIMATION.defaultTiming};

--- a/src/shared-components/alert/style.ts
+++ b/src/shared-components/alert/style.ts
@@ -1,7 +1,13 @@
 import styled from '@emotion/styled';
 import { keyframes } from '@emotion/core';
 
-import { MEDIA_QUERIES, SPACER, ANIMATION, ThemeType } from '../../constants';
+import {
+  MEDIA_QUERIES,
+  SPACER,
+  ANIMATION,
+  ThemeType,
+  BORDER_RADIUS,
+} from '../../constants';
 
 import { AlertType } from '.';
 
@@ -57,7 +63,7 @@ export const AlertContainer = styled.button<{
   margin: 0 auto ${SPACER.small};
   padding: 0;
   width: 327px;
-  border-radius: ${SPACER.small};
+  border-radius: ${BORDER_RADIUS.medium};
   opacity: ${({ exiting }) => (exiting ? '0' : '1')};
   animation: ${fadeInMobile} ${ANIMATION.defaultTiming} 1;
   transition: ${ANIMATION.defaultTiming};

--- a/src/shared-components/banner/__snapshots__/test.tsx.snap
+++ b/src/shared-components/banner/__snapshots__/test.tsx.snap
@@ -51,7 +51,7 @@ exports[`Banner UI snapshots renders error type and text 1`] = `
   position: relative;
   margin: 0 auto 0.5rem;
   padding: 1rem;
-  border-radius: 0.5rem;
+  border-radius: 8px;
   background-color: #BD200F;
   box-shadow: 0px 8px 24px rgba(189,32,15,0.05);
 }
@@ -153,7 +153,7 @@ exports[`Banner UI snapshots renders info type and text 1`] = `
   position: relative;
   margin: 0 auto 0.5rem;
   padding: 1rem;
-  border-radius: 0.5rem;
+  border-radius: 8px;
   background-color: #332E54;
   box-shadow: 0px 8px 24px rgba(51,46,84,0.05);
 }
@@ -211,7 +211,7 @@ exports[`Banner UI snapshots renders success type and text 1`] = `
   position: relative;
   margin: 0 auto 0.5rem;
   padding: 1rem;
-  border-radius: 0.5rem;
+  border-radius: 8px;
   background-color: #2B6E33;
   box-shadow: 0px 8px 24px rgba(43,110,51,0.05);
 }

--- a/src/shared-components/banner/style.ts
+++ b/src/shared-components/banner/style.ts
@@ -1,12 +1,7 @@
 import styled from '@emotion/styled';
 import { buttonReset } from 'src/utils/styles/buttonReset';
 
-import {
-  BORDER_RADIUS,
-  MEDIA_QUERIES,
-  SPACER,
-  ThemeType,
-} from '../../constants';
+import { MEDIA_QUERIES, SPACER, ThemeType } from '../../constants';
 
 import { BannerType } from '.';
 
@@ -40,7 +35,7 @@ export const BannerContainer = styled.button<{
   position: relative;
   margin: 0 auto ${SPACER.small};
   padding: ${SPACER.medium};
-  border-radius: ${BORDER_RADIUS.medium};
+  border-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
 
   ${({ bannerType, theme }) => {
     switch (bannerType) {

--- a/src/shared-components/banner/style.ts
+++ b/src/shared-components/banner/style.ts
@@ -1,7 +1,12 @@
 import styled from '@emotion/styled';
 import { buttonReset } from 'src/utils/styles/buttonReset';
 
-import { MEDIA_QUERIES, SPACER, ThemeType } from '../../constants';
+import {
+  BORDER_RADIUS,
+  MEDIA_QUERIES,
+  SPACER,
+  ThemeType,
+} from '../../constants';
 
 import { BannerType } from '.';
 
@@ -35,7 +40,7 @@ export const BannerContainer = styled.button<{
   position: relative;
   margin: 0 auto ${SPACER.small};
   padding: ${SPACER.medium};
-  border-radius: ${SPACER.small};
+  border-radius: ${BORDER_RADIUS.medium};
 
   ${({ bannerType, theme }) => {
     switch (bannerType) {

--- a/src/shared-components/button/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/__snapshots__/test.tsx.snap
@@ -104,7 +104,7 @@ exports[`<Button /> UI snapshots renders with props 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   cursor: pointer;

--- a/src/shared-components/button/components/linkButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/linkButton/__snapshots__/test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<LinkButton/> UI snapshots renders with props 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   cursor: pointer;

--- a/src/shared-components/button/components/roundButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/roundButton/__snapshots__/test.tsx.snap
@@ -122,7 +122,7 @@ exports[`<RoundButton /> UI snapshots renders with props 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   cursor: pointer;

--- a/src/shared-components/button/components/textButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/textButton/__snapshots__/test.tsx.snap
@@ -36,7 +36,7 @@ exports[`<TextButton /> UI snapshots renders with disabled prop 1`] = `
 .emotion-2 {
   border-color: transparent;
   background-color: transparent;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   color: #C3C0CD;
   cursor: not-allowed;
 }
@@ -69,7 +69,7 @@ exports[`<TextButton /> UI snapshots renders without any props 1`] = `
 .emotion-2 {
   border-color: transparent;
   background-color: transparent;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   color: #332E54;
   cursor: pointer;
 }

--- a/src/shared-components/button/components/textButton/style.ts
+++ b/src/shared-components/button/components/textButton/style.ts
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
 
-import { SPACER } from '../../../../constants';
+import { BORDER_RADIUS } from '../../../../constants';
 
 export const BaseTextButton = styled.button<{ disabled: boolean }>`
   border-color: transparent;
   background-color: transparent;
-  border-radius: ${SPACER.xsmall};
+  border-radius: ${BORDER_RADIUS.small};
 
   color: ${({ disabled, theme }) =>
     `${disabled ? theme.COLORS.textDisabled : theme.COLORS.primary}`};

--- a/src/shared-components/button/components/textButton/style.ts
+++ b/src/shared-components/button/components/textButton/style.ts
@@ -1,11 +1,9 @@
 import styled from '@emotion/styled';
 
-import { BORDER_RADIUS } from '../../../../constants';
-
 export const BaseTextButton = styled.button<{ disabled: boolean }>`
   border-color: transparent;
   background-color: transparent;
-  border-radius: ${BORDER_RADIUS.small};
+  border-radius: ${({ theme }) => theme.BORDER_RADIUS.small};
 
   color: ${({ disabled, theme }) =>
     `${disabled ? theme.COLORS.textDisabled : theme.COLORS.primary}`};

--- a/src/shared-components/button/style.ts
+++ b/src/shared-components/button/style.ts
@@ -2,13 +2,7 @@ import styled from '@emotion/styled';
 import tinycolor from 'tinycolor2';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import {
-  ANIMATION,
-  BORDER_RADIUS,
-  SPACER,
-  ThemeColors,
-  ThemeType,
-} from '../../constants';
+import { ANIMATION, SPACER, ThemeColors, ThemeType } from '../../constants';
 import { textColorsAssociatedWithColors } from './constants';
 
 import { ButtonTypeWithAction } from '.';
@@ -177,7 +171,7 @@ export const baseButtonStyles = ({
 }: BaseButtonStylesTypes) => `
   ${TYPOGRAPHY_STYLE.button(theme)}
   appearance: none;
-  border-radius:  ${BORDER_RADIUS.small};
+  border-radius:  ${theme.BORDER_RADIUS.small};
   border-style: solid;
   border-width: 1px;
   cursor: pointer;

--- a/src/shared-components/button/style.ts
+++ b/src/shared-components/button/style.ts
@@ -2,7 +2,13 @@ import styled from '@emotion/styled';
 import tinycolor from 'tinycolor2';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { ANIMATION, SPACER, ThemeColors, ThemeType } from '../../constants';
+import {
+  ANIMATION,
+  BORDER_RADIUS,
+  SPACER,
+  ThemeColors,
+  ThemeType,
+} from '../../constants';
 import { textColorsAssociatedWithColors } from './constants';
 
 import { ButtonTypeWithAction } from '.';
@@ -171,7 +177,7 @@ export const baseButtonStyles = ({
 }: BaseButtonStylesTypes) => `
   ${TYPOGRAPHY_STYLE.button(theme)}
   appearance: none;
-  border-radius: ${SPACER.xsmall};
+  border-radius:  ${BORDER_RADIUS.small};
   border-style: solid;
   border-width: 1px;
   cursor: pointer;

--- a/src/shared-components/button/style.ts
+++ b/src/shared-components/button/style.ts
@@ -171,7 +171,7 @@ export const baseButtonStyles = ({
 }: BaseButtonStylesTypes) => `
   ${TYPOGRAPHY_STYLE.button(theme)}
   appearance: none;
-  border-radius:  ${theme.BORDER_RADIUS.small};
+  border-radius: ${theme.BORDER_RADIUS.small};
   border-style: solid;
   border-width: 1px;
   cursor: pointer;

--- a/src/shared-components/callout/style.ts
+++ b/src/shared-components/callout/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { SPACER } from '../../constants';
+import { BORDER_RADIUS, SPACER } from '../../constants';
 
 const ParentContainer = styled.div`
   max-width: 327px;
@@ -9,7 +9,7 @@ const ParentContainer = styled.div`
 const CalloutContainer = styled.div`
   background-color: ${({ theme }) => theme.COLORS.infoLight};
   padding: ${SPACER.medium};
-  border-radius: 8px;
+  border-radius: ${BORDER_RADIUS.medium};
   display: flex;
   flex-flow: row nowrap;
   justify-content: space-between;

--- a/src/shared-components/callout/style.ts
+++ b/src/shared-components/callout/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { BORDER_RADIUS, SPACER } from '../../constants';
+import { SPACER } from '../../constants';
 
 const ParentContainer = styled.div`
   max-width: 327px;
@@ -9,7 +9,7 @@ const ParentContainer = styled.div`
 const CalloutContainer = styled.div`
   background-color: ${({ theme }) => theme.COLORS.infoLight};
   padding: ${SPACER.medium};
-  border-radius: ${BORDER_RADIUS.medium};
+  border-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
   display: flex;
   flex-flow: row nowrap;
   justify-content: space-between;

--- a/src/shared-components/carousel/arrow/__snapshots__/test.tsx.snap
+++ b/src/shared-components/carousel/arrow/__snapshots__/test.tsx.snap
@@ -244,7 +244,7 @@ exports[`<Arrow /> UI snapshots renders with bottom right alignment 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   cursor: pointer;
@@ -527,7 +527,7 @@ exports[`<Arrow /> UI snapshots renders with props 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   border-style: solid;
   border-width: 1px;
   cursor: pointer;

--- a/src/shared-components/chip/__snapshots__/test.tsx.snap
+++ b/src/shared-components/chip/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<Chip /> UI snapshots renders the correct css and text 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;

--- a/src/shared-components/chip/style.ts
+++ b/src/shared-components/chip/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { BORDER_RADIUS, SPACER, ThemeType } from '../../constants';
+import { SPACER, ThemeType } from '../../constants';
 
 import { StatusType } from '.';
 
@@ -42,7 +42,7 @@ const secondaryStyle = (theme: ThemeType) => `
 
 export const ChipStyles = styled.div<{ status: StatusType }>`
   align-items: center;
-  border-radius: ${BORDER_RADIUS.small};
+  border-radius: ${({ theme }) => theme.BORDER_RADIUS.small};
   display: inline-flex;
   height: ${SPACER.large};
   flex-flow: row nowrap;

--- a/src/shared-components/chip/style.ts
+++ b/src/shared-components/chip/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { SPACER, ThemeType } from '../../constants';
+import { BORDER_RADIUS, SPACER, ThemeType } from '../../constants';
 
 import { StatusType } from '.';
 
@@ -42,7 +42,7 @@ const secondaryStyle = (theme: ThemeType) => `
 
 export const ChipStyles = styled.div<{ status: StatusType }>`
   align-items: center;
-  border-radius: ${SPACER.xsmall};
+  border-radius: ${BORDER_RADIUS.small};
   display: inline-flex;
   height: ${SPACER.large};
   flex-flow: row nowrap;

--- a/src/shared-components/container/__snapshots__/test.tsx.snap
+++ b/src/shared-components/container/__snapshots__/test.tsx.snap
@@ -98,7 +98,7 @@ exports[`Container UI snapshots renders message type container 1`] = `
 .emotion-0 {
   background-color: #FFFFFF;
   border: 1px solid #EDEDF0;
-  border-radius: 16px;
+  border-radius: 8px;
   box-shadow: 0px 8px 24px rgba(52,51,82,0.05);
 }
 

--- a/src/shared-components/container/style.ts
+++ b/src/shared-components/container/style.ts
@@ -15,7 +15,7 @@ const clickableStyle = (theme: ThemeType) => `
 `;
 
 const messageStyle = (theme: ThemeType) => `
-  border-radius: 16px;
+  border-radius: ${theme.BORDER_RADIUS.medium};
   box-shadow: ${theme.BOX_SHADOWS.clickable};
 `;
 

--- a/src/shared-components/dialogModal/style.ts
+++ b/src/shared-components/dialogModal/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import Typography from '../typography';
-import { MEDIA_QUERIES, SPACER, Z_SCALE } from '../../constants';
+import { MEDIA_QUERIES, SPACER, Z_SCALE, BORDER_RADIUS } from '../../constants';
 
 export const Overlay = styled.div`
   position: fixed;
@@ -38,8 +38,8 @@ export const ModalContainer = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
-  border-top-left-radius: 32px;
-  border-top-right-radius: 32px;
+  border-top-left-radius: ${BORDER_RADIUS.large};
+  border-top-right-radius: ${BORDER_RADIUS.large};
   box-shadow: ${({ theme }) => theme.BOX_SHADOWS.modal};
   background: ${({ theme }) => theme.COLORS.white};
   padding: ${SPACER.x4large} ${SPACER.large} ${SPACER.xlarge};
@@ -69,7 +69,7 @@ export const ModalContainer = styled.div`
   ${MEDIA_QUERIES.mdUp} {
     position: relative;
     width: 456px;
-    border-radius: 8px;
+    border-radius: ${BORDER_RADIUS.medium};
     padding: ${SPACER.x4large};
 
     &.entering,
@@ -91,7 +91,7 @@ export const CrossIconContainer = styled.div`
   z-index: ${Z_SCALE.e2000};
   width: 40px;
   height: 40px;
-  border-radius: 40px;
+  border-radius: 50%;
   background: ${({ theme }) => theme.COLORS.white};
   display: flex;
   flex-flow: row nowrap;

--- a/src/shared-components/dialogModal/style.ts
+++ b/src/shared-components/dialogModal/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import Typography from '../typography';
-import { MEDIA_QUERIES, SPACER, Z_SCALE, BORDER_RADIUS } from '../../constants';
+import { MEDIA_QUERIES, SPACER, Z_SCALE } from '../../constants';
 
 export const Overlay = styled.div`
   position: fixed;
@@ -38,8 +38,8 @@ export const ModalContainer = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
-  border-top-left-radius: ${BORDER_RADIUS.large};
-  border-top-right-radius: ${BORDER_RADIUS.large};
+  border-top-left-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
+  border-top-right-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
   box-shadow: ${({ theme }) => theme.BOX_SHADOWS.modal};
   background: ${({ theme }) => theme.COLORS.white};
   padding: ${SPACER.x4large} ${SPACER.large} ${SPACER.xlarge};
@@ -69,7 +69,7 @@ export const ModalContainer = styled.div`
   ${MEDIA_QUERIES.mdUp} {
     position: relative;
     width: 456px;
-    border-radius: ${BORDER_RADIUS.medium};
+    border-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
     padding: ${SPACER.x4large};
 
     &.entering,

--- a/src/shared-components/dropdown/index.tsx
+++ b/src/shared-components/dropdown/index.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { MobileDropdown } from './mobileDropdown';
 import { DesktopDropdown } from './desktopDropdown';
+import { BORDER_RADIUS } from '../../constants';
 
 export type OptionValue = string | number;
 
@@ -45,7 +46,7 @@ type DropdownProps<T> = {
  * This ships with a mobile implementation that will handle mobile devices automatically.
  */
 export const Dropdown = <T extends OptionType>({
-  borderRadius = '4px',
+  borderRadius = BORDER_RADIUS.small,
   onChange,
   options,
   optionsContainerMaxHeight = '250px',

--- a/src/shared-components/dropdown/index.tsx
+++ b/src/shared-components/dropdown/index.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { useTheme } from 'emotion-theming';
 
 import { MobileDropdown } from './mobileDropdown';
 import { DesktopDropdown } from './desktopDropdown';
-import { BORDER_RADIUS } from '../../constants';
 
 export type OptionValue = string | number;
 
@@ -46,15 +46,17 @@ type DropdownProps<T> = {
  * This ships with a mobile implementation that will handle mobile devices automatically.
  */
 export const Dropdown = <T extends OptionType>({
-  borderRadius = BORDER_RADIUS.small,
+  borderRadius,
   onChange,
   options,
   optionsContainerMaxHeight = '250px',
   textAlign = 'left',
   value,
 }: DropdownProps<T>) => {
+  const theme = useTheme();
   const [isOpen, setIsOpen] = useState(false);
   const touchSupported = 'ontouchstart' in document.documentElement;
+  const borderRadiusValue = borderRadius || theme.BORDER_RADIUS.small;
 
   const toggleDropdown = () => {
     setIsOpen((prevIsOpen) => !prevIsOpen);
@@ -106,7 +108,7 @@ export const Dropdown = <T extends OptionType>({
   if (touchSupported) {
     return (
       <MobileDropdown
-        borderRadius={borderRadius}
+        borderRadius={borderRadiusValue}
         onMobileSelectChange={onMobileSelectChange}
         options={options}
         textAlign={textAlign}
@@ -119,7 +121,7 @@ export const Dropdown = <T extends OptionType>({
 
   return (
     <DesktopDropdown
-      borderRadius={borderRadius}
+      borderRadius={borderRadiusValue}
       closeDropdown={closeDropdown}
       currentOption={currentOption}
       isOpen={isOpen}

--- a/src/shared-components/dropdown/style.ts
+++ b/src/shared-components/dropdown/style.ts
@@ -146,7 +146,7 @@ export const DropdownOptionsContainer = styled.ul<{
 
   &:last-of-type {
     border-radius: ${({ borderRadius }) =>
-      borderRadius ? `0 0 ${borderRadius} ${borderRadius}` : `0 0 4px 4px`};
+      `0 0 ${borderRadius} ${borderRadius}`};
   }
 `;
 

--- a/src/shared-components/field/__snapshots__/test.tsx.snap
+++ b/src/shared-components/field/__snapshots__/test.tsx.snap
@@ -45,7 +45,7 @@ exports[`<Field /> UI Snapshot renders with default props 1`] = `
   appearance: none;
   background: #FFFFFF;
   border: 1px solid #EDEDF0;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   color: #524D6E;
   -webkit-transition: border-color 350ms;
   transition: border-color 350ms;
@@ -151,7 +151,7 @@ exports[`<Field /> UI Snapshot renders with errorMessage, hintMessage and hideMe
   appearance: none;
   background: #FFFFFF;
   border: 1px solid #EDEDF0;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   color: #524D6E;
   -webkit-transition: border-color 350ms;
   transition: border-color 350ms;
@@ -342,7 +342,7 @@ exports[`<Field /> UI Snapshot renders with label and labelFor props 1`] = `
   appearance: none;
   background: #FFFFFF;
   border: 1px solid #EDEDF0;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   color: #524D6E;
   -webkit-transition: border-color 350ms;
   transition: border-color 350ms;

--- a/src/shared-components/field/style.ts
+++ b/src/shared-components/field/style.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { SPACER, ANIMATION, ThemeType } from '../../constants';
+import { SPACER, ANIMATION, ThemeType, BORDER_RADIUS } from '../../constants';
 import { MessagesTypes } from '../verificationMessages';
 
 export const HintItem = styled.div`
@@ -30,7 +30,7 @@ const inputStyles = (theme: ThemeType) => css`
   appearance: none;
   background: ${theme.COLORS.white};
   border: 1px solid ${theme.COLORS.border};
-  border-radius: ${SPACER.xsmall};
+  border-radius: ${BORDER_RADIUS.small};
   color: ${theme.COLORS.primaryTint1};
   transition: border-color ${ANIMATION.defaultTiming};
   width: 100%;

--- a/src/shared-components/field/style.ts
+++ b/src/shared-components/field/style.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { SPACER, ANIMATION, ThemeType, BORDER_RADIUS } from '../../constants';
+import { SPACER, ANIMATION, ThemeType } from '../../constants';
 import { MessagesTypes } from '../verificationMessages';
 
 export const HintItem = styled.div`
@@ -30,7 +30,7 @@ const inputStyles = (theme: ThemeType) => css`
   appearance: none;
   background: ${theme.COLORS.white};
   border: 1px solid ${theme.COLORS.border};
-  border-radius: ${BORDER_RADIUS.small};
+  border-radius: ${theme.BORDER_RADIUS.small};
   color: ${theme.COLORS.primaryTint1};
   transition: border-color ${ANIMATION.defaultTiming};
   width: 100%;

--- a/src/shared-components/immersiveModal/style.ts
+++ b/src/shared-components/immersiveModal/style.ts
@@ -8,6 +8,7 @@ import {
   Z_SCALE,
   ANIMATION,
   ThemeType,
+  BORDER_RADIUS,
 } from '../../constants';
 
 export const Overlay = styled.div`
@@ -46,7 +47,7 @@ export const CrossIconContainer = styled.button`
   z-index: ${Z_SCALE.e2000};
   width: 40px;
   height: 40px;
-  border-radius: 40px;
+  border-radius: 50%;
   background: ${({ theme }) => theme.COLORS.white};
   display: flex;
   flex-flow: row nowrap;
@@ -75,8 +76,8 @@ export const HeaderImageContainer = styled.div`
     min-height: 240px;
     max-height: 240px;
     width: 100%;
-    border-top-left-radius: 32px;
-    border-top-right-radius: 32px;
+    border-top-left-radius: ${BORDER_RADIUS.large};
+    border-top-right-radius: ${BORDER_RADIUS.large};
   }
 
   ${MEDIA_QUERIES.mdUp} {
@@ -86,8 +87,8 @@ export const HeaderImageContainer = styled.div`
     img {
       height: 264px;
       max-height: 264px;
-      border-top-left-radius: 8px;
-      border-top-right-radius: 8px;
+      border-top-left-radius: ${BORDER_RADIUS.medium};
+      border-top-right-radius: ${BORDER_RADIUS.medium};
     }
   }
 `;
@@ -146,8 +147,8 @@ export const DesktopHeaderBar = styled.div<{ showDesktopHeaderBar: boolean }>`
   ${({ theme }) => commonHeaderBarStyles(theme)}
 
   top: 56px;
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
+  border-top-left-radius: ${BORDER_RADIUS.medium};
+  border-top-right-radius: ${BORDER_RADIUS.medium};
   display: none;
 
   transition: opacity ${ANIMATION.defaultTiming}
@@ -215,15 +216,15 @@ type HasHeaderImageProps = {
 // 272px comes from 32px top overlay + 240px image
 export const MainModalContentContainer = styled.div<HasHeaderImageProps>`
   position: relative;
-  border-top-left-radius: 32px;
-  border-top-right-radius: 32px;
+  border-top-left-radius: ${BORDER_RADIUS.large};
+  border-top-right-radius: ${BORDER_RADIUS.large};
   box-shadow: ${({ theme }) => theme.BOX_SHADOWS.modal};
   background: ${({ theme }) => theme.COLORS.white};
   height: ${({ hasHeaderImage }): string =>
     hasHeaderImage ? 'calc(100% - 272px)' : 'calc(100% - 32px)'};
 
   ${MEDIA_QUERIES.mdUp} {
-    border-radius: 8px;
+    border-radius: ${BORDER_RADIUS.medium};
     margin-top: 56px;
     overflow-y: auto;
     height: 100%;
@@ -235,8 +236,8 @@ export const ContentWithFooterContainer = styled.div<HasHeaderImageProps>`
   flex-flow: column nowrap;
   justify-content: space-between;
   min-height: 100%;
-  border-top-left-radius: 32px;
-  border-top-right-radius: 32px;
+  border-top-left-radius: ${BORDER_RADIUS.large};
+  border-top-right-radius: ${BORDER_RADIUS.large};
   background: ${({ theme }) => theme.COLORS.white};
   padding: ${({ hasHeaderImage }): string =>
     hasHeaderImage

--- a/src/shared-components/immersiveModal/style.ts
+++ b/src/shared-components/immersiveModal/style.ts
@@ -8,7 +8,6 @@ import {
   Z_SCALE,
   ANIMATION,
   ThemeType,
-  BORDER_RADIUS,
 } from '../../constants';
 
 export const Overlay = styled.div`
@@ -76,8 +75,8 @@ export const HeaderImageContainer = styled.div`
     min-height: 240px;
     max-height: 240px;
     width: 100%;
-    border-top-left-radius: ${BORDER_RADIUS.large};
-    border-top-right-radius: ${BORDER_RADIUS.large};
+    border-top-left-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
+    border-top-right-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
   }
 
   ${MEDIA_QUERIES.mdUp} {
@@ -87,8 +86,8 @@ export const HeaderImageContainer = styled.div`
     img {
       height: 264px;
       max-height: 264px;
-      border-top-left-radius: ${BORDER_RADIUS.medium};
-      border-top-right-radius: ${BORDER_RADIUS.medium};
+      border-top-left-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
+      border-top-right-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
     }
   }
 `;
@@ -147,8 +146,8 @@ export const DesktopHeaderBar = styled.div<{ showDesktopHeaderBar: boolean }>`
   ${({ theme }) => commonHeaderBarStyles(theme)}
 
   top: 56px;
-  border-top-left-radius: ${BORDER_RADIUS.medium};
-  border-top-right-radius: ${BORDER_RADIUS.medium};
+  border-top-left-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
+  border-top-right-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
   display: none;
 
   transition: opacity ${ANIMATION.defaultTiming}
@@ -216,15 +215,15 @@ type HasHeaderImageProps = {
 // 272px comes from 32px top overlay + 240px image
 export const MainModalContentContainer = styled.div<HasHeaderImageProps>`
   position: relative;
-  border-top-left-radius: ${BORDER_RADIUS.large};
-  border-top-right-radius: ${BORDER_RADIUS.large};
+  border-top-left-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
+  border-top-right-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
   box-shadow: ${({ theme }) => theme.BOX_SHADOWS.modal};
   background: ${({ theme }) => theme.COLORS.white};
   height: ${({ hasHeaderImage }): string =>
     hasHeaderImage ? 'calc(100% - 272px)' : 'calc(100% - 32px)'};
 
   ${MEDIA_QUERIES.mdUp} {
-    border-radius: ${BORDER_RADIUS.medium};
+    border-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
     margin-top: 56px;
     overflow-y: auto;
     height: 100%;
@@ -236,8 +235,8 @@ export const ContentWithFooterContainer = styled.div<HasHeaderImageProps>`
   flex-flow: column nowrap;
   justify-content: space-between;
   min-height: 100%;
-  border-top-left-radius: ${BORDER_RADIUS.large};
-  border-top-right-radius: ${BORDER_RADIUS.large};
+  border-top-left-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
+  border-top-right-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
   background: ${({ theme }) => theme.COLORS.white};
   padding: ${({ hasHeaderImage }): string =>
     hasHeaderImage

--- a/src/shared-components/indicator/style.ts
+++ b/src/shared-components/indicator/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { SPACER, BORDER_RADIUS } from '../../constants';
+import { SPACER } from '../../constants';
 
 export const IndicatorContainer = styled.div`
   background-color: ${({ theme }) => theme.COLORS.error};
@@ -16,7 +16,7 @@ export const IndicatorContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  border-radius: ${BORDER_RADIUS.medium};
+  border-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
 
   > div {
     position: relative;

--- a/src/shared-components/indicator/style.ts
+++ b/src/shared-components/indicator/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { SPACER } from '../../constants';
+import { SPACER, BORDER_RADIUS } from '../../constants';
 
 export const IndicatorContainer = styled.div`
   background-color: ${({ theme }) => theme.COLORS.error};
@@ -16,7 +16,7 @@ export const IndicatorContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  border-radius: 8px;
+  border-radius: ${BORDER_RADIUS.medium};
 
   > div {
     position: relative;

--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useTheme } from 'emotion-theming';
 
 import {
   ClickableContainer,
@@ -41,46 +40,41 @@ export const OptionButton = ({
   subtext,
   text,
   ...rest
-}: OptionButtonProps) => {
-  const theme = useTheme();
-  const borderRadiusValue = borderRadius || theme.BORDER_RADIUS.small;
-
-  return (
-    <ClickableContainer
-      borderRadius={borderRadiusValue}
-      onClick={onClick}
-      type="button"
-      role={optionType}
-      containerType="clickable"
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      {...rest}
-    >
-      <FlexContainer>
-        {icon ? (
-          <IconWrapper
-            selected={selected}
-            optionType={optionType}
-            buttonType={buttonType}
-          >
-            {selected ? <CheckmarkIcon /> : icon}
-          </IconWrapper>
-        ) : (
-          <CheckmarkWrapper
-            selected={selected}
-            optionType={optionType}
-            buttonType={buttonType}
-          >
-            <CheckmarkIcon />
-          </CheckmarkWrapper>
-        )}
-        <TextContainer>
-          <Text>{text}</Text>
-          {subtext && <SubText>{subtext}</SubText>}
-        </TextContainer>
-      </FlexContainer>
-    </ClickableContainer>
-  );
-};
+}: OptionButtonProps) => (
+  <ClickableContainer
+    borderRadius={borderRadius}
+    onClick={onClick}
+    type="button"
+    role={optionType}
+    containerType="clickable"
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    {...rest}
+  >
+    <FlexContainer>
+      {icon ? (
+        <IconWrapper
+          selected={selected}
+          optionType={optionType}
+          buttonType={buttonType}
+        >
+          {selected ? <CheckmarkIcon /> : icon}
+        </IconWrapper>
+      ) : (
+        <CheckmarkWrapper
+          selected={selected}
+          optionType={optionType}
+          buttonType={buttonType}
+        >
+          <CheckmarkIcon />
+        </CheckmarkWrapper>
+      )}
+      <TextContainer>
+        <Text>{text}</Text>
+        {subtext && <SubText>{subtext}</SubText>}
+      </TextContainer>
+    </FlexContainer>
+  </ClickableContainer>
+);
 
 OptionButton.propTypes = {
   borderRadius: PropTypes.string,

--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -11,6 +11,7 @@ import {
   CheckmarkWrapper,
 } from './style';
 import { CheckmarkIcon } from '../../icons';
+import { BORDER_RADIUS } from '../../constants';
 
 type OptionButtonProps = {
   borderRadius?: string;
@@ -31,7 +32,7 @@ type OptionButtonProps = {
 };
 
 export const OptionButton = ({
-  borderRadius = '4px',
+  borderRadius = BORDER_RADIUS.small,
   buttonType = 'primary',
   icon,
   onClick,

--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useTheme } from 'emotion-theming';
 
 import {
   ClickableContainer,
@@ -11,7 +12,6 @@ import {
   CheckmarkWrapper,
 } from './style';
 import { CheckmarkIcon } from '../../icons';
-import { BORDER_RADIUS } from '../../constants';
 
 type OptionButtonProps = {
   borderRadius?: string;
@@ -32,7 +32,7 @@ type OptionButtonProps = {
 };
 
 export const OptionButton = ({
-  borderRadius = BORDER_RADIUS.small,
+  borderRadius,
   buttonType = 'primary',
   icon,
   onClick,
@@ -41,41 +41,46 @@ export const OptionButton = ({
   subtext,
   text,
   ...rest
-}: OptionButtonProps) => (
-  <ClickableContainer
-    borderRadius={borderRadius}
-    onClick={onClick}
-    type="button"
-    role={optionType}
-    containerType="clickable"
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    {...rest}
-  >
-    <FlexContainer>
-      {icon ? (
-        <IconWrapper
-          selected={selected}
-          optionType={optionType}
-          buttonType={buttonType}
-        >
-          {selected ? <CheckmarkIcon /> : icon}
-        </IconWrapper>
-      ) : (
-        <CheckmarkWrapper
-          selected={selected}
-          optionType={optionType}
-          buttonType={buttonType}
-        >
-          <CheckmarkIcon />
-        </CheckmarkWrapper>
-      )}
-      <TextContainer>
-        <Text>{text}</Text>
-        {subtext && <SubText>{subtext}</SubText>}
-      </TextContainer>
-    </FlexContainer>
-  </ClickableContainer>
-);
+}: OptionButtonProps) => {
+  const theme = useTheme();
+  const borderRadiusValue = borderRadius || theme.BORDER_RADIUS.small;
+
+  return (
+    <ClickableContainer
+      borderRadius={borderRadiusValue}
+      onClick={onClick}
+      type="button"
+      role={optionType}
+      containerType="clickable"
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...rest}
+    >
+      <FlexContainer>
+        {icon ? (
+          <IconWrapper
+            selected={selected}
+            optionType={optionType}
+            buttonType={buttonType}
+          >
+            {selected ? <CheckmarkIcon /> : icon}
+          </IconWrapper>
+        ) : (
+          <CheckmarkWrapper
+            selected={selected}
+            optionType={optionType}
+            buttonType={buttonType}
+          >
+            <CheckmarkIcon />
+          </CheckmarkWrapper>
+        )}
+        <TextContainer>
+          <Text>{text}</Text>
+          {subtext && <SubText>{subtext}</SubText>}
+        </TextContainer>
+      </FlexContainer>
+    </ClickableContainer>
+  );
+};
 
 OptionButton.propTypes = {
   borderRadius: PropTypes.string,

--- a/src/shared-components/optionButton/style.ts
+++ b/src/shared-components/optionButton/style.ts
@@ -31,10 +31,11 @@ const getTypeColor = (
 };
 
 export const ClickableContainer = styled.button<{
-  borderRadius: string;
+  borderRadius?: string;
   containerType: ContainerType;
 }>`
-  border-radius: ${({ borderRadius }) => borderRadius};
+  border-radius: ${({ borderRadius, theme }) =>
+    borderRadius || theme.BORDER_RADIUS.small};
   ${({ containerType, theme }) => containerStyles(theme, containerType)};
   padding: ${SPACER.large};
   margin-bottom: ${SPACER.medium};

--- a/src/shared-components/optionButton/style.ts
+++ b/src/shared-components/optionButton/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { ANIMATION, SPACER, ThemeType } from '../../constants';
+import { ANIMATION, SPACER, ThemeType, BORDER_RADIUS } from '../../constants';
 import { containerStyles, ContainerType } from '../container/style';
 
 type BaseIconWrapperStylesProps = {
@@ -13,7 +13,10 @@ type BaseIconWrapperStylesProps = {
 
 const getOptionTypeStyles = (
   optionType: BaseIconWrapperStylesProps['optionType'],
-) => (optionType === 'checkbox' ? 'border-radius: 4px' : 'border-radius: 50%');
+) =>
+  optionType === 'checkbox'
+    ? `border-radius: ${BORDER_RADIUS.small};`
+    : 'border-radius: 50%';
 
 const getTypeColor = (
   buttonType: BaseIconWrapperStylesProps['buttonType'],

--- a/src/shared-components/optionButton/style.ts
+++ b/src/shared-components/optionButton/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { ANIMATION, SPACER, ThemeType, BORDER_RADIUS } from '../../constants';
+import { ANIMATION, SPACER, ThemeType } from '../../constants';
 import { containerStyles, ContainerType } from '../container/style';
 
 type BaseIconWrapperStylesProps = {
@@ -13,9 +13,10 @@ type BaseIconWrapperStylesProps = {
 
 const getOptionTypeStyles = (
   optionType: BaseIconWrapperStylesProps['optionType'],
+  theme: ThemeType,
 ) =>
   optionType === 'checkbox'
-    ? `border-radius: ${BORDER_RADIUS.small};`
+    ? `border-radius: ${theme.BORDER_RADIUS.small};`
     : 'border-radius: 50%';
 
 const getTypeColor = (
@@ -71,7 +72,7 @@ const getBaseIconWrapperStyles = ({
   align-items: center;
   transition: all ${ANIMATION.defaultTiming};
 
-  ${getOptionTypeStyles(optionType)};
+  ${getOptionTypeStyles(optionType, theme)};
 
   svg {
     opacity: 0;

--- a/src/shared-components/selectorButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/selectorButton/__snapshots__/test.tsx.snap
@@ -173,7 +173,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 
 .emotion-9:focus .emotion-6 {
   box-shadow: 0px 0px 0px 2px #FFFFFF,0px 0px 0px 4px #332E54;
-  border-radius: 100%;
+  border-radius: 50%;
 }
 
 .emotion-5 {
@@ -243,7 +243,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
   justify-content: center;
   -webkit-transition: background-color 350ms;
   transition: background-color 350ms;
-  border-radius: 100%;
+  border-radius: 50%;
   background-color: #332E54;
   border-color: #332E54;
 }
@@ -474,7 +474,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for radio
 
 .emotion-9:focus .emotion-6 {
   box-shadow: 0px 0px 0px 2px #FFFFFF,0px 0px 0px 4px #332E54;
-  border-radius: 100%;
+  border-radius: 50%;
 }
 
 .emotion-5 {
@@ -543,7 +543,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays icon for radio
   justify-content: center;
   -webkit-transition: background-color 350ms;
   transition: background-color 350ms;
-  border-radius: 100%;
+  border-radius: 50%;
   background-color: transparent;
   border-color: #332E54;
 }
@@ -746,7 +746,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for radio bu
 
 .emotion-8:focus .emotion-5 {
   box-shadow: 0px 0px 0px 2px #FFFFFF,0px 0px 0px 4px #332E54;
-  border-radius: 100%;
+  border-radius: 50%;
 }
 
 .emotion-4 {
@@ -798,7 +798,7 @@ exports[`<SelectorButton /> UI snapshots when Icon added hides icon for radio bu
   justify-content: center;
   -webkit-transition: background-color 350ms;
   transition: background-color 350ms;
-  border-radius: 100%;
+  border-radius: 50%;
   background-color: transparent;
   border-color: #332E54;
 }
@@ -870,7 +870,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
 
 .emotion-9:focus .emotion-6 {
   box-shadow: 0px 0px 0px 2px #FFFFFF,0px 0px 0px 4px #332E54;
-  border-radius: 100%;
+  border-radius: 50%;
 }
 
 .emotion-5 {
@@ -940,7 +940,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
   justify-content: center;
   -webkit-transition: background-color 350ms;
   transition: background-color 350ms;
-  border-radius: 100%;
+  border-radius: 50%;
   background-color: #332E54;
   border-color: #332E54;
 }
@@ -1023,7 +1023,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
 
 .emotion-9:focus .emotion-6 {
   box-shadow: 0px 0px 0px 2px #FFFFFF,0px 0px 0px 4px #332E54;
-  border-radius: 100%;
+  border-radius: 50%;
 }
 
 .emotion-5 {
@@ -1093,7 +1093,7 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
   justify-content: center;
   -webkit-transition: background-color 350ms;
   transition: background-color 350ms;
-  border-radius: 100%;
+  border-radius: 50%;
   background-color: #A6A1E2;
   border-color: #A6A1E2;
 }
@@ -1176,7 +1176,7 @@ exports[`<SelectorButton /> UI snapshots when children is a node 1`] = `
 
 .emotion-8:focus .emotion-5 {
   box-shadow: 0px 0px 0px 2px #FFFFFF,0px 0px 0px 4px #332E54;
-  border-radius: 100%;
+  border-radius: 50%;
 }
 
 .emotion-4 {
@@ -1228,7 +1228,7 @@ exports[`<SelectorButton /> UI snapshots when children is a node 1`] = `
   justify-content: center;
   -webkit-transition: background-color 350ms;
   transition: background-color 350ms;
-  border-radius: 100%;
+  border-radius: 50%;
   background-color: transparent;
   border-color: #332E54;
 }
@@ -1300,7 +1300,7 @@ exports[`<SelectorButton /> UI snapshots when children is undefined 1`] = `
 
 .emotion-6:focus .emotion-5 {
   box-shadow: 0px 0px 0px 2px #FFFFFF,0px 0px 0px 4px #332E54;
-  border-radius: 100%;
+  border-radius: 50%;
 }
 
 .emotion-4 {
@@ -1352,7 +1352,7 @@ exports[`<SelectorButton /> UI snapshots when children is undefined 1`] = `
   justify-content: center;
   -webkit-transition: background-color 350ms;
   transition: background-color 350ms;
-  border-radius: 100%;
+  border-radius: 50%;
   background-color: transparent;
   border-color: #332E54;
 }

--- a/src/shared-components/selectorButton/style.ts
+++ b/src/shared-components/selectorButton/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { SPACER, ANIMATION, ThemeType } from '../../constants';
+import { SPACER, ANIMATION, ThemeType, BORDER_RADIUS } from '../../constants';
 
 import { SelectorType, SizeType, StyleType } from '.';
 
@@ -24,7 +24,7 @@ export const OuterContainer = styled.div<{ selector: SelectorType }>`
       box-shadow: ${({ theme }) => theme.BOX_SHADOWS.focus};
 
       ${({ selector }) => `
-        border-radius: ${selector === 'checkbox' ? '4px' : '100%'};
+        border-radius: ${selector === 'checkbox' ? BORDER_RADIUS.small : '50%'};
       `};
     }
   }
@@ -77,7 +77,7 @@ export const Selector = styled.div<{
   transition: background-color ${ANIMATION.defaultTiming};
 
   ${({ selector }) => `
-    border-radius: ${selector === 'checkbox' ? '4px' : '100%'};
+    border-radius: ${selector === 'checkbox' ? BORDER_RADIUS.small : '50%'};
   `}
 
   ${({ type, checked, disabled, theme }) => {

--- a/src/shared-components/selectorButton/style.ts
+++ b/src/shared-components/selectorButton/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { SPACER, ANIMATION, ThemeType, BORDER_RADIUS } from '../../constants';
+import { SPACER, ANIMATION, ThemeType } from '../../constants';
 
 import { SelectorType, SizeType, StyleType } from '.';
 
@@ -23,8 +23,10 @@ export const OuterContainer = styled.div<{ selector: SelectorType }>`
     ${SelectorContainer} {
       box-shadow: ${({ theme }) => theme.BOX_SHADOWS.focus};
 
-      ${({ selector }) => `
-        border-radius: ${selector === 'checkbox' ? BORDER_RADIUS.small : '50%'};
+      ${({ selector, theme }) => `
+        border-radius: ${
+          selector === 'checkbox' ? theme.BORDER_RADIUS.small : '50%'
+        };
       `};
     }
   }
@@ -76,8 +78,10 @@ export const Selector = styled.div<{
   justify-content: center;
   transition: background-color ${ANIMATION.defaultTiming};
 
-  ${({ selector }) => `
-    border-radius: ${selector === 'checkbox' ? BORDER_RADIUS.small : '50%'};
+  ${({ selector, theme }) => `
+    border-radius: ${
+      selector === 'checkbox' ? theme.BORDER_RADIUS.small : '50%'
+    };
   `}
 
   ${({ type, checked, disabled, theme }) => {

--- a/src/shared-components/tabs/__snapshots__/test.tsx.snap
+++ b/src/shared-components/tabs/__snapshots__/test.tsx.snap
@@ -62,7 +62,7 @@ exports[`<Tabs /> UI snapshot renders with default props 1`] = `
   padding: 1rem 1.5rem;
   -webkit-transition: 350ms;
   transition: 350ms;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   color: #332E54;
 }
 
@@ -106,7 +106,7 @@ exports[`<Tabs /> UI snapshot renders with default props 1`] = `
   padding: 1rem 1.5rem;
   -webkit-transition: 350ms;
   transition: 350ms;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   color: #C3C0CD;
 }
 
@@ -207,7 +207,7 @@ exports[`<Tabs /> UI snapshot renders with initialActiveTabId and onClick props 
   padding: 1rem 1.5rem;
   -webkit-transition: 350ms;
   transition: 350ms;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   color: #332E54;
 }
 
@@ -251,7 +251,7 @@ exports[`<Tabs /> UI snapshot renders with initialActiveTabId and onClick props 
   padding: 1rem 1.5rem;
   -webkit-transition: 350ms;
   transition: 350ms;
-  border-radius: 0.25rem;
+  border-radius: 4px;
   color: #C3C0CD;
 }
 

--- a/src/shared-components/tabs/style.ts
+++ b/src/shared-components/tabs/style.ts
@@ -2,12 +2,7 @@ import styled from '@emotion/styled';
 import { buttonReset } from 'src/utils/styles/buttonReset';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import {
-  SPACER,
-  ANIMATION,
-  MEDIA_QUERIES,
-  BORDER_RADIUS,
-} from '../../constants';
+import { SPACER, ANIMATION, MEDIA_QUERIES } from '../../constants';
 
 export const TabsContainer = styled.div`
   display: flex;
@@ -34,7 +29,7 @@ export const TabItem = styled.button<{ active: boolean }>`
   margin: 0;
   padding: ${SPACER.medium} ${SPACER.large};
   transition: ${ANIMATION.defaultTiming};
-  border-radius: ${BORDER_RADIUS.small};
+  border-radius: ${({ theme }) => theme.BORDER_RADIUS.small};
 
   color: ${({ active, theme }) =>
     active ? theme.COLORS.primary : theme.COLORS.textDisabled};

--- a/src/shared-components/tabs/style.ts
+++ b/src/shared-components/tabs/style.ts
@@ -2,7 +2,12 @@ import styled from '@emotion/styled';
 import { buttonReset } from 'src/utils/styles/buttonReset';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { SPACER, ANIMATION, MEDIA_QUERIES } from '../../constants';
+import {
+  SPACER,
+  ANIMATION,
+  MEDIA_QUERIES,
+  BORDER_RADIUS,
+} from '../../constants';
 
 export const TabsContainer = styled.div`
   display: flex;
@@ -29,7 +34,7 @@ export const TabItem = styled.button<{ active: boolean }>`
   margin: 0;
   padding: ${SPACER.medium} ${SPACER.large};
   transition: ${ANIMATION.defaultTiming};
-  border-radius: ${SPACER.xsmall};
+  border-radius: ${BORDER_RADIUS.small};
 
   color: ${({ active, theme }) =>
     active ? theme.COLORS.primary : theme.COLORS.textDisabled};

--- a/src/shared-components/toggle/__snapshots__/test.tsx.snap
+++ b/src/shared-components/toggle/__snapshots__/test.tsx.snap
@@ -43,7 +43,7 @@ exports[`<Toggle /> UI snapshot renders the component 1`] = `
 .emotion-2 > div:first-of-type > input:focus {
   box-shadow: 0px 0px 0px 2px #FFFFFF,0px 0px 0px 4px #332E54;
   outline: none;
-  border-radius: 12px;
+  border-radius: 32px;
 }
 
 <div

--- a/src/shared-components/toggle/__snapshots__/test.tsx.snap
+++ b/src/shared-components/toggle/__snapshots__/test.tsx.snap
@@ -43,7 +43,7 @@ exports[`<Toggle /> UI snapshot renders the component 1`] = `
 .emotion-2 > div:first-of-type > input:focus {
   box-shadow: 0px 0px 0px 2px #FFFFFF,0px 0px 0px 4px #332E54;
   outline: none;
-  border-radius: 32px;
+  border-radius: 12px;
 }
 
 <div

--- a/src/shared-components/toggle/style.ts
+++ b/src/shared-components/toggle/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { SPACER, ThemeType } from '../../constants';
+import { SPACER, ThemeType, BORDER_RADIUS } from '../../constants';
 
 export const Container = styled.div`
   position: relative;
@@ -48,7 +48,7 @@ export const ReactToggleButtonContainer = styled.div`
       &:focus {
         box-shadow: ${({ theme }) => theme.BOX_SHADOWS.focus};
         outline: none;
-        border-radius: 12px;
+        border-radius: ${BORDER_RADIUS.large};
       }
     }
   }

--- a/src/shared-components/toggle/style.ts
+++ b/src/shared-components/toggle/style.ts
@@ -48,7 +48,7 @@ export const ReactToggleButtonContainer = styled.div`
       &:focus {
         box-shadow: ${({ theme }) => theme.BOX_SHADOWS.focus};
         outline: none;
-        border-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
+        border-radius: 12px;
       }
     }
   }

--- a/src/shared-components/toggle/style.ts
+++ b/src/shared-components/toggle/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { SPACER, ThemeType, BORDER_RADIUS } from '../../constants';
+import { SPACER, ThemeType } from '../../constants';
 
 export const Container = styled.div`
   position: relative;
@@ -48,7 +48,7 @@ export const ReactToggleButtonContainer = styled.div`
       &:focus {
         box-shadow: ${({ theme }) => theme.BOX_SHADOWS.focus};
         outline: none;
-        border-radius: ${BORDER_RADIUS.large};
+        border-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
       }
     }
   }

--- a/src/shared-components/tooltip/__snapshots__/test.tsx.snap
+++ b/src/shared-components/tooltip/__snapshots__/test.tsx.snap
@@ -21,7 +21,7 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
   top: 120%;
   background: #332E54;
   box-shadow: 0px 8px 24px rgba(51,46,84,0.05);
-  border-radius: 0.5rem;
+  border-radius: 8px;
   color: #FFFFFF;
   min-width: 100px;
   opacity: 0;

--- a/src/shared-components/tooltip/style.ts
+++ b/src/shared-components/tooltip/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
-import { SPACER, BORDER_RADIUS } from '../../constants';
+import { SPACER } from '../../constants';
 
 import { ArrowAlignTypes, PositionTypes } from '.';
 
@@ -104,8 +104,8 @@ export const TooltipBox = styled.div<{
 
   background: ${({ theme }) => theme.COLORS.primary};
   box-shadow: 0px 8px 24px rgba(51, 46, 84, 0.05);
-  border-radius: ${({ isSmall }) =>
-    isSmall ? BORDER_RADIUS.small : BORDER_RADIUS.medium};
+  border-radius: ${({ isSmall, theme }) =>
+    isSmall ? theme.BORDER_RADIUS.small : theme.BORDER_RADIUS.medium};
   color: ${({ theme }) => theme.COLORS.white};
   min-width: ${({ isSmall }) => (isSmall ? '0px' : '100px')};
   opacity: ${({ open }) => (open ? '1' : '0')};

--- a/src/shared-components/tooltip/style.ts
+++ b/src/shared-components/tooltip/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
-import { SPACER } from '../../constants';
+import { SPACER, BORDER_RADIUS } from '../../constants';
 
 import { ArrowAlignTypes, PositionTypes } from '.';
 
@@ -104,7 +104,8 @@ export const TooltipBox = styled.div<{
 
   background: ${({ theme }) => theme.COLORS.primary};
   box-shadow: 0px 8px 24px rgba(51, 46, 84, 0.05);
-  border-radius: ${({ isSmall }) => (isSmall ? SPACER.xsmall : SPACER.small)};
+  border-radius: ${({ isSmall }) =>
+    isSmall ? BORDER_RADIUS.small : BORDER_RADIUS.medium};
   color: ${({ theme }) => theme.COLORS.white};
   min-width: ${({ isSmall }) => (isSmall ? '0px' : '100px')};
   opacity: ${({ open }) => (open ? '1' : '0')};

--- a/stories/theme/borderRadius.stories.tsx
+++ b/stories/theme/borderRadius.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { useTheme } from 'emotion-theming';
+import { SPACER } from 'src/constants';
+
+const MainContainer = styled.div`
+  padding: ${SPACER.large} ${SPACER.large};
+`;
+
+export const BorderRadius = () => {
+  const theme = useTheme();
+  const borderRadiusKeys = Object.keys(theme.BORDER_RADIUS) as Array<
+    keyof typeof theme['BORDER_RADIUS']
+  >;
+
+  return (
+    <MainContainer>
+      {borderRadiusKeys.map((borderRadiusKey) => {
+        const borderRadiusValue = theme.BORDER_RADIUS[borderRadiusKey];
+        return (
+          <p key={borderRadiusKey}>
+            <strong>{borderRadiusKey}</strong>: {borderRadiusValue}
+          </p>
+        );
+      })}
+    </MainContainer>
+  );
+};
+
+BorderRadius.storyName = 'BORDER_RADIUS';

--- a/stories/theme/borderRadius.stories.tsx
+++ b/stories/theme/borderRadius.stories.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { css } from '@emotion/core';
 import styled from '@emotion/styled';
 import { useTheme } from 'emotion-theming';
 import { SPACER } from 'src/constants';
+import { Container } from 'src/shared-components';
 
 const MainContainer = styled.div`
-  padding: ${SPACER.large} ${SPACER.large};
+  padding: ${SPACER.xlarge};
 `;
 
 export const BorderRadius = () => {
@@ -17,10 +19,22 @@ export const BorderRadius = () => {
     <MainContainer>
       {borderRadiusKeys.map((borderRadiusKey) => {
         const borderRadiusValue = theme.BORDER_RADIUS[borderRadiusKey];
+        const borderRadiusBoxStyles = css`
+          width: 350px;
+          margin-bottom: ${SPACER.xlarge};
+          border: 2px solid ${theme.COLORS.primary};
+          border-radius: ${borderRadiusValue};
+        `;
+
         return (
-          <p key={borderRadiusKey}>
-            <strong>{borderRadiusKey}</strong>: {borderRadiusValue}
-          </p>
+          <Container key={borderRadiusKey} css={borderRadiusBoxStyles}>
+            <Container.Section>
+              <strong>Key:</strong> {borderRadiusKey}
+              <br />
+              <br />
+              <strong>Value:</strong> {borderRadiusValue}
+            </Container.Section>
+          </Container>
         );
       })}
     </MainContainer>

--- a/stories/theme/boxShadows.stories.tsx
+++ b/stories/theme/boxShadows.stories.tsx
@@ -9,8 +9,8 @@ const MainContainer = styled.div`
   padding: ${SPACER.xlarge};
   display: flex;
   flex-flow: row wrap;
-  justify-content: space-around;
-  align-items: center;
+  justify-content: flex-start;
+  align-items: flex-start;
 `;
 
 export const BoxShadows = () => {
@@ -25,7 +25,8 @@ export const BoxShadows = () => {
         const boxShadowValue = theme.BOX_SHADOWS[boxShadowKey];
         const boxShadowBoxStyles = css`
           width: 350px;
-          margin: ${SPACER.large};
+          min-height: 135px;
+          margin: 0 ${SPACER.x5large} ${SPACER.x5large} 0;
           box-shadow: ${boxShadowValue};
         `;
 

--- a/stories/theme/color.tsx
+++ b/stories/theme/color.tsx
@@ -14,7 +14,7 @@ const ColorSample = styled.div`
   height: 40px;
   width: 40px;
   background-color: ${(props) => props.color};
-  border-radius: 40px;
+  border-radius: 50%;
 `;
 
 const ColorName = styled.div`

--- a/stories/theme/color.tsx
+++ b/stories/theme/color.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { SPACER } from 'src/constants';
 
 const ColorContainer = styled.div`
-  margin: 48px 48px 0 0;
+  margin: 0 ${SPACER.x3large} ${SPACER.x3large} 0;
   display: flex;
   flex-flow: column nowrap;
   justify-content: center;

--- a/stories/theme/colors.stories.tsx
+++ b/stories/theme/colors.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { useTheme } from 'emotion-theming';
+import { SPACER } from 'src/constants';
 
 import Color from './color';
 
@@ -8,7 +9,8 @@ const MainContainer = styled.div`
   display: flex;
   flex-flow: row wrap;
   justify-content: flex-start;
-  align-items: center;
+  align-items: flex-start;
+  padding: ${SPACER.xlarge};
 `;
 
 export const COLORS = () => {

--- a/stories/theme/fonts.stories.tsx
+++ b/stories/theme/fonts.stories.tsx
@@ -4,7 +4,7 @@ import { useTheme } from 'emotion-theming';
 import { SPACER } from 'src/constants';
 
 const MainContainer = styled.div`
-  padding: ${SPACER.large} ${SPACER.large};
+  padding: ${SPACER.xlarge};
 `;
 
 export const FONTS = () => {

--- a/stories/theme/index.stories.tsx
+++ b/stories/theme/index.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from '@storybook/addon-docs/blocks';
 import type { Meta } from '@storybook/react';
 
+export * from './borderRadius.stories';
 export * from './boxShadows.stories';
 export * from './colors.stories';
 export * from './fonts.stories';

--- a/stories/theme/typography.stories.tsx
+++ b/stories/theme/typography.stories.tsx
@@ -5,7 +5,7 @@ import { SPACER } from 'src/constants';
 import { Typography } from 'src/shared-components';
 
 const MainContainer = styled.div`
-  padding: ${SPACER.large};
+  padding: ${SPACER.xlarge};
 `;
 
 const CategoryContainer = styled.div`


### PR DESCRIPTION
- Review APP: http://curology-radiance-pr-642.herokuapp.com (some components to look for: Modals, Tooltips, Dropdown, Field, Buttons, Alerts, option button, Indicator, Chip)

- Refactor all full circles radius to 50% for consistency:  https://www.codecademy.com/forum_questions/559fe347e39efe4cf40005a9

- Change Container message radius from 16px to theme medium (8px)

- Named exports for some constants (e.g. SPACER) for better intellisense and consistency

- added Border Radius story 

- Changed  Toggle focus border radius to theme large: was hardcoded 12px (beyond 12px the rounded visual is the same so no impact in primary theme). This affects secondary theme, which focus as square
![image](https://user-images.githubusercontent.com/11194969/102233535-267fe380-3ecf-11eb-8432-a729837f1012.png)

it is more aligned to the theme but let me know if this needs to be changed back and hardcoded as rounded focus