### PR TITLE
[Theme] [Components] Add AnchorLinkButton, update TYPOGRAPHY_STYLE.link

### DIFF
--- a/src/constants/typography/primary.ts
+++ b/src/constants/typography/primary.ts
@@ -4,6 +4,7 @@ const fontSize = {
   title: '1.25rem', // 20px
   body: '1rem', // 16px
   caption: '0.875rem', // 14px
+  link: '0.875rem', // 14px;
   button: '0.75rem', // 12px
   label: '0.75rem', // 12px
 } as const;

--- a/src/constants/typography/secondary.ts
+++ b/src/constants/typography/secondary.ts
@@ -4,6 +4,7 @@ const fontSize = {
   title: '1.25rem', // 20px
   body: '1rem', // 16px
   caption: '0.875rem', // 14px
+  link: '0.875rem', // 14px;
   button: '0.875rem', // 14px
   label: '0.75rem', // 12px
 } as const;

--- a/src/shared-components/button/components/anchorLinkButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/anchorLinkButton/__snapshots__/test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AnchorLinkButton/> UI snapshots to double-check regressions renders with props 1`] = `
+.emotion-0 {
+  border-bottom: 1px solid currentColor;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  opacity: 1;
+  -webkit-transition: opacity 350ms;
+  transition: opacity 350ms;
+  background: transparent;
+  border: none;
+  padding: 0;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-text-decoration-skip-ink: none;
+  text-decoration-skip-ink: none;
+  font-size: 0.875rem;
+  border-radius: 4px;
+}
+
+.emotion-0:hover {
+  opacity: 0.6;
+  -webkit-transition: opacity 350ms;
+  transition: opacity 350ms;
+}
+
+.emotion-0:focus {
+  outline: none;
+  box-shadow: 0px 0px 0px 2px #FFFFFF,0px 0px 0px 4px #332E54;
+}
+
+<button
+  class="emotion-0"
+  type="button"
+>
+  Click me
+</button>
+`;

--- a/src/shared-components/button/components/anchorLinkButton/index.tsx
+++ b/src/shared-components/button/components/anchorLinkButton/index.tsx
@@ -19,7 +19,7 @@ type ButtonRefType =
   | undefined;
 
 /**
- * `AnchorLinkButton` will render an `anchor-link-like` button for triggering changes to the page, typically initiating modals.
+ * `AnchorLinkButton` will render an "anchor-link-like" button for triggering changes to the page, typically initiating modals.
  *
  * It should not be used for navigation: see `LinkButton` documentation for navigation functionality.
  *

--- a/src/shared-components/button/components/anchorLinkButton/index.tsx
+++ b/src/shared-components/button/components/anchorLinkButton/index.tsx
@@ -18,13 +18,6 @@ type ButtonRefType =
   | null
   | undefined;
 
-/**
- * `AnchorLinkButton` will render an `anchor-link-like' button for triggering changes to the page, typically initiating modals.
- *
- * It should not be used for navigation: see `LinkButton` documentation for navigation functionality.
- *
- * It is the only "Button" that does not extend the functionality/styling of our base Button component.
- */
 const AnchorLinkButton = (props: AnchorLinkButtonProps, ref: ButtonRefType) => {
   const { children, onClick } = props;
 
@@ -40,6 +33,13 @@ const AnchorLinkButton = (props: AnchorLinkButtonProps, ref: ButtonRefType) => {
   );
 };
 
