### PR TITLE
[TypeScript] Export Type Definitions

### DIFF
--- a/src/shared-components/accordion/thumbnails/style.ts
+++ b/src/shared-components/accordion/thumbnails/style.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { style as TYPOGRAPHY_STYLE } from 'src/shared-components/typography';
+import { TYPOGRAPHY_STYLE } from 'src/shared-components/typography';
 import { SPACER } from 'src/constants';
 
 export const Container = styled.div`

--- a/src/shared-components/button/components/anchorLinkButton/style.ts
+++ b/src/shared-components/button/components/anchorLinkButton/style.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/core';
 
-import { style as TYPOGRAPHY_STYLE } from '../../../typography';
+import { TYPOGRAPHY_STYLE } from '../../../typography';
 import { ThemeType } from '../../../../constants';
 
 /**

--- a/src/shared-components/button/index.tsx
+++ b/src/shared-components/button/index.tsx
@@ -62,7 +62,7 @@ export interface ButtonProps {
  *
  * We should generally try to use the default button color when possible. Only for special cases should we need to use a different button color.
  */
-export const Button = ({
+const Button = ({
   buttonColor,
   buttonType = 'primary',
   children,
@@ -142,4 +142,6 @@ Button.propTypes = {
 };
 
 export { AnchorLinkButton, LinkButton, RoundButton, TextButton };
-export default withDeprecationWarning(Button, deprecatedProperties);
+const ButtonComponent = withDeprecationWarning(Button, deprecatedProperties);
+
+export { ButtonComponent as Button };

--- a/src/shared-components/button/style.ts
+++ b/src/shared-components/button/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import tinycolor from 'tinycolor2';
 
-import { style as TYPOGRAPHY_STYLE } from '../typography';
+import { TYPOGRAPHY_STYLE } from '../typography';
 import { ANIMATION, SPACER, ThemeColors, ThemeType } from '../../constants';
 import { textColorsAssociatedWithColors } from './constants';
 import {

--- a/src/shared-components/chip/style.ts
+++ b/src/shared-components/chip/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { style as TYPOGRAPHY_STYLE } from '../typography';
+import { TYPOGRAPHY_STYLE } from '../typography';
 import { SPACER, ThemeColors } from '../../constants';
 import { applyPrimaryThemeVerticalOffset } from '../../utils/themeStyles';
 

--- a/src/shared-components/field/style.ts
+++ b/src/shared-components/field/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { style as TYPOGRAPHY_STYLE } from '../typography';
+import { TYPOGRAPHY_STYLE } from '../typography';
 import { SPACER, ANIMATION, ThemeType } from '../../constants';
 import { MessagesTypes } from '../verificationMessages';
 import { setThemeLineHeight } from '../../utils/themeStyles';

--- a/src/shared-components/index.ts
+++ b/src/shared-components/index.ts
@@ -1,32 +1,26 @@
-export { Accordion } from './accordion';
-export { Alert } from './alert';
-export { Avatar } from './avatar';
-export { Banner } from './banner';
-export {
-  default as Button,
-  AnchorLinkButton,
-  RoundButton,
-  LinkButton,
-  TextButton,
-} from './button';
-export { Callout } from './callout';
-export { Carousel } from './carousel';
-export { Checkbox } from './checkbox';
-export { Chip } from './chip';
-export { Container } from './container';
-export { DialogModal } from './dialogModal';
-export { Dropdown } from './dropdown';
-export { Field } from './field';
-export { ImmersiveModal } from './immersiveModal';
-export { Indicator } from './indicator';
-export { LoadingSpinner } from './loadingSpinner';
-export { OffClickWrapper } from './offClickWrapper';
-export { OptionButton } from './optionButton';
-export { ProgressBar } from './progressBar';
-export { RadioButton } from './radioButton';
-export { Tabs } from './tabs';
-export { Toggle } from './toggle';
-export { Tooltip } from './tooltip';
-export { Typography, style as TYPOGRAPHY_STYLE } from './typography';
-export { FadeInContainer, opacityInAnimationStyle } from './transitions';
-export { VerificationMessages } from './verificationMessages';
+export * from './accordion';
+export * from './alert';
+export * from './avatar';
+export * from './banner';
+export * from './button';
+export * from './callout';
+export * from './carousel';
+export * from './checkbox';
+export * from './chip';
+export * from './container';
+export * from './dialogModal';
+export * from './dropdown';
+export * from './field';
+export * from './immersiveModal';
+export * from './indicator';
+export * from './loadingSpinner';
+export * from './offClickWrapper';
+export * from './optionButton';
+export * from './progressBar';
+export * from './radioButton';
+export * from './tabs';
+export * from './toggle';
+export * from './tooltip';
+export * from './typography';
+export * from './transitions';
+export * from './verificationMessages';

--- a/src/shared-components/indicator/style.ts
+++ b/src/shared-components/indicator/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { style as TYPOGRAPHY_STYLE } from '../typography';
+import { TYPOGRAPHY_STYLE } from '../typography';
 import { SPACER, ThemeColors } from '../../constants';
 import { applyPrimaryThemeVerticalOffset } from '../../utils/themeStyles';
 

--- a/src/shared-components/optionButton/style.ts
+++ b/src/shared-components/optionButton/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { style as TYPOGRAPHY_STYLE } from '../typography';
+import { TYPOGRAPHY_STYLE } from '../typography';
 import { ANIMATION, SPACER, ThemeType } from '../../constants';
 import { containerStyles, ContainerType } from '../container/style';
 import { setThemeLineHeight } from '../../utils/themeStyles';

--- a/src/shared-components/tabs/style.ts
+++ b/src/shared-components/tabs/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { buttonReset } from 'src/utils/styles/buttonReset';
 
-import { style as TYPOGRAPHY_STYLE } from '../typography';
+import { TYPOGRAPHY_STYLE } from '../typography';
 import { SPACER, ANIMATION, MEDIA_QUERIES } from '../../constants';
 
 export const TabsContainer = styled.div`

--- a/src/shared-components/typography/index.ts
+++ b/src/shared-components/typography/index.ts
@@ -97,7 +97,7 @@ const linkStyle = (theme: ThemeType) => `
   }
 `;
 
-export const style = {
+export const TYPOGRAPHY_STYLE = {
   display: displayStyle,
   heading: headingStyle,
   title: titleStyle,

--- a/src/shared-components/verificationMessages/style.ts
+++ b/src/shared-components/verificationMessages/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { style as TYPOGRAPHY_STYLE } from '../typography';
+import { TYPOGRAPHY_STYLE } from '../typography';
 import { SPACER } from '../../constants';
 import { setThemeLineHeight } from '../../utils/themeStyles';
 


### PR DESCRIPTION
Recently we adopted a pattern of always exporting type definitions so they could be used in consumer applications. However, since we were naming the exports in our actual exports file, none of those definitions were being exported from the same namespace, so importing the type definitions required deeply nested paths (e.g. `import type { ChipProps } from 'radiance-ui/lib/shared-components/chip';`). 

This PR exports everything exported from the component definition files so we have access to the TypeScript types as well. 

TODO: Make it impossible for folks to import exports from `style` files to avoid unintended use of Design System. 