### PR TITLE
[TypeScript] Use type-only import syntax

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -10,7 +10,7 @@ import {
   brandStyles,
 } from '../src/utils/injectGlobalStyles/style';
 import { primaryTheme, secondaryTheme } from '../src/constants/themes';
-import { ThemeType } from '../src/constants/themes/types';
+import type { ThemeType } from '../src/constants/themes/types';
 import { BREAKPOINTS } from '../src/constants';
 
 const ADDONS_REQUIRED_IN_OPTIONS = {

--- a/src/shared-components/accordion/index.tsx
+++ b/src/shared-components/accordion/index.tsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState, useRef } from 'react';
 import { useTheme } from 'emotion-theming';
 
-import { ThemeType } from '../../constants';
+import type { ThemeType } from '../../constants';
 import { ChevronIcon } from '../../icons';
 import { Thumbnails } from './thumbnails';
 import {

--- a/src/shared-components/alert/style.ts
+++ b/src/shared-components/alert/style.ts
@@ -3,7 +3,7 @@ import { keyframes } from '@emotion/core';
 
 import { MEDIA_QUERIES, SPACER, ANIMATION, ThemeType } from '../../constants';
 
-import { AlertType } from '.';
+import type { AlertType } from '.';
 
 export const AlertsContainer = styled.div`
   display: flex;

--- a/src/shared-components/banner/style.ts
+++ b/src/shared-components/banner/style.ts
@@ -3,7 +3,7 @@ import { buttonReset } from 'src/utils/styles/buttonReset';
 
 import { MEDIA_QUERIES, SPACER, ThemeType } from '../../constants';
 
-import { BannerType } from '.';
+import type { BannerType } from '.';
 
 const defaultAlertStyles = (theme: ThemeType) => `
   background-color: ${theme.COLORS.primary};

--- a/src/shared-components/button/components/anchorLinkButton/style.ts
+++ b/src/shared-components/button/components/anchorLinkButton/style.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 
 import { TYPOGRAPHY_STYLE } from '../../../typography';
-import { ThemeType } from '../../../../constants';
+import type { ThemeType } from '../../../../constants';
 
 /**
  * TODO: Consolidate, fully, this specific link style with TYPOGRAPHY_STYLE.link,

--- a/src/shared-components/button/components/linkButton/index.tsx
+++ b/src/shared-components/button/components/linkButton/index.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useTheme } from 'emotion-theming';
 
 import Container from '../../shared-components/container';
-import { ButtonType } from '../..';
+import type { ButtonType } from '../..';
 import { ButtonContents, ButtonText } from '../../style';
 import { linkButtonStyles } from './style';
 import { COLORS_PROP_TYPES, ThemeColors } from '../../../../constants';

--- a/src/shared-components/button/components/linkButton/style.ts
+++ b/src/shared-components/button/components/linkButton/style.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 
-import { ButtonType } from '../..';
-import { ThemeColors, ThemeType } from '../../../../constants';
+import type { ButtonType } from '../..';
+import type { ThemeColors, ThemeType } from '../../../../constants';
 import { baseButtonStyles } from '../../style';
 
 interface LinkButtonStylesProps {

--- a/src/shared-components/button/components/roundButton/index.tsx
+++ b/src/shared-components/button/components/roundButton/index.tsx
@@ -11,7 +11,7 @@ import {
   roundButtonTextStyles,
 } from './style';
 import withDeprecationWarning from '../../../../utils/withDeprecationWarning';
-import { ButtonTypeWithAction } from '../..';
+import type { ButtonTypeWithAction } from '../..';
 import {
   deprecatedProperties,
   isLoadingPropFunction,

--- a/src/shared-components/button/constants.ts
+++ b/src/shared-components/button/constants.ts
@@ -1,4 +1,4 @@
-import { ThemeType } from '../../constants';
+import type { ThemeType } from '../../constants';
 
 // TODO: potentially break out these pairings to the color constants file
 export const textColorsAssociatedWithColors = (theme: ThemeType) =>

--- a/src/shared-components/button/shared-components/loader/index.tsx
+++ b/src/shared-components/button/shared-components/loader/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import ButtonLoader from './style';
-import { ButtonTypeWithAction } from '../..';
-import { ThemeColors } from '../../../../constants';
+import type { ButtonTypeWithAction } from '../..';
+import type { ThemeColors } from '../../../../constants';
 
 export interface LoaderProps {
   buttonColor: ThemeColors;

--- a/src/shared-components/button/shared-components/loader/style.ts
+++ b/src/shared-components/button/shared-components/loader/style.ts
@@ -2,8 +2,8 @@ import styled from '@emotion/styled';
 import tinycolor from 'tinycolor2';
 import { keyframes } from '@emotion/core';
 
-import { ButtonTypeWithAction } from '../..';
-import { ThemeColors, ThemeType } from '../../../../constants';
+import type { ButtonTypeWithAction } from '../..';
+import type { ThemeColors, ThemeType } from '../../../../constants';
 import { primaryButtonLoadingBackgroundColor } from '../../../../utils/themeStyles';
 import { isDefined } from '../../../../utils/isDefined';
 

--- a/src/shared-components/button/style.ts
+++ b/src/shared-components/button/style.ts
@@ -11,7 +11,7 @@ import {
 } from '../../utils/themeStyles';
 import { isDefined } from '../../utils/isDefined';
 
-import { ButtonTypeWithAction } from '.';
+import type { ButtonTypeWithAction } from '.';
 
 const primaryStyles = (buttonColor: ThemeColors, theme: ThemeType) => {
   const backgroundColor = primaryButtonBackgroundColor(theme, buttonColor);

--- a/src/shared-components/callout/index.tsx
+++ b/src/shared-components/callout/index.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useTheme } from 'emotion-theming';
 
 import Style from './style';
-import { ThemeColors, ThemeType } from '../../constants';
+import type { ThemeColors, ThemeType } from '../../constants';
 import { isDefined } from '../../utils/isDefined';
 
 export interface CalloutProps {

--- a/src/shared-components/carousel/style.ts
+++ b/src/shared-components/carousel/style.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import { SPACER, ThemeType } from '../../constants';
 
-import { CarouselType } from '.';
+import type { CarouselType } from '.';
 
 export const Card = styled.div`
   width: 311px !important;

--- a/src/shared-components/chip/index.tsx
+++ b/src/shared-components/chip/index.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useTheme } from 'emotion-theming';
 
 import { ChipStyles, ChipText } from './style';
-import { ThemeColors, ThemeType } from '../../constants';
+import type { ThemeColors, ThemeType } from '../../constants';
 
 export type StatusType = 'primary' | 'success' | 'error' | 'white';
 

--- a/src/shared-components/loadingSpinner/index.tsx
+++ b/src/shared-components/loadingSpinner/index.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useTheme } from 'emotion-theming';
 
 import { LoadingSpinnerContainer, Overlay, Dot } from './style';
-import { ThemeColors } from '../../constants';
+import type { ThemeColors } from '../../constants';
 
 export interface LoadingSpinnerProps {
   /**

--- a/src/shared-components/loadingSpinner/style.ts
+++ b/src/shared-components/loadingSpinner/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { keyframes } from '@emotion/core';
 
-import { ThemeColors } from '../../constants';
+import type { ThemeColors } from '../../constants';
 
 const appPreloader = (translateX: string) => keyframes`
   0% { opacity: 0; transform: translate3d(${translateX}, 0, 0) }

--- a/src/shared-components/progressBar/style.ts
+++ b/src/shared-components/progressBar/style.ts
@@ -3,7 +3,7 @@ import { keyframes } from '@emotion/core';
 
 import { ANIMATION, PROGRESS_BAR_STATUS, ThemeType } from '../../constants';
 
-import { ProgressBarStatusType } from '.';
+import type { ProgressBarStatusType } from '.';
 
 const loadingProgression = keyframes`
   from { transform: translateX(-100%); }

--- a/src/shared-components/selectorButton/style.ts
+++ b/src/shared-components/selectorButton/style.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import { SPACER, ANIMATION, ThemeType } from '../../constants';
 
-import { SelectorType, SizeType, StyleType } from '.';
+import type { SelectorType, SizeType, StyleType } from '.';
 
 export const SelectorContainer = styled.div`
   align-items: center;

--- a/src/shared-components/typography/index.ts
+++ b/src/shared-components/typography/index.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import round from 'lodash.round';
 
-import { ThemeType } from '../../constants';
+import type { ThemeType } from '../../constants';
 import {
   setSecondaryHeadingFont,
   setButtonStyleFontWeight,

--- a/src/types/@emotion/styled/index.ts
+++ b/src/types/@emotion/styled/index.ts
@@ -1,4 +1,4 @@
-import { ThemeType } from '../../../constants/themes/types';
+import type { ThemeType } from '../../../constants/themes/types';
 /**
  * We rely on TypeScript path aliasing in order to decorate our `@emotion/styled` import
  * with built-in type information, so for this one import we need to use relative imports

--- a/src/types/emotion-theming/index.ts
+++ b/src/types/emotion-theming/index.ts
@@ -1,4 +1,4 @@
-import { ThemeType } from '../../constants/themes/types';
+import type { ThemeType } from '../../constants/themes/types';
 /**
  * We rely on TypeScript path aliasing in order to decorate our `emotion-theming` imports
  * with built-in type information, so for this one import we need to use relative imports

--- a/src/utils/injectGlobalStyles/style.ts
+++ b/src/utils/injectGlobalStyles/style.ts
@@ -1,6 +1,6 @@
 import 'focus-visible';
 
-import { ThemeType } from '../../constants';
+import type { ThemeType } from '../../constants';
 import { baseBodyStyles } from '../../shared-components/typography';
 
 /**

--- a/src/utils/themeStyles/index.ts
+++ b/src/utils/themeStyles/index.ts
@@ -1,7 +1,7 @@
 /**
  *  Any conditional style based on theme.__type should be on this file
  */
-import { ThemeColors, ThemeType } from '../../constants';
+import type { ThemeColors, ThemeType } from '../../constants';
 
 export const primaryButtonFontColor = (theme: ThemeType) =>
   theme.__type === 'primary' ? theme.COLORS.white : theme.COLORS.primary;

--- a/stories/button/index.stories.tsx
+++ b/stories/button/index.stories.tsx
@@ -11,7 +11,7 @@ import { text, select, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { Button } from 'src/shared-components';
 import type { Meta } from '@storybook/react';
-import { ThemeColors } from 'src/constants/themes/types';
+import type { ThemeColors } from 'src/constants/themes/types';
 import { useTheme } from 'emotion-theming';
 
 import { CheckmarkIcon } from '../../src/icons';

--- a/stories/button/linkButton/index.stories.tsx
+++ b/stories/button/linkButton/index.stories.tsx
@@ -11,7 +11,7 @@ import { text, select, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { LinkButton } from 'src/shared-components';
 import type { Meta } from '@storybook/react';
-import { ThemeColors } from 'src/constants/themes/types';
+import type { ThemeColors } from 'src/constants/themes/types';
 import { useTheme } from 'emotion-theming';
 
 export const Default = () => (

--- a/stories/button/roundButton/index.stories.tsx
+++ b/stories/button/roundButton/index.stories.tsx
@@ -13,7 +13,7 @@ import { RoundButton } from 'src/shared-components';
 import styled from '@emotion/styled';
 import { SPACER } from 'src/constants';
 import type { Meta } from '@storybook/react';
-import { ThemeColors } from 'src/constants/themes/types';
+import type { ThemeColors } from 'src/constants/themes/types';
 import { useTheme } from 'emotion-theming';
 
 import {

--- a/stories/container/index.stories.tsx
+++ b/stories/container/index.stories.tsx
@@ -8,7 +8,7 @@ import {
   Title,
 } from '@storybook/addon-docs/blocks';
 import { Container } from 'src/shared-components';
-import { ContainerType } from 'src/shared-components/container/style';
+import type { ContainerType } from 'src/shared-components/container/style';
 import type { Meta } from '@storybook/react';
 
 export const Default = () => (

--- a/stories/loadingSpinner/index.stories.tsx
+++ b/stories/loadingSpinner/index.stories.tsx
@@ -12,7 +12,7 @@ import {
   Title,
 } from '@storybook/addon-docs/blocks';
 import type { Meta } from '@storybook/react';
-import { ThemeColors } from 'src/constants/themes/types';
+import type { ThemeColors } from 'src/constants/themes/types';
 import { useTheme } from 'emotion-theming';
 
 const SpinnerContainer = styled.div`

--- a/stories/progressBar/index.stories.tsx
+++ b/stories/progressBar/index.stories.tsx
@@ -13,7 +13,7 @@ import {
   Title,
 } from '@storybook/addon-docs/blocks';
 import type { Meta } from '@storybook/react';
-import { ThemeColors } from 'src/constants/themes/types';
+import type { ThemeColors } from 'src/constants/themes/types';
 import { useTheme } from 'emotion-theming';
 
 const BarContainer = styled.div`


### PR DESCRIPTION
Will clean up the diff in #903, and appears to potentially be required for next-gen tooling like ESBuild: https://github.com/storybookjs/storybook/pull/14380/files