### PR TITLE
[Styling] Remove Superfluous css Serialization to Reduce Size

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,13 +1,13 @@
 {
   "bundle.js": {
-    "bundled": 838566,
-    "minified": 768893,
-    "gzipped": 90370
+    "bundled": 745130,
+    "minified": 676071,
+    "gzipped": 85753
   },
   "bundle.umd.js": {
-    "bundled": 848390,
-    "minified": 744983,
-    "gzipped": 86334
+    "bundled": 754776,
+    "minified": 652557,
+    "gzipped": 81938
   },
   "constants/zScale/index.js": {
     "bundled": 234,
@@ -542,16 +542,16 @@
     }
   },
   "shared-components/button/shared-components/container/index.js": {
-    "bundled": 7040,
-    "minified": 6805,
-    "gzipped": 2030,
+    "bundled": 3131,
+    "minified": 2946,
+    "gzipped": 1461,
     "treeshaked": {
       "rollup": {
-        "code": 887,
-        "import_statements": 190
+        "code": 877,
+        "import_statements": 154
       },
       "webpack": {
-        "code": 2071
+        "code": 2016
       }
     }
   },
@@ -1032,16 +1032,16 @@
     }
   },
   "shared-components/accordion/thumbnails/style.js": {
-    "bundled": 11587,
-    "minified": 11311,
-    "gzipped": 2350,
+    "bundled": 9463,
+    "minified": 9221,
+    "gzipped": 2265,
     "treeshaked": {
       "rollup": {
-        "code": 920,
-        "import_statements": 147
+        "code": 867,
+        "import_statements": 125
       },
       "webpack": {
-        "code": 2030
+        "code": 1944
       }
     }
   },
@@ -1298,16 +1298,16 @@
     }
   },
   "shared-components/field/style.js": {
-    "bundled": 35010,
-    "minified": 34257,
-    "gzipped": 4747,
+    "bundled": 30470,
+    "minified": 29756,
+    "gzipped": 4673,
     "treeshaked": {
       "rollup": {
-        "code": 2486,
-        "import_statements": 207
+        "code": 2753,
+        "import_statements": 171
       },
       "webpack": {
-        "code": 3663
+        "code": 3897
       }
     }
   },
@@ -1396,16 +1396,16 @@
     }
   },
   "shared-components/tooltip/style.js": {
-    "bundled": 114239,
-    "minified": 112312,
-    "gzipped": 8317,
+    "bundled": 31308,
+    "minified": 29892,
+    "gzipped": 4685,
     "treeshaked": {
       "rollup": {
-        "code": 3251,
-        "import_statements": 115
+        "code": 2879,
+        "import_statements": 79
       },
       "webpack": {
-        "code": 4393
+        "code": 3928
       }
     }
   },

--- a/src/shared-components/accordion/thumbnails/style.ts
+++ b/src/shared-components/accordion/thumbnails/style.ts
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 import { style as TYPOGRAPHY_STYLE } from 'src/shared-components/typography';
 import { SPACER } from 'src/constants';
 
@@ -9,7 +8,7 @@ export const Container = styled.div`
   margin-left: ${SPACER.large};
 `;
 
-const thumbnailBase = css`
+const thumbnailBase = `
   display: flex;
   justify-content: center;
   align-items: center;
