### PR TITLE
[Components] Add background color to Indicator component

### DIFF
--- a/src/shared-components/indicator/__snapshots__/test.tsx.snap
+++ b/src/shared-components/indicator/__snapshots__/test.tsx.snap
@@ -25,7 +25,7 @@ exports[`<Indicator /> UI snapshots renders background color override 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border-radius: 8px;
+  border-radius: 50%;
 }
 
 .emotion-0 > div {
@@ -72,7 +72,7 @@ exports[`<Indicator /> UI snapshots renders the correct css with a number 1`] = 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border-radius: 8px;
+  border-radius: 50%;
 }
 
 .emotion-0 > div {
@@ -119,7 +119,7 @@ exports[`<Indicator /> UI snapshots renders the correct css with a text 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border-radius: 8px;
+  border-radius: 50%;
 }
 
 .emotion-0 > div {

--- a/src/shared-components/indicator/__snapshots__/test.tsx.snap
+++ b/src/shared-components/indicator/__snapshots__/test.tsx.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Indicator /> UI snapshots renders background color override 1`] = `
+.emotion-0 {
+  background-color: #332E54;
+  min-height: 16px;
+  height: 16px;
+  max-height: 16px;
+  text-align: center;
+  padding: 0 0.25rem;
+  min-width: 16px;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 8px;
+}
+
+.emotion-0 > div {
+  position: relative;
+  top: 1px;
+  color: #524D6E;
+  font-size: 0.75rem;
+  line-height: 1.67;
+  font-weight: bold;
+  color: #FFFFFF;
+}
+
+<div
+  class="emotion-0 emotion-1"
+>
+  <div>
+    3
+  </div>
+</div>
+`;
+
 exports[`<Indicator /> UI snapshots renders the correct css with a number 1`] = `
 .emotion-0 {
   background-color: #BD200F;

--- a/src/shared-components/indicator/index.tsx
+++ b/src/shared-components/indicator/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { COLORS_PROP_TYPES, ThemeColors } from 'src/constants';
+import { ThemeColors } from 'src/constants';
+import { useTheme } from 'emotion-theming';
 
 import { IndicatorContainer } from './style';
 
@@ -13,13 +14,19 @@ type IndicatorProps = {
  * Indicators are used in navigation to help with wayfinding for messages and notifications.
  * It can also be used for non-navigational purposes for information-intensive pages.
  */
-export const Indicator = ({ text, backgroundColor }: IndicatorProps) => (
-  <IndicatorContainer backgroundColor={backgroundColor}>
-    <div>{text}</div>
-  </IndicatorContainer>
-);
+export const Indicator = ({ text, backgroundColor }: IndicatorProps) => {
+  const theme = useTheme();
+
+  const bgColorWithTheme = backgroundColor || theme.COLORS.error;
+
+  return (
+    <IndicatorContainer backgroundColor={bgColorWithTheme}>
+      <div>{text}</div>
+    </IndicatorContainer>
+  );
+};
 
 Indicator.propTypes = {
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  backgroundColor: COLORS_PROP_TYPES,
+  backgroundColor: PropTypes.string,
 };

--- a/src/shared-components/indicator/index.tsx
+++ b/src/shared-components/indicator/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ThemeColors } from 'src/constants';
+import { COLORS_PROP_TYPES, ThemeColors } from 'src/constants';
 import { useTheme } from 'emotion-theming';
 
 import { IndicatorContainer } from './style';
@@ -28,5 +28,5 @@ export const Indicator = ({ text, backgroundColor }: IndicatorProps) => {
 
 Indicator.propTypes = {
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  backgroundColor: PropTypes.string,
+  backgroundColor: COLORS_PROP_TYPES,
 };

--- a/src/shared-components/indicator/index.tsx
+++ b/src/shared-components/indicator/index.tsx
@@ -11,10 +11,7 @@ type IndicatorProps = {
 
 /**
  * Indicators are used in navigation to help with wayfinding for messages and notifications.
- *
- * By adding an optional `backgroundColor` prop, the component can be reused for other purposes
- * such as indicating the number of dormant formulas a patient has on a prescription plan in the
- * Provider timeline.
+ * It can also be used for non-navigational purposes for information-intensive pages.
  */
 export const Indicator = ({ text, backgroundColor }: IndicatorProps) => (
   <IndicatorContainer backgroundColor={backgroundColor}>

--- a/src/shared-components/indicator/index.tsx
+++ b/src/shared-components/indicator/index.tsx
@@ -1,21 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { COLORS_PROP_TYPES, ThemeColors } from 'src/constants';
 
 import { IndicatorContainer } from './style';
 
 type IndicatorProps = {
   text: string | number;
+  backgroundColor?: ThemeColors;
 };
 
 /**
  * Indicators are used in navigation to help with wayfinding for messages and notifications.
  */
-export const Indicator = ({ text }: IndicatorProps) => (
-  <IndicatorContainer>
+export const Indicator = ({ text, backgroundColor }: IndicatorProps) => (
+  <IndicatorContainer backgroundColor={backgroundColor}>
     <div>{text}</div>
   </IndicatorContainer>
 );
 
 Indicator.propTypes = {
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  backgroundColor: COLORS_PROP_TYPES,
 };

--- a/src/shared-components/indicator/index.tsx
+++ b/src/shared-components/indicator/index.tsx
@@ -11,6 +11,10 @@ type IndicatorProps = {
 
 /**
  * Indicators are used in navigation to help with wayfinding for messages and notifications.
+ *
+ * By adding an optional `backgroundColor` prop, the component can be reused for other purposes
+ * such as indicating the number of dormant formulas a patient has on a prescription plan in the
+ * Provider timeline.
  */
 export const Indicator = ({ text, backgroundColor }: IndicatorProps) => (
   <IndicatorContainer backgroundColor={backgroundColor}>

--- a/src/shared-components/indicator/style.ts
+++ b/src/shared-components/indicator/style.ts
@@ -16,7 +16,7 @@ export const IndicatorContainer = styled.div<{ backgroundColor: ThemeColors }>`
   display: flex;
   justify-content: center;
   align-items: center;
-  border-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
+  border-radius: 50%;
 
   > div {
     position: relative;

--- a/src/shared-components/indicator/style.ts
+++ b/src/shared-components/indicator/style.ts
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { SPACER } from '../../constants';
+import { SPACER, ThemeColors } from '../../constants';
 
-export const IndicatorContainer = styled.div<{ backgroundColor?: string }>`
+export const IndicatorContainer = styled.div<{ backgroundColor: ThemeColors }>`
   background-color: ${(props) => props.backgroundColor};
   min-height: 16px;
   height: 16px;

--- a/src/shared-components/indicator/style.ts
+++ b/src/shared-components/indicator/style.ts
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { SPACER } from '../../constants';
+import { SPACER, ThemeColors } from '../../constants';
 
-export const IndicatorContainer = styled.div`
-  background-color: ${({ theme }) => theme.COLORS.error};
+export const IndicatorContainer = styled.div<{ backgroundColor?: ThemeColors }>`
+  background-color: ${({ theme, backgroundColor }) =>
+    backgroundColor || theme.COLORS.error};
   min-height: 16px;
   height: 16px;
   max-height: 16px;

--- a/src/shared-components/indicator/style.ts
+++ b/src/shared-components/indicator/style.ts
@@ -1,11 +1,10 @@
 import styled from '@emotion/styled';
 
 import { style as TYPOGRAPHY_STYLE } from '../typography';
-import { SPACER, ThemeColors } from '../../constants';
+import { SPACER } from '../../constants';
 
-export const IndicatorContainer = styled.div<{ backgroundColor?: ThemeColors }>`
-  background-color: ${({ theme, backgroundColor }) =>
-    backgroundColor || theme.COLORS.error};
+export const IndicatorContainer = styled.div<{ backgroundColor?: string }>`
+  background-color: ${(props) => props.backgroundColor};
   min-height: 16px;
   height: 16px;
   max-height: 16px;

--- a/src/shared-components/indicator/test.tsx
+++ b/src/shared-components/indicator/test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from 'src/tests/testingLibraryHelpers';
+import { primaryTheme } from 'src/constants/themes';
 
 import { Indicator } from './index';
 
@@ -13,6 +14,14 @@ describe('<Indicator />', () => {
 
     it('renders the correct css with a number', () => {
       const { container } = render(<Indicator text={3} />);
+
+      expect(container.firstElementChild).toMatchSnapshot();
+    });
+
+    it('renders background color override', () => {
+      const { container } = render(
+        <Indicator text={3} backgroundColor={primaryTheme.COLORS.primary} />,
+      );
 
       expect(container.firstElementChild).toMatchSnapshot();
     });

--- a/stories/indicator/index.stories.tsx
+++ b/stories/indicator/index.stories.tsx
@@ -11,6 +11,7 @@ import {
 } from '@storybook/addon-docs/blocks';
 import type { Meta } from '@storybook/react';
 import { BREAKPOINTS } from 'src/constants';
+import { useTheme } from 'emotion-theming';
 
 export const NumbersAndText = () => (
   <React.Fragment>
@@ -19,6 +20,12 @@ export const NumbersAndText = () => (
     <Indicator text={999} />
   </React.Fragment>
 );
+
+export const WithColor = () => {
+  const theme = useTheme();
+
+  return <Indicator text="+2" backgroundColor={theme.COLORS.primary} />;
+};
 
 export const WithControls = () => <Indicator text={text('text', '10')} />;
 


### PR DESCRIPTION
This PR updates `<Indicator />` to include a `backgroundColor` prop to allow the component to be reused for purposes outside of messages and notifications. 

<img width="1063" alt="Screen Shot 2021-01-26 at 3 47 53 PM" src="https://user-images.githubusercontent.com/48392176/105921578-dcba0b00-5fed-11eb-8451-517b13b06d9f.png">

Other: the border-radius has been hardcoded to 50% in order to show the component consistently between the primary and secondary themes.