### PR TITLE
[Bugfix] Add additional false check to icon props

### DIFF
--- a/src/shared-components/button/index.tsx
+++ b/src/shared-components/button/index.tsx
@@ -78,7 +78,7 @@ const Button = ({
   const theme = useTheme();
   const buttonColorWithTheme = buttonColor ?? theme.COLORS.primary;
   const loadingVal = loading === undefined ? isLoading : loading;
-  const hasIcon = isDefined(icon);
+  const hasIcon = isDefined(icon) && icon !== false;
 
   return (
     <ButtonBase

--- a/src/shared-components/callout/index.tsx
+++ b/src/shared-components/callout/index.tsx
@@ -57,7 +57,9 @@ export const Callout = ({ children, icon, type }: CalloutProps) => {
   return (
     <Style.CalloutContainer backgroundColor={backgroundColor}>
       <Style.Text textColor={textColor}>{children}</Style.Text>
-      {isDefined(icon) && <Style.Icon iconColor={textColor}>{icon}</Style.Icon>}
+      {isDefined(icon) && icon !== false && (
+        <Style.Icon iconColor={textColor}>{icon}</Style.Icon>
+      )}
     </Style.CalloutContainer>
   );
 };

--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -52,7 +52,10 @@ export const OptionButton = ({
     {...rest}
   >
     <FlexContainer>
-      {isDefined(icon) ? (
+      {/**
+       * We sometimes use && conditionals such that we are passing in `false` as a value
+       */}
+      {isDefined(icon) && icon !== false ? (
         <IconWrapper
           selected={selected}
           optionType={optionType}


### PR DESCRIPTION
We sometimes pass in `false` which is a valid `node` type (and the offending component is written in JS, not TS) when we really should be passing in `null` or `undefined`. 