### PR TITLE
Update Agency Fonts + Story

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -46,7 +46,8 @@
   }
 
   @font-face {
-    font-family: 'quadrant-text-italic';
+    font-family: 'quadrant-text';
+    font-style: italic;
     src: url('https://assets.curology.com/fonts/quadrant-text/QuadrantText-RegularItalic.woff2')
       format('woff2');
   }
@@ -58,7 +59,8 @@
   }
 
   @font-face {
-    font-family: 'quadrant-text-mono-italic';
+    font-family: 'quadrant-text-mono';
+    font-style: italic;
     src: url('https://assets.curology.com/fonts/quadrant-mono/QuadrantTextMono-RegularItalic.woff2')
       format('woff2');
   }

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,9 +1,7 @@
 <style>
   @font-face {
     font-family: 'nocturno';
-    src: url('https://s3-us-west-1.amazonaws.com/fonts-california.typotheque.com/WF-029669-009918-001560-fa6dd062b0c32d6d9a297bd175bb0381.eot');
-    src: url('https://s3-us-west-1.amazonaws.com/fonts-california.typotheque.com/WF-029669-009918-001560-fa6dd062b0c32d6d9a297bd175bb0381.eot?#iefix')
-        format('embedded-opentype'),
+    src: url('https://s3-us-west-1.amazonaws.com/fonts-california.typotheque.com/WF-029669-009918-001560-fa6dd062b0c32d6d9a297bd175bb0381.eot'),
       url('https://s3-us-west-1.amazonaws.com/fonts-california.typotheque.com/WF-029669-009918-001560-fa6dd062b0c32d6d9a297bd175bb0381.woff2')
         format('woff2'),
       url('https://s3-us-west-1.amazonaws.com/fonts-california.typotheque.com/WF-029669-009918-001560-fa6dd062b0c32d6d9a297bd175bb0381.woff')
@@ -14,9 +12,7 @@
 
   @font-face {
     font-family: 'larssiet';
-    src: url('https://assets.curology.com/fonts/larssiet/34535B_1_0.eot');
-    src: url('https://assets.curology.com/fonts/larssiet/34535B_1_0.eot?#iefix')
-        format('embedded-opentype'),
+    src: url('https://assets.curology.com/fonts/larssiet/34535B_1_0.eot'),
       url('https://assets.curology.com/fonts/larssiet/34535B_1_0.woff2')
         format('woff2'),
       url('https://assets.curology.com/fonts/larssiet/34535B_1_0.woff')
@@ -28,9 +24,7 @@
   @font-face {
     font-family: 'larssiet';
     font-weight: bold;
-    src: url('https://assets.curology.com/fonts/larssiet/34535B_0_0.eot');
-    src: url('https://assets.curology.com/fonts/larssiet/34535B_0_0.eot?#iefix')
-        format('embedded-opentype'),
+    src: url('https://assets.curology.com/fonts/larssiet/34535B_0_0.eot'),
       url('https://assets.curology.com/fonts/larssiet/34535B_0_0.woff2')
         format('woff2'),
       url('https://assets.curology.com/fonts/larssiet/34535B_0_0.woff')
@@ -46,7 +40,8 @@
   }
 
   @font-face {
-    font-family: 'quadrant-text-italic';
+    font-family: 'quadrant-text';
+    font-style: italic;
     src: url('https://assets.curology.com/fonts/quadrant-text/QuadrantText-RegularItalic.woff2')
       format('woff2');
   }
@@ -58,7 +53,8 @@
   }
 
   @font-face {
-    font-family: 'quadrant-text-mono-italic';
+    font-family: 'quadrant-text-mono';
+    font-style: italic;
     src: url('https://assets.curology.com/fonts/quadrant-mono/QuadrantTextMono-RegularItalic.woff2')
       format('woff2');
   }

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,7 +1,9 @@
 <style>
   @font-face {
     font-family: 'nocturno';
-    src: url('https://s3-us-west-1.amazonaws.com/fonts-california.typotheque.com/WF-029669-009918-001560-fa6dd062b0c32d6d9a297bd175bb0381.eot'),
+    src: url('https://s3-us-west-1.amazonaws.com/fonts-california.typotheque.com/WF-029669-009918-001560-fa6dd062b0c32d6d9a297bd175bb0381.eot');
+    src: url('https://s3-us-west-1.amazonaws.com/fonts-california.typotheque.com/WF-029669-009918-001560-fa6dd062b0c32d6d9a297bd175bb0381.eot?#iefix')
+        format('embedded-opentype'),
       url('https://s3-us-west-1.amazonaws.com/fonts-california.typotheque.com/WF-029669-009918-001560-fa6dd062b0c32d6d9a297bd175bb0381.woff2')
         format('woff2'),
       url('https://s3-us-west-1.amazonaws.com/fonts-california.typotheque.com/WF-029669-009918-001560-fa6dd062b0c32d6d9a297bd175bb0381.woff')
@@ -12,7 +14,9 @@
 
   @font-face {
     font-family: 'larssiet';
-    src: url('https://assets.curology.com/fonts/larssiet/34535B_1_0.eot'),
+    src: url('https://assets.curology.com/fonts/larssiet/34535B_1_0.eot');
+    src: url('https://assets.curology.com/fonts/larssiet/34535B_1_0.eot?#iefix')
+        format('embedded-opentype'),
       url('https://assets.curology.com/fonts/larssiet/34535B_1_0.woff2')
         format('woff2'),
       url('https://assets.curology.com/fonts/larssiet/34535B_1_0.woff')
@@ -24,7 +28,9 @@
   @font-face {
     font-family: 'larssiet';
     font-weight: bold;
-    src: url('https://assets.curology.com/fonts/larssiet/34535B_0_0.eot'),
+    src: url('https://assets.curology.com/fonts/larssiet/34535B_0_0.eot');
+    src: url('https://assets.curology.com/fonts/larssiet/34535B_0_0.eot?#iefix')
+        format('embedded-opentype'),
       url('https://assets.curology.com/fonts/larssiet/34535B_0_0.woff2')
         format('woff2'),
       url('https://assets.curology.com/fonts/larssiet/34535B_0_0.woff')
@@ -40,8 +46,7 @@
   }
 
   @font-face {
-    font-family: 'quadrant-text';
-    font-style: italic;
+    font-family: 'quadrant-text-italic';
     src: url('https://assets.curology.com/fonts/quadrant-text/QuadrantText-RegularItalic.woff2')
       format('woff2');
   }
@@ -53,8 +58,7 @@
   }
 
   @font-face {
-    font-family: 'quadrant-text-mono';
-    font-style: italic;
+    font-family: 'quadrant-text-mono-italic';
     src: url('https://assets.curology.com/fonts/quadrant-mono/QuadrantTextMono-RegularItalic.woff2')
       format('woff2');
   }

--- a/stories/theme/fonts.stories.tsx
+++ b/stories/theme/fonts.stories.tsx
@@ -19,7 +19,19 @@ export const FONTS = () => {
         const fontsValue = theme.FONTS[fontsKey];
         return (
           <p key={fontsKey}>
-            <strong>{fontsKey}</strong>: {fontsValue}
+            <span style={{ fontFamily: fontsValue }}>
+              {fontsKey}: {fontsValue}
+            </span>
+            <br />
+            <span style={{ fontFamily: fontsValue, fontWeight: 'bold' }}>
+              {fontsKey} bold: {fontsValue}
+            </span>
+            <br />
+            <span style={{ fontFamily: fontsValue, fontStyle: 'italic' }}>
+              {fontsKey} italic: {fontsValue}
+            </span>
+            <br />
+            <br />
           </p>
         );
       })}


