### PR TITLE
[Components] Remove lingering style exports

### DIFF
--- a/src/shared-components/container/index.ts
+++ b/src/shared-components/container/index.ts
@@ -1,1 +1,5 @@
-export { Container } from './style';
+import Style from './style';
+
+const { Container } = Style;
+
+export { Container };

--- a/src/shared-components/container/style.ts
+++ b/src/shared-components/container/style.ts
@@ -34,14 +34,14 @@ const getContainerTypeStyles = (theme: ThemeType, type?: ContainerType) => {
   }
 };
 
-export const containerStyles = (theme: ThemeType, type?: ContainerType) => `
+const containerStyles = (theme: ThemeType, type?: ContainerType) => `
   background-color: ${theme.COLORS.white};
   border: 1px solid ${theme.COLORS.border};
 
   ${getContainerTypeStyles(theme, type)}
 `;
 
-export const Section = styled.div`
+const Section = styled.div`
   padding: ${SPACER.large};
 
   ${MEDIA_QUERIES.lgUp} {
@@ -50,7 +50,7 @@ export const Section = styled.div`
   }
 `;
 
-export const Divider = styled.div`
+const Divider = styled.div`
   margin: 0 ${SPACER.large};
   border-bottom: ${({ theme }) => `1px solid ${theme.COLORS.border}`};
 
@@ -59,7 +59,7 @@ export const Divider = styled.div`
   }
 `;
 
-export const Image = styled.img`
+const Image = styled.img`
   width: 100%;
   overflow: hidden;
   object-fit: cover;
@@ -99,4 +99,4 @@ Container.propTypes = {
   type: PropTypes.oneOf(['message', 'clickable', 'none']),
 };
 
-export { Container };
+export default { containerStyles, Container };

--- a/src/shared-components/optionButton/style.ts
+++ b/src/shared-components/optionButton/style.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import { TYPOGRAPHY_STYLE } from '../typography';
 import { ANIMATION, SPACER, ThemeType } from '../../constants';
-import { containerStyles, ContainerType } from '../container/style';
+import ContainerStyle, { ContainerType } from '../container/style';
 import { setThemeLineHeight } from '../../utils/themeStyles';
 
 export interface BaseIconWrapperStylesProps {
@@ -46,18 +46,18 @@ const sharedContainerStyles = ({
   theme,
 }: SharedContainerStylesProps) => `
   border-radius: ${borderRadius ?? theme.BORDER_RADIUS.small};
-  ${containerStyles(theme, containerType)}
+  ${ContainerStyle.containerStyles(theme, containerType)}
   padding: ${SPACER.large};
   margin-bottom: ${SPACER.medium};
   width: 100%;
   text-align: left;
 `;
 
-export const DisplayContainer = styled.div<ContainerProps>`
+const DisplayContainer = styled.div<ContainerProps>`
   ${sharedContainerStyles}
 `;
 
-export const ClickableContainer = styled.button<ContainerProps>`
+const ClickableContainer = styled.button<ContainerProps>`
   ${sharedContainerStyles}
 
   :focus {


### PR DESCRIPTION
#903 removed most of our `export const` declarations in `style.ts` files, but it looks like I missed a few (besides the `button` ones purposefully left that way). This updates that. 