+/**
+ * `AnchorLinkButton` will render an `anchor-link-like' button for triggering changes to the page, typically initiating modals.
+ *
+ * It should not be used for navigation: see `LinkButton` documentation for navigation functionality.
+ *
+ * It is the only "Button" that does not extend the functionality/styling of our base Button component.
+ */
 const AnchorLinkButtonWithRef = React.forwardRef(AnchorLinkButton);
 
 AnchorLinkButtonWithRef.propTypes = {

--- a/src/shared-components/button/components/anchorLinkButton/index.tsx
+++ b/src/shared-components/button/components/anchorLinkButton/index.tsx
@@ -18,33 +18,31 @@ type ButtonRefType =
   | null
   | undefined;
 
-const AnchorLinkButton = (props: AnchorLinkButtonProps, ref: ButtonRefType) => {
-  const { children, onClick } = props;
-
-  return (
-    <button
-      ref={ref}
-      css={Style.anchorLinkButton}
-      onClick={onClick}
-      type="button"
-    >
-      {children}
-    </button>
-  );
-};
-
 /**
- * `AnchorLinkButton` will render an `anchor-link-like' button for triggering changes to the page, typically initiating modals.
+ * `AnchorLinkButton` will render an `anchor-link-like` button for triggering changes to the page, typically initiating modals.
  *
  * It should not be used for navigation: see `LinkButton` documentation for navigation functionality.
  *
  * It is the only "Button" that does not extend the functionality/styling of our base Button component.
  */
-const AnchorLinkButtonWithRef = React.forwardRef(AnchorLinkButton);
+export const AnchorLinkButton = React.forwardRef(
+  (props: AnchorLinkButtonProps, ref: ButtonRefType) => {
+    const { children, onClick } = props;
 
-AnchorLinkButtonWithRef.propTypes = {
+    return (
+      <button
+        ref={ref}
+        css={Style.anchorLinkButton}
+        onClick={onClick}
+        type="button"
+      >
+        {children}
+      </button>
+    );
+  },
+);
+
+AnchorLinkButton.propTypes = {
   children: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
 };
-
-export { AnchorLinkButtonWithRef as AnchorLinkButton };

--- a/src/shared-components/button/components/anchorLinkButton/index.tsx
+++ b/src/shared-components/button/components/anchorLinkButton/index.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Style from './style';
+
+export interface AnchorLinkButtonProps {
+  /**
+   * Text to be displayed
+   */
+  children: string;
+  onClick: () => void;
+}
+
+type ButtonRefType =
+  | string
+  | ((instance: HTMLButtonElement | null) => void)
+  | React.RefObject<HTMLButtonElement>
+  | null
+  | undefined;
+
+/**
+ * `AnchorLinkButton` will render an `anchor-link-like' button for triggering changes to the page, typically initiating modals.
+ *
+ * It should not be used for navigation: see `LinkButton` documentation for navigation functionality.
+ *
+ * It is the only "Button" that does not extend the functionality/styling of our base Button component.
+ */
+const AnchorLinkButton = (props: AnchorLinkButtonProps, ref: ButtonRefType) => {
+  const { children, onClick } = props;
+
+  return (
+    <button
+      ref={ref}
+      css={Style.anchorLinkButton}
+      onClick={onClick}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+};
+
+const AnchorLinkButtonWithRef = React.forwardRef(AnchorLinkButton);
+
+AnchorLinkButtonWithRef.propTypes = {
+  children: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+export { AnchorLinkButtonWithRef as AnchorLinkButton };

--- a/src/shared-components/button/components/anchorLinkButton/style.ts
+++ b/src/shared-components/button/components/anchorLinkButton/style.ts
@@ -1,0 +1,23 @@
+import { css } from '@emotion/core';
+
+import { style as TYPOGRAPHY_STYLE } from '../../../typography';
+import { ThemeType } from '../../../../constants';
+
+/**
+ * TODO: Consolidate, fully, this specific link style with TYPOGRAPHY_STYLE.link,
+ * or otherwise figure out how to maintain meaningful distinction.
+ */
+const anchorLinkButton = (theme: ThemeType) => css`
+  ${TYPOGRAPHY_STYLE.link(theme)};
+  background: transparent;
+  border: none;
+  padding: 0;
+  text-decoration: underline;
+  text-decoration-skip-ink: none;
+  font-size: ${theme.TYPOGRAPHY.fontSize.link};
+  border-radius: ${theme.BORDER_RADIUS.small};
+`;
+
+export default {
+  anchorLinkButton,
+};

--- a/src/shared-components/button/components/anchorLinkButton/test.tsx
+++ b/src/shared-components/button/components/anchorLinkButton/test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from 'src/tests/testingLibraryHelpers';
+
+import { AnchorLinkButton } from './index';
+
+describe('<AnchorLinkButton/>', () => {
+  describe('UI snapshots to double-check regressions', () => {
+    it('renders with props', () => {
+      const { container } = render(
+        <AnchorLinkButton onClick={() => undefined}>Click me</AnchorLinkButton>,
+      );
+
+      expect(container.firstElementChild).toMatchSnapshot();
+    });
+  });
+});

--- a/src/shared-components/button/index.tsx
+++ b/src/shared-components/button/index.tsx
@@ -7,6 +7,7 @@ import Container from './shared-components/container';
 import { ButtonBase, ButtonText, ButtonContents } from './style';
 import withDeprecationWarning from '../../utils/withDeprecationWarning';
 import { LinkButton } from './components/linkButton';
+import { AnchorLinkButton } from './components/anchorLinkButton';
 import RoundButton from './components/roundButton';
 import { TextButton } from './components/textButton';
 import {
@@ -136,5 +137,5 @@ Button.propTypes = {
   textColor: PropTypes.string,
 };
 
-export { LinkButton, RoundButton, TextButton };
+export { AnchorLinkButton, LinkButton, RoundButton, TextButton };
 export default withDeprecationWarning(Button, deprecatedProperties);

--- a/src/shared-components/dialogModal/style.ts
+++ b/src/shared-components/dialogModal/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import Typography from '../typography';
+import { Typography } from '../typography';
 import { Colors, MEDIA_QUERIES, SPACER, Z_SCALE } from '../../constants';
 
 export const Overlay = styled.div`

--- a/src/shared-components/immersiveModal/style.ts
+++ b/src/shared-components/immersiveModal/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { buttonReset } from 'src/utils/styles/buttonReset';
 
-import Typography from '../typography';
+import { Typography } from '../typography';
 import {
   MEDIA_QUERIES,
   SPACER,

--- a/src/shared-components/index.ts
+++ b/src/shared-components/index.ts
@@ -4,6 +4,7 @@ export { Avatar } from './avatar';
 export { Banner } from './banner';
 export {
   default as Button,
+  AnchorLinkButton,
   RoundButton,
   LinkButton,
   TextButton,

--- a/src/shared-components/index.ts
+++ b/src/shared-components/index.ts
@@ -27,6 +27,6 @@ export { RadioButton } from './radioButton';
 export { Tabs } from './tabs';
 export { Toggle } from './toggle';
 export { Tooltip } from './tooltip';
-export { default as Typography, style as TYPOGRAPHY_STYLE } from './typography';
+export { Typography, style as TYPOGRAPHY_STYLE } from './typography';
 export { FadeInContainer, opacityInAnimationStyle } from './transitions';
 export { VerificationMessages } from './verificationMessages';

--- a/src/shared-components/typography/index.ts
+++ b/src/shared-components/typography/index.ts
@@ -119,7 +119,7 @@ const Caption = styled.p`
 const Display = styled.h1`
   ${({ theme }) => displayStyle(theme)}
 `;
-const ErrorComponent = styled.p`
+const Error = styled.p`
   ${({ theme }) => errorStyle(theme)}
 `;
 const Heading = styled.h2`
@@ -142,16 +142,10 @@ export const Typography = {
   Button,
   Caption,
   Display,
-  Error: ErrorComponent,
+  Error,
   Heading,
   Label,
   Link,
   Success,
   Title,
-
-  // Deprecated legacy names
-  LinkTag: Link,
-  ButtonText: Button,
-  SuccessText: Success,
-  ErrorText: ErrorComponent,
 } as const;

--- a/src/shared-components/typography/index.ts
+++ b/src/shared-components/typography/index.ts
@@ -75,7 +75,10 @@ const buttonStyle = (theme: ThemeType) => `
   text-transform: uppercase;
 `;
 
-const linkStyle = () => `
+/**
+ * TODO-MA: Add theme.TYPOGRAPHY.fontSize.link to guarantee font-size compatibility
+ */
+const linkStyle = (theme: ThemeType) => `
   border-bottom: 1px solid currentColor;
   cursor: pointer;
   text-decoration: none;
@@ -87,6 +90,11 @@ const linkStyle = () => `
   &:hover {
     opacity: 0.6;
     transition: opacity 350ms;
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: ${theme.BOX_SHADOWS.focus};
   }
 `;
 
@@ -122,7 +130,7 @@ const Label = styled.label`
   ${({ theme }) => labelStyle(theme)}
 `;
 const Link = styled.a`
-  ${linkStyle()}
+  ${({ theme }) => linkStyle(theme)}
 `;
 const Success = styled.p`
   ${({ theme }) => successStyle(theme)}

--- a/src/shared-components/typography/index.ts
+++ b/src/shared-components/typography/index.ts
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import round from 'lodash.round';
 
-import { withDeprecationWarning } from '../../utils';
 import { ThemeType } from '../../constants';
 import {
   setSecondaryHeadingFont,
@@ -156,14 +155,3 @@ export const Typography = {
   SuccessText: Success,
   ErrorText: ErrorComponent,
 } as const;
-
-const deprecatedProperties = {
-  LinkTag: 'LinkTag is deprecated. Use Link instead',
-  ButtonText: 'ButtonText is deprecated. Use Button instead',
-  SuccessText: 'SuccessText is deprecated. Use Success instead',
-  ErrorText: 'ErrorText is deprecated. Use Error instead',
-};
-
-const TYPOGRAPHY = withDeprecationWarning(Typography, deprecatedProperties);
-
-export default TYPOGRAPHY;

--- a/stories/button/anchorLinkButton/index.stories.tsx
+++ b/stories/button/anchorLinkButton/index.stories.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import {
+  ArgsTable,
+  Description,
+  Heading,
+  Source,
+  Stories,
+  Title,
+} from '@storybook/addon-docs/blocks';
+import { text } from '@storybook/addon-knobs';
+import { AnchorLinkButton } from 'src/shared-components';
+import type { Meta } from '@storybook/react';
+
+export const Default = () => (
+  <AnchorLinkButton onClick={() => undefined}>
+    Tips for taking photos
+  </AnchorLinkButton>
+);
+
+export const Focused = () => {
+  const anchorLinkButtonRef = React.useRef<HTMLButtonElement | null>(null);
+
+  React.useEffect(() => {
+    anchorLinkButtonRef.current?.focus();
+  }, []);
+
+  return (
+    <AnchorLinkButton ref={anchorLinkButtonRef} onClick={() => undefined}>
+      Tips for taking photos
+    </AnchorLinkButton>
+  );
+};
+
+export const WithControls = () => (
+  <AnchorLinkButton onClick={() => undefined}>
+    {text('children', 'Edit me!')}
+  </AnchorLinkButton>
+);
+
+WithControls.parameters = {
+  chromatic: { disable: true },
+};
+
+export default {
+  title: 'Components/Button/AnchorLinkButton',
+  component: AnchorLinkButton,
+  parameters: {
+    docs: {
+      page: () => (
+        <React.Fragment>
+          <Title />
+          <Description />
+          <Heading>Usage:</Heading>
+          <Source
+            language="tsx"
+            code={"import { AnchorLinkButton } from 'radiance-ui';"}
+          />
+          <Heading>Props:</Heading>
+          <ArgsTable />
+          <Stories includePrimary />
+        </React.Fragment>
+      ),
+    },
+  },
+} as Meta;

--- a/stories/button/anchorLinkButton/index.stories.tsx
+++ b/stories/button/anchorLinkButton/index.stories.tsx
@@ -11,6 +11,15 @@ import { text } from '@storybook/addon-knobs';
 import { AnchorLinkButton } from 'src/shared-components';
 import type { Meta } from '@storybook/react';
 
+import { BREAKPOINTS, SPACER } from '../../../src/constants';
+
+/**
+ * Adds padding to Focused story to capture focus state in Chromatic
+ */
+const AnchorLinkContainer = ({ children }: { children: JSX.Element }) => (
+  <div style={{ padding: SPACER.medium }}>{children}</div>
+);
+
 export const Default = () => (
   <AnchorLinkButton onClick={() => undefined}>
     Tips for taking photos
@@ -25,9 +34,11 @@ export const Focused = () => {
   }, []);
 
   return (
-    <AnchorLinkButton ref={anchorLinkButtonRef} onClick={() => undefined}>
-      Tips for taking photos
-    </AnchorLinkButton>
+    <AnchorLinkContainer>
+      <AnchorLinkButton ref={anchorLinkButtonRef} onClick={() => undefined}>
+        Tips for taking photos
+      </AnchorLinkButton>
+    </AnchorLinkContainer>
   );
 };
 
@@ -45,6 +56,7 @@ export default {
   title: 'Components/Button/AnchorLinkButton',
   component: AnchorLinkButton,
   parameters: {
+    chromatic: { viewports: [BREAKPOINTS.xs] },
     docs: {
       page: () => (
         <React.Fragment>


### PR DESCRIPTION
### CHANGELOG

1. This PR adds a new component, `AnchorLinkButton`, to match the spec of our Figma design for buttons that look like links:

<img width="479" alt="Screen Shot 2021-02-12 at 12 00 46 PM" src="https://user-images.githubusercontent.com/13544620/107804772-f798b900-6d29-11eb-83d9-e5555d477d43.png">

Here is the Review App story: https://curology-radiance-pr-778.herokuapp.com/?path=/story/components-button-anchorlinkbutton--default

This component does not currently exist in `radiance-ui`. Moreover, attempts to approximate this design using our existing `TYPOGRAPHY_STYLE.link` styling **do not match this spec**. It applies `border-bottom` rather than `text-decoration: underline`, among other things. We've started [surfacing issues around text placement between the two brands](https://github.com/curology/radiance-ui/pull/720#discussion_r568047415), and it seems ideal to rely on CSS to avoid more pixel displacement as we seek out solutions for those discrepancies.

The solution is to add an `AnchorLinkButton` nested under our `Button` components, since it is an underlying `<button>`. This PR also adds TODOs related to design discrepancies that will still exist after making these changes. 

2. This PR also adds `:focus` styling to `TYPOGRAPHY_STYLE.link` so that focus states appear with an on-brand styled outline, rather than the browser/page defaults.

Before:

<img width="42" alt="Screen Shot 2021-02-12 at 12 04 52 PM" src="https://user-images.githubusercontent.com/13544620/107805213-a5a46300-6d2a-11eb-8abf-35dbd15aec69.png">

<img width="178" alt="Screen Shot 2021-02-12 at 12 05 31 PM" src="https://user-images.githubusercontent.com/13544620/107805230-ab9a4400-6d2a-11eb-8385-b10b2a421ba4.png">

After: 

<img width="162" alt="Screen Shot 2021-02-12 at 12 09 53 PM" src="https://user-images.githubusercontent.com/13544620/107805662-4abf3b80-6d2b-11eb-9d3e-4b61b7a1439c.png">

<img width="151" alt="Screen Shot 2021-02-12 at 12 09 57 PM" src="https://user-images.githubusercontent.com/13544620/107805667-4d219580-6d2b-11eb-8ff5-807915626051.png">

### Release details

This PR requires releasing a new version of radiance due to the `TYPOGRAPHY_STYLE.link` breaking change: we will have to update the API in usage to pass a theme. 

We are also removing the deprecated properties handling in `src/shared-components/typography/index.ts`. When I checked this summer it was not in use (https://github.com/curology/radiance-ui/pull/274#issue-454519414). 