### PR TITLE
[Theming] Modify Secondary Theme line-height and font-weight

### DIFF
--- a/src/shared-components/button/style.ts
+++ b/src/shared-components/button/style.ts
@@ -7,6 +7,7 @@ import { textColorsAssociatedWithColors } from './constants';
 import {
   primaryButtonFontColor,
   primaryButtonBackgroundColor,
+  setThemeLineHeight,
 } from '../../utils/themeStyles';
 
 import { ButtonTypeWithAction } from '.';
@@ -286,7 +287,7 @@ export const ButtonText = styled.span<{
   hasIcon?: boolean;
   isLoading?: boolean;
 }>`
-  line-height: 1.5;
+  line-height: ${({ theme }) => setThemeLineHeight(theme, '1.5')};
   margin: 0;
   padding-top: 2px;
 

--- a/src/shared-components/field/style.ts
+++ b/src/shared-components/field/style.ts
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { style as TYPOGRAPHY_STYLE } from '../typography';
 import { SPACER, ANIMATION, ThemeType } from '../../constants';
 import { MessagesTypes } from '../verificationMessages';
+import { setThemeLineHeight } from '../../utils/themeStyles';
 
 export const HintItem = styled.div`
   ${({ theme }) => TYPOGRAPHY_STYLE.caption(theme)}
@@ -72,7 +73,7 @@ export const Textarea = styled.textarea`
   color: ${({ theme }) => theme.COLORS.primary};
   display: block;
   height: 100%;
-  line-height: ${SPACER.large};
+  line-height: ${({ theme }) => setThemeLineHeight(theme, SPACER.large)};
   margin: 0 auto;
   max-width: 35rem;
   padding: ${SPACER.medium};

--- a/src/shared-components/optionButton/style.ts
+++ b/src/shared-components/optionButton/style.ts
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { style as TYPOGRAPHY_STYLE } from '../typography';
 import { ANIMATION, SPACER, ThemeType } from '../../constants';
 import { containerStyles, ContainerType } from '../container/style';
+import { setThemeLineHeight } from '../../utils/themeStyles';
 
 type BaseIconWrapperStylesProps = {
   buttonType?: 'primary' | 'secondary';
@@ -143,10 +144,10 @@ export const TextContainer = styled.div`
 
 export const Text = styled.div`
   color: ${({ theme }) => theme.COLORS.primaryTint1};
-  line-height: 1.5;
+  line-height: ${({ theme }) => setThemeLineHeight(theme, '1.5')};
 `;
 
 export const SubText = styled.div`
   ${({ theme }) => TYPOGRAPHY_STYLE.caption(theme)}
-  line-height: 1.5;
+  line-height: ${({ theme }) => setThemeLineHeight(theme, '1.5')};
 `;

--- a/src/shared-components/toggle/style.ts
+++ b/src/shared-components/toggle/style.ts
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import { SPACER, ThemeType } from '../../constants';
+import { setThemeLineHeight } from '../../utils/themeStyles';
 
 export const Container = styled.div`
   position: relative;
@@ -20,7 +21,7 @@ export const Label = styled.span`
   color: ${({ theme }) => theme.COLORS.primaryTint1};
   margin: 0;
   font-size: ${SPACER.medium};
-  line-height: ${SPACER.large};
+  line-height: ${({ theme }) => setThemeLineHeight(theme, SPACER.large)};
   text-align: left;
   cursor: pointer;
   user-select: none;

--- a/src/shared-components/typography/index.ts
+++ b/src/shared-components/typography/index.ts
@@ -7,12 +7,13 @@ import {
   setSecondaryHeadingFont,
   setButtonStyleFontWeight,
   setThemeLineHeight,
+  setThemeFontWeight,
 } from '../../utils/themeStyles';
 
 const displayStyle = (theme: ThemeType) => `
   color: ${theme.COLORS.primary};
   font-size: ${theme.TYPOGRAPHY.fontSize.display};
-  font-weight: ${theme.TYPOGRAPHY.fontWeight.bold};
+  font-weight: ${setThemeFontWeight(theme)};
   line-height: ${setThemeLineHeight(theme, round(48 / 36, 2))};
   ${setSecondaryHeadingFont(theme)}
 `;
@@ -20,7 +21,7 @@ const displayStyle = (theme: ThemeType) => `
 const headingStyle = (theme: ThemeType) => `
   color: ${theme.COLORS.primary};
   font-size: ${theme.TYPOGRAPHY.fontSize.heading};
-  font-weight: ${theme.TYPOGRAPHY.fontWeight.bold};
+  font-weight: ${setThemeFontWeight(theme)};
   line-height: ${setThemeLineHeight(theme, round(40 / 24, 2))};
   ${setSecondaryHeadingFont(theme)}
 `;
@@ -29,7 +30,7 @@ const titleStyle = (theme: ThemeType) => `
   color: ${theme.COLORS.primary};
   font-size: ${theme.TYPOGRAPHY.fontSize.title};
   line-height: ${setThemeLineHeight(theme, round(32 / 20, 2))};
-  font-weight: ${theme.TYPOGRAPHY.fontWeight.bold};
+  font-weight: ${setThemeFontWeight(theme)};
   ${setSecondaryHeadingFont(theme)}
 `;
 

--- a/src/shared-components/typography/index.ts
+++ b/src/shared-components/typography/index.ts
@@ -6,13 +6,14 @@ import { ThemeType } from '../../constants';
 import {
   setSecondaryHeadingFont,
   setButtonStyleFontWeight,
+  setThemeLineHeight,
 } from '../../utils/themeStyles';
 
 const displayStyle = (theme: ThemeType) => `
   color: ${theme.COLORS.primary};
   font-size: ${theme.TYPOGRAPHY.fontSize.display};
   font-weight: ${theme.TYPOGRAPHY.fontWeight.bold};
