### PR TITLE
Export constants

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './shared-components';
+export * from './constants';


### PR DESCRIPTION
The `package.json` `main` field points to `dist/bundle.js` and the `module` field points to `dist/bundle-es/index.js`. These are from `src/index.ts`. The `index.ts` [only has a single export](https://github.com/curology/radiance-ui/blob/3f57bb79718862749dfa87d938488fff0b58d3d9/src/index.ts#L1), which exports the components. It doesn't export constants or icons.

Since only components are exported, that's all you can access when using the package entrypoint. If you need to use constants or icons, you have to import the paths directly and build the library for that environment yourself. From a cursory glance it looks like the constants are already in the bundle, they just aren't being exported.

I think the constants and the icons should probably both be exported, because they're listed in the documentation as being part of the public API. However exporting the icons bumps the bundle size to 1.1 MB, which fails bundlewatch. I think it's probably fine if the common.js bundle is large since anyone using that is probably either using node or a build tool that can treeshake, but I'm curious to hear everyone else's thoughts.

The use case for me is to be able to easily access the constants from node, so I can write them to a JSON file that can then be used in PHP templates. Basically I'm trying to do this:

```js
const radiance = require('radiance');

const { primaryTheme, secondaryTheme } = radiance;

// ...
```