### PR TITLE
Add ability to change DialogModal background color

### DIFF
--- a/src/constants/themes/types.ts
+++ b/src/constants/themes/types.ts
@@ -11,7 +11,9 @@ type BoxShadows =
   | typeof primaryTheme['BOX_SHADOWS']
   | typeof secondaryTheme['BOX_SHADOWS'];
 
-type Colors = typeof primaryTheme['COLORS'] | typeof secondaryTheme['COLORS'];
+export type Colors =
+  | typeof primaryTheme['COLORS']
+  | typeof secondaryTheme['COLORS'];
 
 type Fonts = typeof primaryTheme['FONTS'] | typeof secondaryTheme['FONTS'];
 

--- a/src/shared-components/dialogModal/__snapshots__/test.tsx.snap
+++ b/src/shared-components/dialogModal/__snapshots__/test.tsx.snap
@@ -1,0 +1,121 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<DialogModal /> renders dialog modal with custom color 1`] = `
+.emotion-2 {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 999999;
+  background-color: rgba(58,55,75,0.7);
+  -webkit-transition: opacity 250ms cubic-bezier(0.075,0.82,0.165,1);
+  transition: opacity 250ms cubic-bezier(0.075,0.82,0.165,1);
+}
+
+.emotion-2.entering,
+.emotion-2.exiting,
+.emotion-2.exited {
+  opacity: 0;
+}
+
+.emotion-2.entered {
+  opacity: 1;
+}
+
+@media (min-width:768px) {
+  .emotion-2 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-flow: row nowrap;
+    -ms-flex-flow: row nowrap;
+    flex-flow: row nowrap;
+    -webkit-box-pack: center;
+    -webkit-justify-content: center;
+    -ms-flex-pack: center;
+    justify-content: center;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+  }
+}
+
+.emotion-0 {
+  width: 100%;
+  margin: 0 auto;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  border-top-left-radius: 32px;
+  border-top-right-radius: 32px;
+  box-shadow: 0px -8px 24px rgba(52,51,82,0.05);
+  background: #F8F8FA;
+  padding: 3.5rem 1.5rem 2rem;
+  overflow-y: auto;
+  max-height: 700px;
+  -webkit-transition: -webkit-transform 250ms cubic-bezier(0.075,0.82,0.165,1);
+  -webkit-transition: transform 250ms cubic-bezier(0.075,0.82,0.165,1);
+  transition: transform 250ms cubic-bezier(0.075,0.82,0.165,1);
+}
+
+.emotion-0.entered {
+  -webkit-transform: translateY(0%);
+  -ms-transform: translateY(0%);
+  transform: translateY(0%);
+}
+
+.emotion-0.entering,
+.emotion-0.exiting,
+.emotion-0.exited {
+  -webkit-transform: translateY(100%);
+  -ms-transform: translateY(100%);
+  transform: translateY(100%);
+}
+
+.emotion-0 p {
+  margin-bottom: 1.5rem;
+}
+
+.emotion-0 p:last-of-type {
+  margin-bottom: 2rem;
+}
+
+@media (min-width:768px) {
+  .emotion-0 {
+    position: relative;
+    width: 456px;
+    border-radius: 8px;
+    padding: 3.5rem;
+  }
+
+  .emotion-0.entering,
+  .emotion-0.exiting,
+  .emotion-0.exited {
+    -webkit-transform: translateY(40%);
+    -ms-transform: translateY(40%);
+    transform: translateY(40%);
+  }
+}
+
+<div
+  class="entering emotion-2 emotion-3"
+>
+  <span
+    hidden=""
+  />
+  <div
+    class="entering emotion-0 emotion-1"
+  >
+    <div>
+      Dialog Modal Children Content
+    </div>
+  </div>
+  <span
+    hidden=""
+  />
+</div>
+`;

--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -12,18 +12,18 @@ import {
   ModalTitle,
   CrossIconContainer,
 } from './style';
-import { Colors, primaryTheme, ThemeType } from '../../constants';
+import { Colors, primaryTheme, secondaryTheme } from '../../constants';
 
 export interface DialogModalProps {
+  /**
+   * DialogModal background color. Defaults to the current theme's `white` if not specified.
+   */
+  backgroundColor?: Colors['background'];
   /**
    * Dialog Modal content.
    * Must contain at least 1 button and is responsible for closing the modal.
    */
   children: React.ReactNode;
-  /**
-   * DialogModal background color. Defaults to the current theme's `white` if not specified.
-   */
-  modalColor?: Colors['background'];
   /**
    * If provided, DialogModal displays a Close Icon positioned top-right.
    * This function must contain the logic for closing the modal.
@@ -47,14 +47,14 @@ const getDomNode = () =>
  * Dialog Modals should always contain at least 1 button and the logic should close the modal at some point.
  */
 export const DialogModal = ({
+  backgroundColor,
   children,
-  modalColor,
   onCloseIconClick,
   title = '',
   ...rest
 }: DialogModalProps) => {
-  const theme: ThemeType = useTheme();
-  const modalColorWithTheme = modalColor || theme.COLORS.white;
+  const theme = useTheme();
+  const backgroundColorWithTheme = backgroundColor || theme.COLORS.white;
   const [isClosing, setIsClosing] = useState(false);
 
   const domNode = useRef<HTMLElement>(getDomNode());
@@ -96,7 +96,7 @@ export const DialogModal = ({
         <Overlay className={transitionState} {...rest}>
           <FocusScope contain restoreFocus autoFocus>
             <ModalContainer
-              backgroundColor={modalColorWithTheme}
+              backgroundColor={backgroundColorWithTheme}
               className={transitionState}
               onKeyDown={handleKeyDown}
             >
@@ -122,8 +122,11 @@ export const DialogModal = ({
 };
 
 DialogModal.propTypes = {
+  backgroundColor: PropTypes.oneOf([
+    primaryTheme.COLORS.background,
+    secondaryTheme.COLORS.background,
+  ]),
   children: PropTypes.node.isRequired,
-  modalColor: PropTypes.oneOf([primaryTheme.COLORS.background]),
   onCloseIconClick: PropTypes.func,
   title: PropTypes.string,
 };

--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -102,6 +102,7 @@ export const DialogModal = ({
             >
               {onCloseIconClick && (
                 <CrossIconContainer
+                  backgroundColor={backgroundColorWithTheme}
                   onClick={handleCloseIntent}
                   role="button"
                   tabIndex={0}

--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -3,6 +3,7 @@ import React, { useRef, useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { Transition } from 'react-transition-group';
 import { FocusScope } from '@react-aria/focus';
+import { useTheme } from 'emotion-theming';
 
 import { CrossIcon } from '../../icons';
 import {
@@ -11,6 +12,7 @@ import {
   ModalTitle,
   CrossIconContainer,
 } from './style';
+import { Colors, primaryTheme, ThemeType } from '../../constants';
 
 export interface DialogModalProps {
   /**
@@ -18,6 +20,10 @@ export interface DialogModalProps {
    * Must contain at least 1 button and is responsible for closing the modal.
    */
   children: React.ReactNode;
+  /**
+   * DialogModal background color. Defaults to the current theme's `white` if not specified.
+   */
+  modalColor?: Colors['background'];
   /**
    * If provided, DialogModal displays a Close Icon positioned top-right.
    * This function must contain the logic for closing the modal.
@@ -42,10 +48,13 @@ const getDomNode = () =>
  */
 export const DialogModal = ({
   children,
+  modalColor,
   onCloseIconClick,
   title = '',
   ...rest
 }: DialogModalProps) => {
+  const theme: ThemeType = useTheme();
+  const modalColorWithTheme = modalColor || theme.COLORS.white;
   const [isClosing, setIsClosing] = useState(false);
 
   const domNode = useRef<HTMLElement>(getDomNode());
@@ -87,6 +96,7 @@ export const DialogModal = ({
         <Overlay className={transitionState} {...rest}>
           <FocusScope contain restoreFocus autoFocus>
             <ModalContainer
+              backgroundColor={modalColorWithTheme}
               className={transitionState}
               onKeyDown={handleKeyDown}
             >
@@ -113,6 +123,7 @@ export const DialogModal = ({
 
 DialogModal.propTypes = {
   children: PropTypes.node.isRequired,
+  modalColor: PropTypes.oneOf([primaryTheme.COLORS.background]),
   onCloseIconClick: PropTypes.func,
   title: PropTypes.string,
 };

--- a/src/shared-components/dialogModal/style.ts
+++ b/src/shared-components/dialogModal/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import Typography from '../typography';
-import { MEDIA_QUERIES, SPACER, Z_SCALE } from '../../constants';
+import { Colors, MEDIA_QUERIES, SPACER, Z_SCALE } from '../../constants';
 
 export const Overlay = styled.div`
   position: fixed;