@@ -18,7 +17,8 @@ const thumbnailBase = css`
 `;
 
 export const ImageContainer = styled.div`
-  ${thumbnailBase} overflow: hidden;
+  ${thumbnailBase}
+  overflow: hidden;
   height: 1.5rem;
   width: 1rem;
 

--- a/src/shared-components/button/shared-components/container/index.ts
+++ b/src/shared-components/button/shared-components/container/index.ts
@@ -1,10 +1,9 @@
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 
 import { MEDIA_QUERIES, SPACER } from '../../../../constants';
 
-const reverseStyles = css`
+const reverseStyles = `
   flex-direction: column-reverse;
 
   & > :not(:last-child) {
@@ -13,7 +12,7 @@ const reverseStyles = css`
   }
 `;
 
-const flexMdUpStyles = css`
+const flexMdUpStyles = `
   & > :not(:last-child) {
     margin-bottom: 0;
     margin-top: ${SPACER.medium};

--- a/src/shared-components/field/style.ts
+++ b/src/shared-components/field/style.ts
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
 import { SPACER, ANIMATION, ThemeType } from '../../constants';
@@ -25,7 +24,7 @@ export const Label = styled.label<{ disabled: boolean }>`
     disabled ? `color: ${theme.COLORS.primaryTint3};` : ''}
 `;
 
-const inputStyles = (theme: ThemeType) => css`
+const inputStyles = (theme: ThemeType) => `
   ${TYPOGRAPHY_STYLE.body(theme)}
   appearance: none;
   background: ${theme.COLORS.white};

--- a/src/shared-components/tooltip/style.ts
+++ b/src/shared-components/tooltip/style.ts
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 
 import { SPACER } from '../../constants';
 
@@ -35,11 +34,11 @@ export const TooltipBox = styled.div<{
   ${({ position }) => {
     switch (position) {
       case 'bottom':
-        return css`
+        return `
           top: 120%;
         `;
       case 'top':
-        return css`
+        return `
           bottom: 120%;
         `;
       default:
@@ -50,11 +49,11 @@ export const TooltipBox = styled.div<{
   ${({ arrowAlign }) => {
     switch (arrowAlign) {
       case 'left':
-        return css`
+        return `
           left: 0;
         `;
       case 'right':
-        return css`
+        return `
           right: 0;
         `;
       default:
@@ -64,40 +63,40 @@ export const TooltipBox = styled.div<{
 
   ${({ nudgeRight }) =>
     nudgeRight &&
-    css`
+    `
       right: ${nudgeRight * -1}px;
     `};
 
   ${({ nudgeLeft }) =>
     nudgeLeft &&
-    css`
+    `
       left: ${nudgeLeft * -1}px;
     `};
 
   ${({ nudgeTop }) =>
     nudgeTop &&
-    css`
+    `
       top: ${nudgeTop * -1}px;
       bottom: auto;
     `};
 
   ${({ nudgeBottom }) =>
     nudgeBottom &&
-    css`
+    `
       bottom: ${nudgeBottom * -1}px;
       top: auto;
     `};
 
   ${({ alignRightPercent }) =>
     alignRightPercent &&
-    css`
+    `
       right: ${alignRightPercent}%;
       margin-right: -69px;
     `};
 
   ${({ alignTopPercent }) =>
     alignTopPercent &&
-    css`
+    `
       top: ${alignTopPercent}%;
       bottom: auto;
     `};
@@ -138,12 +137,12 @@ export const ArrowImageContainer = styled.div<{
   ${({ position }) => {
     switch (position) {
       case 'bottom':
-        return css`
+        return `
           top: -8px;
           transform: rotate(180deg);
         `;
       case 'top':
-        return css`
+        return `
           bottom: -8px;
         `;
       default:
@@ -154,15 +153,15 @@ export const ArrowImageContainer = styled.div<{
   ${({ arrowAlign }) => {
     switch (arrowAlign) {
       case 'left':
-        return css`
+        return `
           left: 10.25%;
         `;
       case 'right':
-        return css`
+        return `
           right: 10.25%;
         `;
       case 'middle':
-        return css`
+        return `
           left: 50%;
           margin-left: -10px;
         `;


### PR DESCRIPTION
### What & Why

We have some instances of in-lining `css` serialization within other `css` serializations and `styled` serializations, which are unnecessary and contribute to bundle size bloat, particularly in our Tooltip component. 

Removing them in favor of plain string in-lining results in an overall ~5.1% reduction in gzip size and ~12.1% reduction in minified size in the `radiance-ui` package.