-  line-height: ${round(48 / 36, 2)};
+  line-height: ${setThemeLineHeight(theme, round(48 / 36, 2))};
   ${setSecondaryHeadingFont(theme)}
 `;
 
@@ -20,14 +21,14 @@ const headingStyle = (theme: ThemeType) => `
   color: ${theme.COLORS.primary};
   font-size: ${theme.TYPOGRAPHY.fontSize.heading};
   font-weight: ${theme.TYPOGRAPHY.fontWeight.bold};
-  line-height: ${round(40 / 24, 2)};
+  line-height: ${setThemeLineHeight(theme, round(40 / 24, 2))};
   ${setSecondaryHeadingFont(theme)}
 `;
 
 const titleStyle = (theme: ThemeType) => `
   color: ${theme.COLORS.primary};
   font-size: ${theme.TYPOGRAPHY.fontSize.title};
-  line-height: ${round(32 / 20, 2)};
+  line-height: ${setThemeLineHeight(theme, round(32 / 20, 2))};
   font-weight: ${theme.TYPOGRAPHY.fontWeight.bold};
   ${setSecondaryHeadingFont(theme)}
 `;
@@ -35,7 +36,7 @@ const titleStyle = (theme: ThemeType) => `
 export const baseBodyStyles = (theme: ThemeType) => `
   color: ${theme.COLORS.primaryTint1};
   font-size: ${theme.TYPOGRAPHY.fontSize.body};
-  line-height: ${round(28 / 16, 2)};
+  line-height: ${setThemeLineHeight(theme, round(28 / 16, 2))};
 `;
 
 const bodyStyle = (theme: ThemeType) => `
@@ -45,7 +46,7 @@ const bodyStyle = (theme: ThemeType) => `
 const captionStyle = (theme: ThemeType) => `
   color: ${theme.COLORS.primaryTint2};
   font-size: ${theme.TYPOGRAPHY.fontSize.caption};
-  line-height: ${round(24 / 14, 2)};
+  line-height: ${setThemeLineHeight(theme, round(24 / 14, 2))};
 `;
 
 const errorStyle = (theme: ThemeType) => `
@@ -61,13 +62,13 @@ const successStyle = (theme: ThemeType) => `
 const labelStyle = (theme: ThemeType) => `
   color: ${theme.COLORS.primaryTint1};
   font-size: ${theme.TYPOGRAPHY.fontSize.label};
-  line-height: ${round(20 / 12, 2)};
+  line-height: ${setThemeLineHeight(theme, round(20 / 12, 2))};
 `;
 
 const buttonStyle = (theme: ThemeType) => `
   color: ${theme.COLORS.primaryTint1};
   font-size: ${theme.TYPOGRAPHY.fontSize.button};
-  line-height: ${round(20 / 12, 2)};
+  line-height: ${setThemeLineHeight(theme, round(20 / 12, 2))};
   ${setButtonStyleFontWeight(theme)}
   letter-spacing: 1px;
   text-transform: uppercase;

--- a/src/shared-components/verificationMessages/style.ts
+++ b/src/shared-components/verificationMessages/style.ts
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
 import { SPACER } from '../../constants';
+import { setThemeLineHeight } from '../../utils/themeStyles';
 
 import { MessagesTypes } from '.';
 
@@ -24,5 +25,5 @@ export const MessageItem = styled.li<{ type: MessagesTypes }>`
       ? TYPOGRAPHY_STYLE.success(theme)
       : TYPOGRAPHY_STYLE.error(theme)}
 
-  line-height: 24px;
+  line-height: ${({ theme }) => setThemeLineHeight(theme, '24px')};
 `;

--- a/src/utils/themeStyles/index.ts
+++ b/src/utils/themeStyles/index.ts
@@ -37,3 +37,8 @@ export const setThemeLineHeight = (
   theme: ThemeType,
   primaryLineHeight: string | number,
 ) => (theme.__type === 'secondary' ? '1.4' : primaryLineHeight);
+
+export const setThemeFontWeight = (theme: ThemeType) =>
+  theme.__type === 'secondary'
+    ? theme.TYPOGRAPHY.fontWeight.normal
+    : theme.TYPOGRAPHY.fontWeight.bold;

--- a/src/utils/themeStyles/index.ts
+++ b/src/utils/themeStyles/index.ts
@@ -32,3 +32,8 @@ export const setButtonStyleFontWeight = (theme: ThemeType) =>
   theme.__type === 'primary'
     ? `font-weight: ${theme.TYPOGRAPHY.fontWeight.bold};`
     : '';
+
+export const setThemeLineHeight = (
+  theme: ThemeType,
+  primaryLineHeight: string | number,
+) => (theme.__type === 'secondary' ? '1.4' : primaryLineHeight);


### PR DESCRIPTION
### What & Why

1. Sets `line-height: 1.4` across all applicable `line-height` stylings.
    - Exceptions are of the type like the Dropdown `line-height`, which is set to a very large value to center the text. 
1. Removes `bold` font-weight from secondary header components (display/h1, heading/h2, title/h3).

### Next steps

Release as patch version in consumer apps, but also we're at the point where we should add visual regression testing for our secondary theme, too. So I will open up that PR as well.