### PR DESCRIPTION
1. Updates our `theme.FONTS` story to show bold and italic versions of the different fonts.

Before (only shows actual values, nothing visual):

<img width="894" alt="Screen Shot 2021-05-10 at 11 29 25 AM" src="https://user-images.githubusercontent.com/13544620/117692810-00f7bd00-b183-11eb-8c73-858baac3caf6.png"> 


<img width="804" alt="Screen Shot 2021-05-10 at 11 29 20 AM" src="https://user-images.githubusercontent.com/13544620/117692807-005f2680-b183-11eb-9141-c9bd75067082.png">


After:

<img width="880" alt="Screen Shot 2021-05-10 at 11 29 00 AM" src="https://user-images.githubusercontent.com/13544620/117692870-0f45d900-b183-11eb-9441-13ef443063c8.png">
<img width="926" alt="Screen Shot 2021-05-10 at 11 29 07 AM" src="https://user-images.githubusercontent.com/13544620/117692875-10770600-b183-11eb-9ab2-dc58deceef97.png">

___

2. Fixes how we're setting up our `quadrant-text` fonts with italics. `font-style: italic` should be used so that when there are italics on the page, the correct font is requested. If this isn't set up correctly, the browser tries its best to approximate an italic font on its own.

Before:

<img width="669" alt="Screen Shot 2021-05-10 at 11 43 35 AM" src="https://user-images.githubusercontent.com/13544620/117694754-1e2d8b00-b185-11eb-92fd-e01dd6ee9ae9.png">

After:

<img width="643" alt="Screen Shot 2021-05-10 at 11 39 59 AM" src="https://user-images.githubusercontent.com/13544620/117694773-22f23f00-b185-11eb-9bef-40fe1d355bad.png">

You'll also notice that fetching the italic font also means we're rendering the actual font we want to for the `quadrant-text` fonts:

Without change:

<img width="941" alt="Screen Shot 2021-05-10 at 11 49 04 AM" src="https://user-images.githubusercontent.com/13544620/117695339-bdeb1900-b185-11eb-8d3c-737c79600b51.png">

With change:
<img width="926" alt="Screen Shot 2021-05-10 at 11 29 07 AM" src="https://user-images.githubusercontent.com/13544620/117695359-c3486380-b185-11eb-85c7-40e616e03cea.png">

The true italic font is much more elegant than the Browser approximation, which mostly just applies some slant to the base font. 

### TODO

Investigate & update our `grey-ll` usage to match this behavior, since the provided stylesheet does not take into account this `font-weight`/`font-style` browser behavior, treating it as an entirely separate font. 
