### PR TITLE
Update theme of background-color on Avatar component to secondaryTint1

### DIFF
--- a/src/shared-components/avatar/__snapshots__/test.tsx.snap
+++ b/src/shared-components/avatar/__snapshots__/test.tsx.snap
@@ -4,7 +4,7 @@ exports[`<Avatar /> UI snapshot render with size large styles 1`] = `
 .emotion-0 {
   height: 80px;
   width: 80px;
-  background-color: #A6A1E2;
+  background-color: #B8B4E8;
   border-radius: 50%;
   overflow: hidden;
 }
@@ -20,7 +20,7 @@ exports[`<Avatar /> UI snapshot render with size medium styles 1`] = `
 .emotion-0 {
   height: 48px;
   width: 48px;
-  background-color: #A6A1E2;
+  background-color: #B8B4E8;
   border-radius: 50%;
   overflow: hidden;
 }
@@ -36,7 +36,7 @@ exports[`<Avatar /> UI snapshot renders the Avatar with default props 1`] = `
 .emotion-0 {
   height: 32px;
   width: 32px;
-  background-color: #A6A1E2;
+  background-color: #B8B4E8;
   border-radius: 50%;
   overflow: hidden;
 }

--- a/src/shared-components/avatar/style.ts
+++ b/src/shared-components/avatar/style.ts
@@ -19,7 +19,7 @@ const AvatarImage = styled.img<{
   avatarSize: 'small' | 'medium' | 'large';
 }>`
   ${determineSize}
-  background-color: ${({ theme }) => theme.COLORS.secondary};
+  background-color: ${({ theme }) => theme.COLORS.secondaryTint1};
   border-radius: 50%;
   overflow: hidden;
 `;


### PR DESCRIPTION
This updates the `background-color` of the Avatar component to use `secondaryTint1` rather than `secondary`. 