@@ -32,7 +32,7 @@ export const Overlay = styled.div`
 `;
 
 export const ModalContainer = styled.div<{
-  backgroundColor: string;
+  backgroundColor: Colors['background'] | Colors['white'];
 }>`
   width: 100%;
   margin: 0 auto;

--- a/src/shared-components/dialogModal/style.ts
+++ b/src/shared-components/dialogModal/style.ts
@@ -86,7 +86,9 @@ export const ModalTitle = styled(Typography.Title)`
   margin-bottom: ${SPACER.small};
 `;
 
-export const CrossIconContainer = styled.div`
+export const CrossIconContainer = styled.div<{
+  backgroundColor: Colors['background'] | Colors['white'];
+}>`
   position: absolute;
   top: 8px;
   right: 12px;
@@ -94,7 +96,7 @@ export const CrossIconContainer = styled.div`
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background: ${({ theme }) => theme.COLORS.white};
+  background: ${({ backgroundColor }) => backgroundColor};
   display: flex;
   flex-flow: row nowrap;
   justify-content: center;

--- a/src/shared-components/dialogModal/style.ts
+++ b/src/shared-components/dialogModal/style.ts
@@ -31,7 +31,9 @@ export const Overlay = styled.div`
   }
 `;
 
-export const ModalContainer = styled.div`
+export const ModalContainer = styled.div<{
+  backgroundColor: string;
+}>`
   width: 100%;
   margin: 0 auto;
   position: absolute;
