### PR TITLE
Account for border and margin for Accordion child elements

### DIFF
--- a/src/shared-components/accordion/index.tsx
+++ b/src/shared-components/accordion/index.tsx
@@ -63,9 +63,15 @@ export const Accordion = ({
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    const refStyles =
+      contentRef.current && window.getComputedStyle(contentRef.current);
+    const marginTopBottom = refStyles
+      ? parseFloat(refStyles.marginTop) + parseFloat(refStyles.marginBottom)
+      : 0;
+
     const nextHeight =
       isOpen && contentRef.current
-        ? `${contentRef.current.clientHeight}px`
+        ? `${contentRef.current.offsetHeight + marginTopBottom}px`
         : '0px';
 
     if (contentHeight !== nextHeight) {


### PR DESCRIPTION
## Background
If the child element put in `Accordion` component had `margin-top` or `margin-bottom` set, the `Accordion` would not account for that additional space when calculating its `max-height` while open. This caused issues where the inner content would be clipped when the `Accordion` was open.

## In this PR:
- Change `clientHeight` to `offsetHeight` to account for element border height.
- Add element's `margin-top` and `margin-bottom` into total height calculation.


## Example of clipping issue
![Screen Shot 2021-03-09 at 4 36 17 PM](https://user-images.githubusercontent.com/49820968/110701825-83292c80-81a6-11eb-9781-48028dbf07fb.png)

