### PR TITLE
[Theming] Hard-code label line-height for focus state compatibility

### DIFF
--- a/src/shared-components/typography/index.ts
+++ b/src/shared-components/typography/index.ts
@@ -63,7 +63,7 @@ const successStyle = (theme: ThemeType) => `
 const labelStyle = (theme: ThemeType) => `
   color: ${theme.COLORS.primaryTint1};
   font-size: ${theme.TYPOGRAPHY.fontSize.label};
-  line-height: ${setThemeLineHeight(theme, round(20 / 12, 2))};
+  line-height: ${round(20 / 12, 2)};
 `;
 
 const buttonStyle = (theme: ThemeType) => `


### PR DESCRIPTION
Undoes the `labelStyle` portion of the changes in #704 for better compat. 