@@ -41,7 +43,7 @@ export const ModalContainer = styled.div`
   border-top-left-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
   border-top-right-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
   box-shadow: ${({ theme }) => theme.BOX_SHADOWS.modal};
-  background: ${({ theme }) => theme.COLORS.white};
+  background: ${({ backgroundColor }) => backgroundColor};
   padding: ${SPACER.x4large} ${SPACER.large} ${SPACER.xlarge};
   overflow-y: auto;
   max-height: 700px;

--- a/src/shared-components/dialogModal/test.tsx
+++ b/src/shared-components/dialogModal/test.tsx
@@ -21,7 +21,7 @@ describe('<DialogModal />', () => {
 
   it('renders dialog modal with custom color', () => {
     const { container } = render(
-      <DialogModal modalColor={primaryTheme.COLORS.background}>
+      <DialogModal backgroundColor={primaryTheme.COLORS.background}>
         <div>{modalBody}</div>
       </DialogModal>,
     );

--- a/src/shared-components/dialogModal/test.tsx
+++ b/src/shared-components/dialogModal/test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { primaryTheme } from 'src/constants/themes';
 import { render } from 'src/tests/testingLibraryHelpers';
 
 import { DialogModal } from './index';
@@ -16,5 +17,16 @@ describe('<DialogModal />', () => {
 
     getAllByText(modalTitle);
     getAllByText(modalBody);
+  });
+
+  it('renders dialog modal with custom color', () => {
+    const { container } = render(
+      <DialogModal modalColor={primaryTheme.COLORS.background}>
+        <div>{modalBody}</div>
+      </DialogModal>,
+    );
+
+    // DOM Traversal necessary to find the React portal element
+    expect(container.parentNode?.lastChild).toMatchSnapshot();
   });
 });

--- a/src/shared-components/dialogModal/test.tsx
+++ b/src/shared-components/dialogModal/test.tsx
@@ -24,9 +24,9 @@ describe('<DialogModal />', () => {
       <DialogModal backgroundColor={primaryTheme.COLORS.background}>
         <div>{modalBody}</div>
       </DialogModal>,
+      { withPortalContainer: true },
     );
 
-    // DOM Traversal necessary to find the React portal element
-    expect(container.parentNode?.lastChild).toMatchSnapshot();
+    expect(container.firstElementChild).toMatchSnapshot();
   });
 });

--- a/src/tests/testingLibraryHelpers.tsx
+++ b/src/tests/testingLibraryHelpers.tsx
@@ -6,7 +6,23 @@ import { primaryTheme, ThemeType } from '../constants';
 
 interface RenderOptions extends ReactTestingLibrary.RenderOptions {
   theme?: ThemeType;
+  withPortalContainer?: boolean;
 }
+
+/**
+ * Many of our pages rely on components that make use of portals.
+ *
+ * Unit tests for components that do that **do not include such a portal
+ * container in their unit test** will have test failures on CI due to
+ * serialization order being off.
+ */
+const usePortalContainer = () => {
+  const portalContainer = document.createElement('div');
+  portalContainer.setAttribute('id', 'reactPortalSection');
+  document.body.appendChild(portalContainer);
+
+  return portalContainer;
+};
 
 // We customize @testing-library methods to bake-in theming and keep unit tests DRY.
 // We do not use ReactTestingLibrary.render(Component, { wrapper }) option because
@@ -17,11 +33,17 @@ const customRender = (
   Component: React.ReactElement,
   options: RenderOptions = {},
 ): ReactTestingLibrary.RenderResult => {
-  const { theme = primaryTheme, ...rest } = options;
+  const {
+    theme = primaryTheme,
+    container,
+    withPortalContainer,
+    ...rest
+  } = options;
 
   return ReactTestingLibrary.render(
     <ThemeProvider theme={theme}>{Component}</ThemeProvider>,
     {
+      container: withPortalContainer ? usePortalContainer() : container,
       ...rest,
     },
   );

--- a/stories/dialogModal/index.stories.tsx
+++ b/stories/dialogModal/index.stories.tsx
@@ -11,7 +11,7 @@ import {
   Title,
 } from '@storybook/addon-docs/blocks';
 import type { Meta } from '@storybook/react';
-import { ANIMATION } from 'src/constants';
+import { ANIMATION, primaryTheme } from 'src/constants';
 import { modalStoryDecoratorForChromatic } from 'stories/utils';
 
 const DIALOG_MODAL_STORY_ID_PREFIX = 'components-dialogmodal--';
@@ -82,6 +82,82 @@ export const DefaultOpened = () => {
     </React.Fragment>
   );
 };
+
+export const WithColor = () => {
+  const [openModal, setOpenModal] = useState(false);
+
+  return (
+    <React.Fragment>
+      <Button onClick={() => setOpenModal(true)}>open dialog modal</Button>
+
+      {openModal && (
+        <DialogModal
+          title="Heads up!"
+          modalColor={primaryTheme.COLORS.background}
+        >
+          <p>
+            This will remove the cleanser and moisturizer from your free trial,
+            too. Just the custom bottle will be sent your way!
+          </p>
+          <Button.Container>
+            <Button isFullWidth onClick={() => setOpenModal(false)}>
+              Yes, remove
+            </Button>
+            <Button
+              isFullWidth
+              onClick={() => setOpenModal(false)}
+              buttonType="tertiary"
+            >
+              never mind
+            </Button>
+          </Button.Container>
+        </DialogModal>
+      )}
+    </React.Fragment>
+  );
+};
+
+WithColor.id = `${DIALOG_MODAL_STORY_ID_PREFIX}with-color`;
+WithColor.paramters = {
+  chromatic: { disable: true },
+};
+
+export const WithColorOpened = () => {
+  const [openModal, setOpenModal] = useState(true);
+
+  return (
+    <React.Fragment>
+      <Button onClick={() => setOpenModal(true)}>open dialog modal</Button>
+
+      {openModal && (
+        <DialogModal
+          title="Heads up!"
+          modalColor={primaryTheme.COLORS.background}
+        >
+          <p>
+            This will remove the cleanser and moisturizer from your free trial,
+            too. Just the custom bottle will be sent your way!
+          </p>
+          <Button.Container>
+            <Button isFullWidth onClick={() => setOpenModal(false)}>
+              Yes, remove
+            </Button>
+            <Button
+              isFullWidth
+              onClick={() => setOpenModal(false)}
+              buttonType="tertiary"
+            >
+              never mind
+            </Button>
+          </Button.Container>
+        </DialogModal>
+      )}
+    </React.Fragment>
+  );
+};
+
+WithColorOpened.id = `${DIALOG_MODAL_STORY_ID_PREFIX}with-color`;
+WithColorOpened.decorators = [modalStoryDecoratorForChromatic];
 
 DefaultOpened.storyName = 'Default (Opened)';
 DefaultOpened.decorators = [modalStoryDecoratorForChromatic];
@@ -188,8 +264,13 @@ export default {
             <Story id={Default.id} />
           </Canvas>
           <Anchor storyId={Default.id} />
-          <Heading>With Close Icon</Heading>
+          <Heading>With Color</Heading>
+          <Anchor storyId={WithColor.id} />
+          <Canvas>
+            <Story id={WithColor.id} />
+          </Canvas>
           <Anchor storyId={WithCloseIcon.id} />
+          <Heading>With Close Icon</Heading>
           <Canvas>
             <Story id={WithCloseIcon.id} />
           </Canvas>

--- a/stories/dialogModal/index.stories.tsx
+++ b/stories/dialogModal/index.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from '@storybook/addon-docs/blocks';
 import { Meta } from '@storybook/react';
 import { useTheme } from 'emotion-theming';
-import { ANIMATION, primaryTheme } from 'src/constants';
+import { ANIMATION } from 'src/constants';
 import { modalStoryDecoratorForChromatic } from 'stories/utils';
 
 const DIALOG_MODAL_STORY_ID_PREFIX = 'components-dialogmodal--';
@@ -85,29 +85,30 @@ export const DefaultOpened = () => {
 };
 
 export const WithColor = () => {
-  const [openModal, setOpenModal] = useState(false);
+  const [withCloseIcon, setWithCloseIcon] = useState(false);
   const theme = useTheme();
 
   return (
     <React.Fragment>
-      <Button onClick={() => setOpenModal(true)}>open dialog modal</Button>
+      <Button onClick={() => setWithCloseIcon(true)}>open dialog modal</Button>
 
-      {openModal && (
+      {withCloseIcon && (
         <DialogModal
           title="Heads up!"
           backgroundColor={theme.COLORS.background}
+          onCloseIconClick={() => setWithCloseIcon(false)}
         >
           <p>
             This will remove the cleanser and moisturizer from your free trial,
             too. Just the custom bottle will be sent your way!
           </p>
           <Button.Container>
-            <Button isFullWidth onClick={() => setOpenModal(false)}>
+            <Button isFullWidth onClick={() => setWithCloseIcon(false)}>
               Yes, remove
             </Button>
             <Button
               isFullWidth
-              onClick={() => setOpenModal(false)}
+              onClick={() => setWithCloseIcon(false)}
               buttonType="tertiary"
             >
               never mind
@@ -125,28 +126,30 @@ WithColor.parameters = {
 };
 
 export const WithColorOpened = () => {
-  const [openModal, setOpenModal] = useState(true);
+  const [withCloseIcon, setWithCloseIcon] = useState(true);
+  const theme = useTheme();
 
   return (
     <React.Fragment>
-      <Button onClick={() => setOpenModal(true)}>open dialog modal</Button>
+      <Button onClick={() => setWithCloseIcon(true)}>open dialog modal</Button>
 
-      {openModal && (
+      {withCloseIcon && (
         <DialogModal
           title="Heads up!"
-          backgroundColor={primaryTheme.COLORS.background}
+          backgroundColor={theme.COLORS.background}
+          onCloseIconClick={() => setWithCloseIcon(false)}
         >
           <p>
             This will remove the cleanser and moisturizer from your free trial,
             too. Just the custom bottle will be sent your way!
           </p>
           <Button.Container>
-            <Button isFullWidth onClick={() => setOpenModal(false)}>
+            <Button isFullWidth onClick={() => setWithCloseIcon(false)}>
               Yes, remove
             </Button>
             <Button
               isFullWidth
-              onClick={() => setOpenModal(false)}
+              onClick={() => setWithCloseIcon(false)}
               buttonType="tertiary"
             >
               never mind

--- a/stories/dialogModal/index.stories.tsx
+++ b/stories/dialogModal/index.stories.tsx
@@ -10,7 +10,8 @@ import {
   Story,
   Title,
 } from '@storybook/addon-docs/blocks';
-import type { Meta } from '@storybook/react';
+import { Meta } from '@storybook/react';
+import { useTheme } from 'emotion-theming';
 import { ANIMATION, primaryTheme } from 'src/constants';
 import { modalStoryDecoratorForChromatic } from 'stories/utils';
 
@@ -85,6 +86,7 @@ export const DefaultOpened = () => {
 
 export const WithColor = () => {
   const [openModal, setOpenModal] = useState(false);
+  const theme = useTheme();
 
   return (
     <React.Fragment>
@@ -93,7 +95,7 @@ export const WithColor = () => {
       {openModal && (
         <DialogModal
           title="Heads up!"
-          modalColor={primaryTheme.COLORS.background}
+          backgroundColor={theme.COLORS.background}
         >
           <p>
             This will remove the cleanser and moisturizer from your free trial,
@@ -118,7 +120,7 @@ export const WithColor = () => {
 };
 
 WithColor.id = `${DIALOG_MODAL_STORY_ID_PREFIX}with-color`;
-WithColor.paramters = {
+WithColor.parameters = {
   chromatic: { disable: true },
 };
 
@@ -132,7 +134,7 @@ export const WithColorOpened = () => {
       {openModal && (
         <DialogModal
           title="Heads up!"
-          modalColor={primaryTheme.COLORS.background}
+          backgroundColor={primaryTheme.COLORS.background}
         >
           <p>
             This will remove the cleanser and moisturizer from your free trial,


### PR DESCRIPTION
Exposes a prop, `modalColor`, for the `DialogModal` component. This prop allows us to specify the background color of the modal. Currently, we are limited it to the theme's `background` color.

This change is necessitated by a [new design](https://www.figma.com/file/6QekjeGkdl6PUKNcdQA9mc/CS-and-provider-messages-workload-tweaks?node-id=54%3A0) for the "New Message" prompt in the patient dashboard.

I wasn't able to verify within the app via `yarn link` due to some [puzzling JS errors](https://curology.slack.com/archives/CU02B06GY/p1613010943108300), but Storybook looks 👍 to me.

To review the new stories in Chromatic, looks like I need to log in. Is this an IT helpdesk request? I don't see any Chromatic credentials in 1Password's Engineering vault.