### PR TITLE
[Theme] Update Component Border Radius Props

### DIFF
--- a/src/shared-components/accordion/index.tsx
+++ b/src/shared-components/accordion/index.tsx
@@ -8,15 +8,9 @@ import { Thumbnails } from './thumbnails';
 import Style from './style';
 import { keyboardKeys } from '../../constants/keyboardKeys';
 
-export type BorderRadiusValues =
-  | valueof<ThemeType['BORDER_RADIUS']>
-  | '0.25rem'
-  | '0.5rem'
-  | '2rem';
-
 export interface AccordionProps {
   /** Sets the border-radius of Accordion.Container, AccordionBox, and TitleWrapper */
-  borderRadius?: BorderRadiusValues;
+  borderRadius?: keyof ThemeType['BORDER_RADIUS'];
   /** node(s) that will render only when expanded */
   children: React.ReactNode;
   /** when true, the accordion will be greyed out and the onClick prop will be disabled */
@@ -41,7 +35,7 @@ export interface AccordionProps {
  * The accordion component expands to reveal hidden information. They should be used when you need to fit a large amount of content but don't want to visually overwhelm the user.
  */
 export const Accordion = ({
-  borderRadius,
+  borderRadius = 'small',
   children,
   disabled = false,
   isOpen,

--- a/src/shared-components/accordion/style.ts
+++ b/src/shared-components/accordion/style.ts
@@ -94,7 +94,7 @@ const Truncate = styled.div`
  * component if opting out of default values.
  */
 const Container = styled.div<{
-  borderRadius: BorderRadiusValues;
+  borderRadius: keyof ThemeType['BORDER_RADIUS'];
 }>`
   box-shadow: ${({ theme }) => theme.BOX_SHADOWS.clickable};
   background-color: ${({ theme }) => theme.COLORS.white};

--- a/src/shared-components/accordion/style.ts
+++ b/src/shared-components/accordion/style.ts
@@ -2,8 +2,6 @@ import styled from '@emotion/styled';
 
 import { ANIMATION, BREAKPOINTS, SPACER, ThemeType } from '../../constants';
 
-import { BorderRadiusValues } from '.';
-
 const Content = styled.div`
   padding: ${SPACER.medium};
   width: 100%;
@@ -58,7 +56,7 @@ const ArrowWrapper = styled.div<{ rightAlign: boolean }>`
 `;
 
 const TitleWrapper = styled.div<{
-  borderRadius?: BorderRadiusValues;
+  borderRadius: keyof ThemeType['BORDER_RADIUS'];
   disabled: boolean;
   isOpen: boolean;
 }>`
@@ -75,9 +73,8 @@ const TitleWrapper = styled.div<{
     &:focus {
       ${({ borderRadius, isOpen, theme }) => {
         if (!isOpen) {
-          const borderRadiusValue = borderRadius ?? theme.BORDER_RADIUS.small;
-          return `border-bottom-left-radius: ${borderRadiusValue}; 
-                  border-bottom-right-radius: ${borderRadiusValue};`;
+          return `border-bottom-left-radius: ${theme.BORDER_RADIUS[borderRadius]}; 
+                  border-bottom-right-radius: ${theme.BORDER_RADIUS[borderRadius]};`;
         }
         return '';
       }}}
@@ -97,14 +94,14 @@ const Truncate = styled.div`
  * component if opting out of default values.
  */
 const Container = styled.div<{
-  borderRadius?: BorderRadiusValues;
+  borderRadius: BorderRadiusValues;
 }>`
   box-shadow: ${({ theme }) => theme.BOX_SHADOWS.clickable};
   background-color: ${({ theme }) => theme.COLORS.white};
   max-width: ${BREAKPOINTS.md}px;
 
   ${({ borderRadius, theme }) => {
-    const borderRadiusValue = borderRadius ?? theme.BORDER_RADIUS.small;
+    const borderRadiusValue = theme.BORDER_RADIUS[borderRadius];
 
     return `
     > div:first-of-type {

--- a/src/shared-components/accordion/style.ts
+++ b/src/shared-components/accordion/style.ts
@@ -73,8 +73,10 @@ const TitleWrapper = styled.div<{
     &:focus {
       ${({ borderRadius, isOpen, theme }) => {
         if (!isOpen) {
-          return `border-bottom-left-radius: ${theme.BORDER_RADIUS[borderRadius]}; 
-                  border-bottom-right-radius: ${theme.BORDER_RADIUS[borderRadius]};`;
+          const borderRadiusValue = theme.BORDER_RADIUS[borderRadius];
+
+          return `border-bottom-left-radius: ${borderRadiusValue}; 
+                  border-bottom-right-radius: ${borderRadiusValue};`;
         }
         return '';
       }}}
@@ -94,13 +96,13 @@ const Truncate = styled.div`
  * component if opting out of default values.
  */
 const Container = styled.div<{
-  borderRadius: keyof ThemeType['BORDER_RADIUS'];
+  borderRadius?: keyof ThemeType['BORDER_RADIUS'];
 }>`
   box-shadow: ${({ theme }) => theme.BOX_SHADOWS.clickable};
   background-color: ${({ theme }) => theme.COLORS.white};
   max-width: ${BREAKPOINTS.md}px;
 
-  ${({ borderRadius, theme }) => {
+  ${({ borderRadius = 'small', theme }) => {
     const borderRadiusValue = theme.BORDER_RADIUS[borderRadius];
 
     return `

--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -7,7 +7,7 @@ import { isDefined } from '../../utils/isDefined';
 import type { ThemeType } from '../../constants';
 
 export interface OptionButtonProps {
-  borderRadius?: valueof<ThemeType['BORDER_RADIUS']>;
+  borderRadius?: keyof ThemeType['BORDER_RADIUS'];
   buttonType?: 'primary' | 'secondary';
   /**
    * Show custom icon in the unselected state

--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -6,6 +6,8 @@ import { CheckmarkIcon } from '../../icons';
 import { isDefined } from '../../utils/isDefined';
 import type { ThemeType } from '../../constants';
 
+const DEFAULT_BORDER_RADIUS = 'small';
+
 export interface OptionButtonProps {
   borderRadius?: keyof ThemeType['BORDER_RADIUS'];
   buttonType?: 'primary' | 'secondary';
@@ -79,7 +81,7 @@ const OptionButtonContent = ({
  * than a functional button associated with form inputs
  */
 export const OptionButton = ({
-  borderRadius,
+  borderRadius = DEFAULT_BORDER_RADIUS,
   buttonType,
   icon,
   onClick,
@@ -113,6 +115,7 @@ export const OptionButton = ({
  * A presentational component to match the display of an OptionButton with an icon
  */
 export const OptionButtonNotClickable = ({
+  borderRadius = DEFAULT_BORDER_RADIUS,
   icon,
   optionType,
   subtext,
@@ -120,6 +123,7 @@ export const OptionButtonNotClickable = ({
   ...rest
 }: OptionButtonNotClickableProps) => (
   <Style.DisplayContainer
+    borderRadius={borderRadius}
     containerType="none"
     // eslint-disable-next-line react/jsx-props-no-spreading
     {...rest}

--- a/src/shared-components/optionButton/style.ts
+++ b/src/shared-components/optionButton/style.ts
@@ -32,7 +32,7 @@ const getTypeColor = (
 };
 
 interface ContainerProps {
-  borderRadius?: valueof<ThemeType['BORDER_RADIUS']>;
+  borderRadius: keyof ThemeType['BORDER_RADIUS'];
   containerType: ContainerType;
 }
 
@@ -45,7 +45,7 @@ const sharedContainerStyles = ({
   containerType,
   theme,
 }: SharedContainerStylesProps) => `
-  border-radius: ${borderRadius ?? theme.BORDER_RADIUS.small};
+  border-radius: ${theme.BORDER_RADIUS[borderRadius]};
   ${ContainerStyle.containerStyles(theme, containerType)}
   padding: ${SPACER.large};
   margin-bottom: ${SPACER.medium};


### PR DESCRIPTION
Our components allow string literal union props for border radius, but these are not theme-aware, meaning a theme that generally has no border-radius will not raise an error if we pass in a `'32px'` border-radius, for example.

This PR modifies the props to allow only the keys present in `theme.BORDER_RADIUS`, so that usage will also conform with that given theme. 