### PR TITLE
[Callout] Adds new 'success' type

### DIFF
--- a/src/shared-components/callout/index.tsx
+++ b/src/shared-components/callout/index.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useTheme } from 'emotion-theming';
 
 import Style from './style';
-import { COLORS_PROP_TYPES, ThemeColors } from '../../constants';
+import { COLORS_PROP_TYPES, ThemeColors, ThemeType } from '../../constants';
 
 export interface CalloutProps {
   /**
@@ -18,7 +18,36 @@ export interface CalloutProps {
    * Icon displayed inside the callout right aligned
    */
   icon?: React.ReactNode;
+  /**
+   * Custom prop to draw on preset Callout styles
+   */
+  type?: 'success';
 }
+
+/**
+ * Pulls a specific styling preset based on available theme values and `type`
+ */
+const getCalloutStyles = (
+  theme: ThemeType,
+  color?: ThemeColors,
+  type?: CalloutProps['type'],
+) => {
+  let backgroundColor;
+  let textColor;
+
+  if (type === 'success') {
+    backgroundColor = theme.COLORS.successLight;
+    textColor = theme.COLORS.success;
+  } else {
+    backgroundColor = theme.COLORS.infoLight;
+    textColor = color || theme.COLORS.primary;
+  }
+
+  return {
+    backgroundColor,
+    textColor,
+  };
+};
 
 /**
  * Callouts should be used to provide valuable information or additional context on a page. One of the best examples of a callout is for product recommendations.
@@ -27,14 +56,20 @@ export interface CalloutProps {
  *
  * If you use a glyph as callout icon the recommended dimesions are 48x48 pixels.
  */
-export const Callout = ({ children, color, icon = null }: CalloutProps) => {
+export const Callout = ({
+  children,
+  color,
+  icon = null,
+  type,
+}: CalloutProps) => {
   const theme = useTheme();
-  const colorWithTheme = color || theme.COLORS.primary;
+
+  const { backgroundColor, textColor } = getCalloutStyles(theme, color, type);
 
   return (
-    <Style.CalloutContainer>
-      <Style.Text textColor={colorWithTheme}>{children}</Style.Text>
-      {icon && <Style.Icon iconColor={colorWithTheme}>{icon}</Style.Icon>}
+    <Style.CalloutContainer backgroundColor={backgroundColor}>
+      <Style.Text textColor={textColor}>{children}</Style.Text>
+      {icon && <Style.Icon iconColor={textColor}>{icon}</Style.Icon>}
     </Style.CalloutContainer>
   );
 };

--- a/src/shared-components/callout/index.tsx
+++ b/src/shared-components/callout/index.tsx
@@ -32,15 +32,12 @@ const getCalloutStyles = (
   color?: ThemeColors,
   type?: CalloutProps['type'],
 ) => {
-  let backgroundColor;
-  let textColor;
+  let backgroundColor: ThemeColors = theme.COLORS.infoLight;
+  let textColor = color || theme.COLORS.primary;
 
   if (type === 'success') {
     backgroundColor = theme.COLORS.successLight;
     textColor = theme.COLORS.success;
-  } else {
-    backgroundColor = theme.COLORS.infoLight;
-    textColor = color || theme.COLORS.primary;
   }
 
   return {
@@ -63,7 +60,6 @@ export const Callout = ({
   type,
 }: CalloutProps) => {
   const theme = useTheme();
-
   const { backgroundColor, textColor } = getCalloutStyles(theme, color, type);
 
   return (

--- a/src/shared-components/callout/style.ts
+++ b/src/shared-components/callout/style.ts
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 
-import { SPACER } from '../../constants';
+import { SPACER, ThemeColors } from '../../constants';
 
 const ParentContainer = styled.div`
   max-width: 327px;
 `;
 
-const CalloutContainer = styled.div`
-  background-color: ${({ theme }) => theme.COLORS.infoLight};
+const CalloutContainer = styled.div<{ backgroundColor: ThemeColors }>`
+  background-color: ${({ backgroundColor }) => backgroundColor};
   padding: ${SPACER.medium};
   border-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
   display: flex;
@@ -17,14 +17,14 @@ const CalloutContainer = styled.div`
 `;
 
 const Text = styled.div<{
-  textColor: string;
+  textColor: ThemeColors;
 }>`
   color: ${({ textColor }) => textColor};
   font-size: ${({ theme }) => theme.TYPOGRAPHY.fontSize.caption};
 `;
 
 const Icon = styled.div<{
-  iconColor: string;
+  iconColor: ThemeColors;
 }>`
   margin-left: ${SPACER.small};
 

--- a/stories/callout/index.stories.tsx
+++ b/stories/callout/index.stories.tsx
@@ -13,7 +13,7 @@ import { BREAKPOINTS } from 'src/constants';
 import type { Meta } from '@storybook/react';
 import { useTheme } from 'emotion-theming';
 
-import { NeckGlyph } from '../../src/icons';
+import { LockGlyph, NeckGlyph } from '../../src/icons';
 
 export const Default = () => (
   <Callout.Container>
@@ -40,6 +40,14 @@ export const WithIcon = () => (
     <Callout icon={<NeckGlyph />}>
       <strong>We recommend</strong> this bundle because you indicated concern
       about <strong>dry skin</strong> and <strong>body acne</strong>
+    </Callout>
+  </Callout.Container>
+);
+
+export const SuccessCallout = () => (
+  <Callout.Container>
+    <Callout type="success" icon={<LockGlyph />}>
+      Your photos are private and are used by your provider to treat your skin
     </Callout>
   </Callout.Container>
 );


### PR DESCRIPTION
### What & Why

Some of our components have a `*type` paradigm that allows us to set specific styling properties, primarily our Buttons (`primary`/`secondary`/`tertiary`/`quaternary`).

This PR adds a `success` type to our Callout component--which pulls in our `success` and `successBackground` colors--to style the Callout. We do not expose styling of the component generally, and rather than overhaul the API to allow any set of colors, this PR prefers the course of adding specific presets for consistency in use. (We can also test here whether any combination is inaccessible, for which the `'success'` preset passes our built-in accessibility add-on).

Design:

<img width="346" alt="Screen Shot 2021-02-12 at 6 13 38 PM" src="https://user-images.githubusercontent.com/13544620/107835126-11ec8a00-6d5e-11eb-965a-588d45d36ed0.png">

Story:

<img width="345" alt="Screen Shot 2021-02-12 at 6 14 06 PM" src="https://user-images.githubusercontent.com/13544620/107835145-1f097900-6d5e-11eb-9bb1-fb0dde45af8d.png">
<img width="346" alt="Screen Shot 2021-02-12 at 6 14 02 PM" src="https://user-images.githubusercontent.com/13544620/107835146-1fa20f80-6d5e-11eb-9604-294911d8be44.png">

This PR adds a Storybook story for this version in order to test it via Chromatic, rather than add unit tests. 