### PR TITLE
[TypeScript] Prefer React.FC For Component Typing

### DIFF
--- a/src/constants/themes/types.ts
+++ b/src/constants/themes/types.ts
@@ -7,14 +7,13 @@ type BorderRadius =
   | typeof primaryTheme['BORDER_RADIUS']
   | typeof secondaryTheme['BORDER_RADIUS'];
 
-export const BORDER_RADIUS_PROP_TYPES = PropTypes.oneOf([
-  ...(Object.keys(primaryTheme.BORDER_RADIUS) as Array<
+export const BORDER_RADIUS_PROP_TYPES = PropTypes.oneOf(
+  // Since usage relies on keys, we only need to pull
+  // the keys from one theme rather than all of them
+  Object.keys(primaryTheme.BORDER_RADIUS) as Array<
     keyof typeof primaryTheme.BORDER_RADIUS
-  >),
-  ...(Object.keys(secondaryTheme.BORDER_RADIUS) as Array<
-    keyof typeof secondaryTheme.BORDER_RADIUS
-  >),
-]);
+  >,
+);
 
 type BoxShadows =
   | typeof primaryTheme['BOX_SHADOWS']

--- a/src/constants/themes/types.ts
+++ b/src/constants/themes/types.ts
@@ -7,6 +7,15 @@ type BorderRadius =
   | typeof primaryTheme['BORDER_RADIUS']
   | typeof secondaryTheme['BORDER_RADIUS'];
 
+export const BORDER_RADIUS_PROP_TYPES = PropTypes.oneOf([
+  ...(Object.keys(primaryTheme.BORDER_RADIUS) as Array<
+    keyof typeof primaryTheme.BORDER_RADIUS
+  >),
+  ...(Object.keys(secondaryTheme.BORDER_RADIUS) as Array<
+    keyof typeof secondaryTheme.BORDER_RADIUS
+  >),
+]);
+
 type BoxShadows =
   | typeof primaryTheme['BOX_SHADOWS']
   | typeof secondaryTheme['BOX_SHADOWS'];

--- a/src/shared-components/accordion/index.tsx
+++ b/src/shared-components/accordion/index.tsx
@@ -6,8 +6,7 @@ import { ChevronIcon } from '../../icons';
 import { Thumbnails } from './thumbnails';
 import Style from './style';
 import { keyboardKeys } from '../../constants/keyboardKeys';
-
-import type { ThemeType } from '../../constants';
+import { BORDER_RADIUS_PROP_TYPES, ThemeType } from '../../constants';
 
 export interface AccordionProps {
   /** Sets the border-radius of Accordion.Container, AccordionBox, and TitleWrapper */
@@ -30,12 +29,19 @@ export interface AccordionProps {
   title: React.ReactNode;
 }
 
+interface Accordion extends React.FC<AccordionProps> {
+  Container: typeof Style.Container;
+  Content: typeof Style.Content;
+  Thumbnails: typeof Thumbnails;
+  Truncate: typeof Style.Truncate;
+}
+
 /**
  * A list of items that allows each item's content to be expanded and collapsed by clicking its title bar.
  *
  * The accordion component expands to reveal hidden information. They should be used when you need to fit a large amount of content but don't want to visually overwhelm the user.
  */
-export const Accordion = ({
+export const Accordion: Accordion = ({
   borderRadius = 'small',
   children,
   disabled = false,
@@ -44,7 +50,7 @@ export const Accordion = ({
   onClick,
   rightAlignArrow = false,
   title,
-}: AccordionProps) => {
+}) => {
   const theme = useTheme();
   const [contentHeight, setContentHeight] = useState('0px');
 
@@ -113,7 +119,7 @@ Accordion.Thumbnails = Thumbnails;
 Accordion.Truncate = Style.Truncate;
 
 Accordion.propTypes = {
-  borderRadius: PropTypes.string,
+  borderRadius: BORDER_RADIUS_PROP_TYPES,
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   isOpen: PropTypes.bool.isRequired,

--- a/src/shared-components/accordion/thumbnails/index.tsx
+++ b/src/shared-components/accordion/thumbnails/index.tsx
@@ -7,7 +7,7 @@ export interface ThumbnailsProps {
   photoSrcs: Array<string>;
 }
 
-export const Thumbnails = ({ photoSrcs }: ThumbnailsProps) => {
+export const Thumbnails: React.FC<ThumbnailsProps> = ({ photoSrcs }) => {
   /**
    * Thumbnail images set with empty alt text because they are decorative.
    * Accessible Accordion functionality does not depend on these thumbnails.

--- a/src/shared-components/alert/index.tsx
+++ b/src/shared-components/alert/index.tsx
@@ -53,7 +53,7 @@ interface Alert extends React.FC<AlertProps> {
  *
  * All alerts are dimissable by clicking on them. However, you can use the `duration` prop to determine if the alert is sticky or dismissed on a timer (in units of seconds).
  */
-export const Alert: React.FC<AlertProps> = (alertProps) => {
+export const Alert: Alert = (alertProps) => {
   const {
     avatarSrc = '',
     content,
@@ -139,6 +139,8 @@ export const Alert: React.FC<AlertProps> = (alertProps) => {
     </Style.AlertContainer>
   );
 };
+
+Alert.Container = Style.AlertsContainer;
 
 Alert.propTypes = {
   avatarSrc: PropTypes.string,

--- a/src/shared-components/alert/index.tsx
+++ b/src/shared-components/alert/index.tsx
@@ -30,6 +30,10 @@ export interface AlertProps {
   [key: string]: unknown;
 }
 
+interface Alert extends React.FC<AlertProps> {
+  Container: typeof Style.AlertsContainer;
+}
+
 /**
  * Alerts should be used to show notifications or messages from (providers, support, or system).
  *
@@ -49,7 +53,7 @@ export interface AlertProps {
  *
  * All alerts are dimissable by clicking on them. However, you can use the `duration` prop to determine if the alert is sticky or dismissed on a timer (in units of seconds).
  */
-export const Alert = (alertProps: AlertProps) => {
+export const Alert: React.FC<AlertProps> = (alertProps) => {
   const {
     avatarSrc = '',
     content,
@@ -135,10 +139,6 @@ export const Alert = (alertProps: AlertProps) => {
     </Style.AlertContainer>
   );
 };
-
-Alert.Container = ({ children }: { children: React.ReactNode }) => (
-  <Style.AlertsContainer>{children}</Style.AlertsContainer>
-);
 
 Alert.propTypes = {
   avatarSrc: PropTypes.string,

--- a/src/shared-components/avatar/index.tsx
+++ b/src/shared-components/avatar/index.tsx
@@ -9,7 +9,7 @@ export interface AvatarProps {
   src: string;
 }
 
-export const Avatar = ({ alt, size = 'small', src }: AvatarProps) => (
+export const Avatar: React.FC<AvatarProps> = ({ alt, size = 'small', src }) => (
   <Style.AvatarImage alt={alt} avatarSize={size} src={src} />
 );
 

--- a/src/shared-components/banner/index.tsx
+++ b/src/shared-components/banner/index.tsx
@@ -27,7 +27,11 @@ export interface BannerProps {
  *
  * Banners are not dismissable.
  */
-export const Banner = ({ content, onClick, type = 'default' }: BannerProps) => {
+export const Banner: React.FC<BannerProps> = ({
+  content,
+  onClick,
+  type = 'default',
+}) => {
   const theme = useTheme();
   const Icon = bannerIconMapping[type];
 

--- a/src/shared-components/button/components/anchorLinkButton/index.tsx
+++ b/src/shared-components/button/components/anchorLinkButton/index.tsx
@@ -25,22 +25,22 @@ type ButtonRefType =
  *
  * It is the only "Button" that does not extend the functionality/styling of our base Button component.
  */
-export const AnchorLinkButton = React.forwardRef(
-  (props: AnchorLinkButtonProps, ref: ButtonRefType) => {
-    const { children, onClick } = props;
+export const AnchorLinkButton: React.ForwardRefExoticComponent<
+  AnchorLinkButtonProps & React.RefAttributes<HTMLButtonElement>
+> = React.forwardRef((props: AnchorLinkButtonProps, ref: ButtonRefType) => {
+  const { children, onClick } = props;
 
-    return (
-      <button
-        ref={ref}
-        css={Style.anchorLinkButton}
-        onClick={onClick}
-        type="button"
-      >
-        {children}
-      </button>
-    );
-  },
-);
+  return (
+    <button
+      ref={ref}
+      css={Style.anchorLinkButton}
+      onClick={onClick}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+});
 
 AnchorLinkButton.propTypes = {
   children: PropTypes.string.isRequired,

--- a/src/shared-components/button/components/button/index.tsx
+++ b/src/shared-components/button/components/button/index.tsx
@@ -47,6 +47,10 @@ export interface ButtonProps {
   [key: string]: unknown;
 }
 
+interface Button extends React.FC<ButtonProps> {
+  Container: typeof Container;
+}
+
 /**
  * Buttons can be used as a main call-to-action (CTA). Try to avoid using buttons of the same `buttonType` next to each other since we want to guide the user towards one option.
  *
@@ -54,7 +58,7 @@ export interface ButtonProps {
  *
  * We should generally try to use the default button color when possible. Only for special cases should we need to use a different button color.
  */
-const Button = ({
+const Button: Button = ({
   buttonColor,
   buttonType = 'primary',
   children,
@@ -66,7 +70,7 @@ const Button = ({
   onClick,
   textColor,
   ...rest
-}: ButtonProps) => {
+}) => {
   const theme = useTheme();
   const buttonColorWithTheme = buttonColor ?? theme.COLORS.primary;
   const loadingVal = loading === undefined ? isLoading : loading;
@@ -130,7 +134,7 @@ Button.propTypes = {
   isLoading: PropTypes.bool,
   loading: isLoadingPropFunction,
   onClick: PropTypes.func,
-  textColor: PropTypes.string,
+  textColor: COLORS_PROP_TYPES,
 };
 
 const ButtonComponent = withDeprecationWarning(Button, deprecatedProperties);

--- a/src/shared-components/button/components/linkButton/index.tsx
+++ b/src/shared-components/button/components/linkButton/index.tsx
@@ -11,9 +11,9 @@ import type { ButtonType } from '../../types';
 
 export interface LinkButtonProps {
   /**
-   * Specifies the tag or element to be rendered
+   * Specifies the tag or element to be rendered, like an 'a' or 'span'
    */
-  as?: 'a' | React.ElementType;
+  as?: string | React.ElementType;
   buttonColor?: ThemeColors;
   /**
    * Determines the button's main style theme
@@ -32,6 +32,10 @@ export interface LinkButtonProps {
   [key: string]: unknown;
 }
 
+interface LinkButton extends React.FC<LinkButtonProps> {
+  Container: typeof Container;
+}
+
 /**
  * `LinkButton` will render a 'button-like' link for directing/linking to the path specified. This component can work with React Router's `Link`/`NavLink` by passing in the router component as a prop ---> `<LinkButton to='/path' as={Link}> ....`.
  *
@@ -39,7 +43,7 @@ export interface LinkButtonProps {
  *
  * We should generally try to use the default button color when possible. Only for special cases should we need to use a different button color.
  */
-export const LinkButton = ({
+export const LinkButton: LinkButton = ({
   as = 'a',
   buttonColor,
   buttonType = 'primary',
@@ -48,7 +52,7 @@ export const LinkButton = ({
   onClick = () => undefined,
   textColor,
   ...rest
-}: LinkButtonProps) => {
+}) => {
   const theme = useTheme();
   const ContainerTag = as;
   const buttonColorWithTheme = buttonColor ?? theme.COLORS.primary;
@@ -90,5 +94,5 @@ LinkButton.propTypes = {
   children: PropTypes.node.isRequired,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
-  textColor: PropTypes.string,
+  textColor: COLORS_PROP_TYPES,
 };

--- a/src/shared-components/button/components/roundButton/index.tsx
+++ b/src/shared-components/button/components/roundButton/index.tsx
@@ -42,6 +42,10 @@ export interface RoundButtonProps {
   [key: string]: unknown;
 }
 
+interface RoundButton extends React.FC<RoundButtonProps> {
+  Container: typeof Style.RoundButtonContainer;
+}
+
 /**
  * `<RoundButton />` behaves mostly the same as `<Button />` except that it requires an `icon` prop since that is the main content placed with in the round button. Any children of the component will be rendered immediately below the round button.
  *
@@ -49,7 +53,7 @@ export interface RoundButtonProps {
  *
  * We should generally try to use the default button color when possible. Only for special cases should we need to use a different button color.
  */
-export const RoundButton = ({
+export const RoundButton: RoundButton = ({
   buttonColor,
   buttonType = 'primary',
   children,
@@ -60,7 +64,7 @@ export const RoundButton = ({
   onClick = () => undefined,
   textColor,
   ...rest
-}: RoundButtonProps) => {
+}) => {
   const theme = useTheme();
   const buttonColorWithTheme = buttonColor ?? theme.COLORS.primary;
   const loadingVal = loading === undefined ? isLoading : loading;
@@ -121,7 +125,7 @@ RoundButton.propTypes = {
   isLoading: PropTypes.bool,
   loading: isLoadingPropFunction,
   onClick: PropTypes.func,
-  textColor: PropTypes.string,
+  textColor: COLORS_PROP_TYPES,
 };
 
 export default withDeprecationWarning(RoundButton, deprecatedProperties);

--- a/src/shared-components/button/components/textButton/index.tsx
+++ b/src/shared-components/button/components/textButton/index.tsx
@@ -19,12 +19,12 @@ export interface TextButtonProps {
  * The component renders with padding and should not be used inline within body text, etc.
  * Useful for rendering a chunk of text that can be clicked but can also be disabled if needed.
  */
-export const TextButton = ({
+export const TextButton: React.FC<TextButtonProps> = ({
   children,
   disabled = false,
   onClick = () => undefined,
   ...rest
-}: TextButtonProps) => (
+}) => (
   <Style.BaseTextButton
     disabled={disabled}
     onClick={

--- a/src/shared-components/button/shared-components/loader/index.tsx
+++ b/src/shared-components/button/shared-components/loader/index.tsx
@@ -15,7 +15,7 @@ export interface LoaderProps {
   textColor?: ThemeColors;
 }
 
-const Loader = ({
+const Loader: React.FC<LoaderProps> = ({
   buttonColor,
   buttonType,
   className = '',
@@ -23,7 +23,7 @@ const Loader = ({
   isFullWidth = false,
   isLoading,
   textColor,
-}: LoaderProps) => (
+}) => (
   <ButtonLoader
     buttonColor={buttonColor}
     buttonType={buttonType}

--- a/src/shared-components/callout/index.tsx
+++ b/src/shared-components/callout/index.tsx
@@ -22,6 +22,10 @@ export interface CalloutProps {
   type?: 'error' | 'success';
 }
 
+interface Callout extends React.FC<CalloutProps> {
+  Container: typeof Style.ParentContainer;
+}
+
 /**
  * Pulls a specific styling preset based on available theme values and `type`
  */
@@ -51,7 +55,7 @@ const getCalloutStyles = (theme: ThemeType, type?: CalloutProps['type']) => {
  *
  * If you use a glyph as callout icon the recommended dimesions are 48x48 pixels (which is the default for Glyphs)
  */
-export const Callout = ({ children, icon, type }: CalloutProps) => {
+export const Callout: Callout = ({ children, icon, type }) => {
   const theme = useTheme();
   const { backgroundColor, textColor } = getCalloutStyles(theme, type);
 

--- a/src/shared-components/carousel/arrow/index.tsx
+++ b/src/shared-components/carousel/arrow/index.tsx
@@ -12,13 +12,13 @@ export interface ArrowProps {
   prev?: boolean;
 }
 
-const Arrow = ({
+const Arrow: React.FC<ArrowProps> = ({
   bottomRightAlignedArrows = false,
   disabled = false,
   next = false,
   onClick = () => undefined,
   prev = false,
-}: ArrowProps) => {
+}) => {
   const ArrowContainerComponent = bottomRightAlignedArrows
     ? Style.BottomRightAlignedArrowContainer
     : Style.ArrowContainer;

--- a/src/shared-components/carousel/index.tsx
+++ b/src/shared-components/carousel/index.tsx
@@ -47,6 +47,10 @@ export interface CarouselProps {
   numCardsVisible: 1 | 2 | 3;
 }
 
+interface Carousel extends React.FC<CarouselProps> {
+  Card: typeof Style.Card;
+}
+
 // TODO-eslint: Reduce cognitive complexity of component
 /* eslint-disable sonarjs/cognitive-complexity */
 /**
@@ -56,7 +60,7 @@ export interface CarouselProps {
  *
  * An array of `Carousel.Card` must be used for the carousel content. It includes the base styles for the Card which may be extended as shown above.
  */
-export const Carousel = ({
+export const Carousel: Carousel = ({
   autoplay = false,
   autoplaySpeed = 5000,
   bottomRightAlignedArrows = false,
@@ -67,7 +71,7 @@ export const Carousel = ({
   hideDots = false,
   infinite = false,
   numCardsVisible,
-}: CarouselProps) => {
+}) => {
   const getLastIndex = () => {
     const numberSlides = children.length;
     return numberSlides - numCardsVisible;
@@ -186,5 +190,5 @@ Carousel.propTypes = {
   hideArrows: PropTypes.bool,
   hideDots: PropTypes.bool,
   infinite: PropTypes.bool,
-  numCardsVisible: PropTypes.number.isRequired,
+  numCardsVisible: PropTypes.oneOf([1, 2, 3] as const).isRequired,
 };

--- a/src/shared-components/checkbox/index.tsx
+++ b/src/shared-components/checkbox/index.tsx
@@ -27,7 +27,7 @@ export interface CheckboxProps {
  *
  * `<Checkbox />` is a controlled component that represents a checkbox selection. This means that the `onClick` function should be used to change the checked state of the checkbox. Note that a group of checkbox buttons must be composed by a parent component.
  */
-export const Checkbox = ({
+export const Checkbox: React.FC<CheckboxProps> = ({
   checked,
   children = null,
   disabled = false,
@@ -36,7 +36,7 @@ export const Checkbox = ({
   size = 'small',
   type = 'primary',
   ...rest
-}: CheckboxProps) => (
+}) => (
   <SelectorButton
     checked={checked}
     disabled={disabled}

--- a/src/shared-components/chip/index.tsx
+++ b/src/shared-components/chip/index.tsx
@@ -67,11 +67,11 @@ const getStyles = ({ isLowContrast, status, theme }: GetStylesProps) => {
  *
  * These chips can have a status value of Error, Primary, Success, or White. "White" does not have a low contrast version, and can be used on top of photos or illustrations.
  */
-export const Chip = ({
+export const Chip: React.FC<ChipProps> = ({
   isLowContrast = false,
   status = 'primary',
   text,
-}: ChipProps) => {
+}) => {
   const theme = useTheme();
 
   const { backgroundColor, textColor } = getStyles({

--- a/src/shared-components/container/style.ts
+++ b/src/shared-components/container/style.ts
@@ -1,5 +1,4 @@
-import { DetailedHTMLProps, HTMLAttributes } from 'react';
-import styled, { StyledComponent } from '@emotion/styled';
+import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
 import { SPACER, MEDIA_QUERIES, ThemeType } from '../../constants';
@@ -65,20 +64,11 @@ const Image = styled.img`
   object-fit: cover;
 `;
 
-/**
- * This is the type returned by `styled.div`
- *
- * @see `node_modules/@emotion/styled-base/types/index.d.ts`
- */
-type StyledContainer = StyledComponent<
-  DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
-  {
-    type?: ContainerType;
-  },
-  { theme?: ThemeType }
->;
+const ContainerComponentForTypesOnly = styled.div<{
+  type?: ContainerType;
+}>``;
 
-type CompositeContainer = StyledContainer & {
+type CompositeContainer = typeof ContainerComponentForTypesOnly & {
   Divider: typeof Divider;
   Image: typeof Image;
   Section: typeof Section;

--- a/src/shared-components/container/style.ts
+++ b/src/shared-components/container/style.ts
@@ -64,6 +64,12 @@ const Image = styled.img`
   object-fit: cover;
 `;
 
+/**
+ * Variable defined solely for type definitions.
+ *
+ * Our pattern for setting subcomponents via dot notion is easy within a proper component
+ * but not when setting it directly on the return value of a `styled` call.
+ */
 const ContainerComponentForTypesOnly = styled.div<{
   type?: ContainerType;
 }>``;
@@ -74,9 +80,6 @@ type CompositeContainer = typeof ContainerComponentForTypesOnly & {
   Section: typeof Section;
 };
 
-// Our reliance on setting dot.notation subcomponents directly on the
-// styled component is not well supported. CompositeContainer defines those
-// subcomponents ahead of time to account for styled.div limitations.
 const Container = styled.div<{ type?: ContainerType }>`
   ${({ theme, type }) => containerStyles(theme, type)};
 ` as CompositeContainer;

--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -29,6 +29,10 @@ export interface DialogModalProps {
   [key: string]: unknown;
 }
 
+interface DialogModal extends React.FC<DialogModalProps> {
+  Paragraph: typeof Style.Paragraph;
+}
+
 const getHtmlNode = () => document.querySelector('html') ?? document.body;
 const getDomNode = () =>
   document.getElementById(REACT_PORTAL_SECTION_ID) ?? document.body;
@@ -42,13 +46,13 @@ const getDomNode = () =>
  *
  * `DialogModal.Paragraph` subcomponent may be used to add some margin to the paragraphs inside the modal body.
  */
-export const DialogModal = ({
+export const DialogModal: DialogModal = ({
   backgroundColor,
   children,
   onCloseIconClick,
   title = '',
   ...rest
-}: DialogModalProps) => {
+}) => {
   const theme = useTheme();
   const backgroundColorWithTheme = backgroundColor ?? theme.COLORS.white;
   const [isClosing, setIsClosing] = useState(false);

--- a/src/shared-components/field/index.tsx
+++ b/src/shared-components/field/index.tsx
@@ -42,12 +42,17 @@ export interface FieldProps {
   messagesType?: MessagesTypes;
 }
 
+interface Field extends React.FC<FieldProps> {
+  Input: typeof Style.Input;
+  Textarea: typeof Style.Textarea;
+}
+
 /**
  * Field component uses VerificationMessages component internally along with extra styling for the input.
  *
  * If you don't need validation, label or hint message; you can use `Field.Input` or `Field.Textarea` directly without the `Field` wrapper.
  */
-export const Field = ({
+export const Field: Field = ({
   children: inputChild,
   disabled = false,
   hideMessagesIcon = false,
@@ -56,7 +61,7 @@ export const Field = ({
   labelFor = '',
   messages = {},
   messagesType = 'error',
-}: FieldProps) => {
+}) => {
   const theme = useTheme();
   const htmlFor = labelFor || label;
   const messagesKeys = Object.keys(messages);
@@ -111,6 +116,13 @@ Field.propTypes = {
   hintMessage: PropTypes.string,
   label: PropTypes.string,
   labelFor: PropTypes.string,
-  messages: PropTypes.objectOf(PropTypes.node),
+  messages: PropTypes.objectOf(
+    PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string.isRequired),
+      PropTypes.arrayOf(PropTypes.element.isRequired),
+    ]).isRequired,
+  ),
   messagesType: PropTypes.oneOf(['error', 'success']),
 };

--- a/src/shared-components/icon/index.tsx
+++ b/src/shared-components/icon/index.tsx
@@ -47,8 +47,7 @@ Icon.propTypes = {
   displayInline: PropTypes.bool,
   fill: PropTypes.string,
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  // @ts-expect-error -- TypeScript type is too specific for PropTypes types
-  IconComponent: PropTypes.element.isRequired,
+  IconComponent: PropTypes.func.isRequired,
   rotate: PropTypes.number,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };

--- a/src/shared-components/icon/index.tsx
+++ b/src/shared-components/icon/index.tsx
@@ -21,17 +21,21 @@ export interface IconProps extends React.SVGProps<SVGSVGElement> {
   [key: string]: unknown;
 }
 
+export type RadianceIconComponent = (
+  props: IconProps,
+) => ReturnType<typeof useIcon>;
+
 /**
  * Helper component to pass the necessary props down to direct SVG imports, supported by @svgr (cli and rollup).
  *
  * **This component should not be used directly**, and so is not included in the `shared-components` export.
  */
-export const Icon = ({
+export const Icon: React.FC<IconProps & { IconComponent: SVGComponent }> = ({
   displayInline = false,
   IconComponent,
   rotate = 0,
   ...rest
-}: IconProps & { IconComponent: SVGComponent }) => (
+}) => (
   <IconComponent
     css={Style.iconStyles({ displayInline, fill: rest.fill, rotate })}
     {...rest}
@@ -43,7 +47,8 @@ Icon.propTypes = {
   displayInline: PropTypes.bool,
   fill: PropTypes.string,
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  IconComponent: PropTypes.elementType.isRequired,
+  // @ts-expect-error -- TypeScript type is too specific for PropTypes types
+  IconComponent: PropTypes.element.isRequired,
   rotate: PropTypes.number,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };

--- a/src/shared-components/immersiveModal/index.tsx
+++ b/src/shared-components/immersiveModal/index.tsx
@@ -35,6 +35,10 @@ export interface ImmersiveModalProps {
   [key: string]: unknown;
 }
 
+interface ImmersiveModal extends React.FC<ImmersiveModalProps> {
+  Paragraph: typeof Style.Paragraph;
+}
+
 const MODAL_MOBILE_SCROLLING_ID = 'modal-mobile-scrolling-id';
 const MODAL_DESKTOP_SCROLLING_ID = 'modal-desktop-scrolling-id';
 
@@ -59,14 +63,14 @@ const getModalDesktopScrollingElement = () =>
  *
  * `ImmersiveModal.Paragraph` subcomponent may be used to add some margin to the paragraphs inside the modal body.
  */
-export const ImmersiveModal = ({
+export const ImmersiveModal: ImmersiveModal = ({
   children,
   footerContent = null,
   headerImage = null,
   onClose,
   title = '',
   ...rest
-}: ImmersiveModalProps) => {
+}) => {
   const [isClosing, setIsClosing] = useState(false);
   const [showMobileHeaderBar, setShowMobileHeaderBar] = useState(false);
   const [showDesktopHeaderBar, setShowDesktopHeaderBar] = useState(false);

--- a/src/shared-components/index.ts
+++ b/src/shared-components/index.ts
@@ -11,7 +11,7 @@ export * from './container';
 export * from './dialogModal';
 export * from './dropdown';
 export * from './field';
-export type { IconProps } from './icon';
+export type { IconProps, RadianceIconComponent } from './icon';
 export * from './immersiveModal';
 export * from './indicator';
 export * from './loadingSpinner';

--- a/src/shared-components/indicator/index.tsx
+++ b/src/shared-components/indicator/index.tsx
@@ -51,7 +51,10 @@ const getStyles = ({ theme, type }: GetStylesProps) => {
  * Indicators are used in navigation to help with wayfinding for messages and notifications.
  * It can also be used for non-navigational purposes for information-intensive pages.
  */
-export const Indicator = ({ text, type = 'error' }: IndicatorProps) => {
+export const Indicator: React.FC<IndicatorProps> = ({
+  text,
+  type = 'error',
+}) => {
   const theme = useTheme();
   const { backgroundColor, textColor } = getStyles({ theme, type });
 

--- a/src/shared-components/loadingSpinner/index.tsx
+++ b/src/shared-components/loadingSpinner/index.tsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { useTheme } from '@emotion/react';
 
 import Style from './style';
-
-import type { ThemeColors } from '../../constants';
+import { COLORS_PROP_TYPES, ThemeColors } from '../../constants';
 
 export interface LoadingSpinnerProps {
   /**
@@ -32,13 +31,13 @@ export interface LoadingSpinnerProps {
 /**
  * LoadingSpinner will cover the entirety of the container that holds it. The container should have `position: relative;` as part of its styling to prevent the LoadingSpinner from spilling outside the container.
  */
-export const LoadingSpinner = ({
+export const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
   bgColor,
   color,
   duration = 2,
   size = '14px',
   translateX = '100px',
-}: LoadingSpinnerProps) => {
+}) => {
   const theme = useTheme();
 
   const bgColorWithTheme = bgColor ?? theme.COLORS.background;
@@ -71,8 +70,8 @@ export const LoadingSpinner = ({
 };
 
 LoadingSpinner.propTypes = {
-  bgColor: PropTypes.string,
-  color: PropTypes.string,
+  bgColor: COLORS_PROP_TYPES,
+  color: COLORS_PROP_TYPES,
   duration: PropTypes.number,
   size: PropTypes.string,
   translateX: PropTypes.string,

--- a/src/shared-components/offClickWrapper/index.tsx
+++ b/src/shared-components/offClickWrapper/index.tsx
@@ -13,11 +13,11 @@ export interface OffClickWrapperProps {
   onOffClick: (event: KeyboardEvent | MouseEvent) => void;
 }
 
-export const OffClickWrapper = ({
+export const OffClickWrapper: React.FC<OffClickWrapperProps> = ({
   children,
   className,
   onOffClick,
-}: OffClickWrapperProps) => {
+}) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
   const handleKeyPress = (event: KeyboardEvent) => {

--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -4,8 +4,7 @@ import PropTypes from 'prop-types';
 import Style from './style';
 import { CheckmarkIcon } from '../../icons';
 import { isDefined } from '../../utils/isDefined';
-
-import type { ThemeType } from '../../constants';
+import { BORDER_RADIUS_PROP_TYPES, ThemeType } from '../../constants';
 
 const DEFAULT_BORDER_RADIUS = 'small';
 
@@ -37,14 +36,14 @@ export type OptionButtonContentProps = Pick<
   'buttonType' | 'icon' | 'optionType' | 'selected' | 'subtext' | 'text'
 >;
 
-const OptionButtonContent = ({
+const OptionButtonContent: React.FC<OptionButtonContentProps> = ({
   buttonType = 'primary',
   icon,
   optionType,
   selected = false,
   subtext,
   text,
-}: OptionButtonContentProps) => (
+}) => (
   <Style.FlexContainer>
     {/**
      * We sometimes use && conditionals such that we are passing in `false` as a value
@@ -73,6 +72,10 @@ const OptionButtonContent = ({
   </Style.FlexContainer>
 );
 
+interface OptionButton extends React.FC<OptionButtonProps> {
+  NotClickable: typeof OptionButtonNotClickable;
+}
+
 /**
  * The `OptionButton` is used within a focused flow (such as the signup page)
  * to provide more context and attention to each selection option.
@@ -81,7 +84,7 @@ const OptionButtonContent = ({
  * want to use the OptionButton as a purely presentational component rather
  * than a functional button associated with form inputs
  */
-export const OptionButton = ({
+export const OptionButton: OptionButton = ({
   borderRadius = DEFAULT_BORDER_RADIUS,
   buttonType,
   icon,
@@ -91,7 +94,7 @@ export const OptionButton = ({
   subtext,
   text,
   ...rest
-}: OptionButtonProps) => (
+}) => (
   <Style.ClickableContainer
     borderRadius={borderRadius}
     onClick={onClick}
@@ -115,31 +118,32 @@ export const OptionButton = ({
 /**
  * A presentational component to match the display of an OptionButton with an icon
  */
-export const OptionButtonNotClickable = ({
-  borderRadius = DEFAULT_BORDER_RADIUS,
-  icon,
-  optionType,
-  subtext,
-  text,
-  ...rest
-}: OptionButtonNotClickableProps) => (
-  <Style.DisplayContainer
-    borderRadius={borderRadius}
-    containerType="none"
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    {...rest}
-  >
-    <OptionButtonContent
-      // The buttonType does not matter for this component
-      buttonType="primary"
-      icon={icon}
-      optionType={optionType}
-      selected={false}
-      subtext={subtext}
-      text={text}
-    />
-  </Style.DisplayContainer>
-);
+export const OptionButtonNotClickable: React.FC<OptionButtonNotClickableProps> =
+  ({
+    borderRadius = DEFAULT_BORDER_RADIUS,
+    icon,
+    optionType,
+    subtext,
+    text,
+    ...rest
+  }) => (
+    <Style.DisplayContainer
+      borderRadius={borderRadius}
+      containerType="none"
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...rest}
+    >
+      <OptionButtonContent
+        // The buttonType does not matter for this component
+        buttonType="primary"
+        icon={icon}
+        optionType={optionType}
+        selected={false}
+        subtext={subtext}
+        text={text}
+      />
+    </Style.DisplayContainer>
+  );
 
 /**
  * Similar OptionButton styling without click elements
@@ -147,11 +151,11 @@ export const OptionButtonNotClickable = ({
 OptionButton.NotClickable = OptionButtonNotClickable;
 
 OptionButton.propTypes = {
-  borderRadius: PropTypes.string,
+  borderRadius: BORDER_RADIUS_PROP_TYPES,
   buttonType: PropTypes.oneOf(['primary', 'secondary']),
   icon: PropTypes.node,
   onClick: PropTypes.func.isRequired,
-  optionType: PropTypes.oneOf(['radio', 'checkbox']).isRequired,
+  optionType: PropTypes.oneOf(['radio', 'checkbox'] as const).isRequired,
   selected: PropTypes.bool,
   subtext: PropTypes.node,
   text: PropTypes.string.isRequired,

--- a/src/shared-components/progressBar/index.tsx
+++ b/src/shared-components/progressBar/index.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useTheme } from '@emotion/react';
 
-import { PROGRESS_BAR_STATUS, ThemeColors } from '../../constants';
+import {
+  COLORS_PROP_TYPES,
+  PROGRESS_BAR_STATUS,
+  ThemeColors,
+} from '../../constants';
 import Style from './style';
 
 export type ProgressBarStatusType = valueof<typeof PROGRESS_BAR_STATUS>;
@@ -27,14 +31,14 @@ export interface ProgressBarProps {
  *
  * To start the animation use `loading` status. To control the result pass `success` or `error` to the status property.
  */
-export const ProgressBar = ({
+export const ProgressBar: React.FC<ProgressBarProps> = ({
   backgroundColor,
   barColor,
   height = 4,
   loadingTime = '20s',
   status,
   ...rest
-}: ProgressBarProps) => {
+}) => {
   const theme = useTheme();
 
   const backgroundColorWithTheme = backgroundColor ?? theme.COLORS.background;
@@ -59,8 +63,8 @@ export const ProgressBar = ({
 };
 
 ProgressBar.propTypes = {
-  backgroundColor: PropTypes.string,
-  barColor: PropTypes.string,
+  backgroundColor: COLORS_PROP_TYPES,
+  barColor: COLORS_PROP_TYPES,
   height: PropTypes.number,
   loadingTime: PropTypes.string,
   status: PropTypes.oneOf([

--- a/src/shared-components/radioButton/index.tsx
+++ b/src/shared-components/radioButton/index.tsx
@@ -29,7 +29,7 @@ export interface RadioButtonProps {
  *
  * Note that a group of radio buttons must be composed by a parent component.
  */
-export const RadioButton = ({
+export const RadioButton: React.FC<RadioButtonProps> = ({
   checked,
   children = null,
   disabled = false,
@@ -38,7 +38,7 @@ export const RadioButton = ({
   size = 'small',
   type = 'primary',
   ...rest
-}: RadioButtonProps) => (
+}) => (
   <SelectorButton
     checked={checked}
     disabled={disabled}

--- a/src/shared-components/selectorButton/index.tsx
+++ b/src/shared-components/selectorButton/index.tsx
@@ -24,7 +24,7 @@ export interface SelectorButtonProps {
   [key: string]: unknown;
 }
 
-export const SelectorButton = ({
+export const SelectorButton: React.FC<SelectorButtonProps> = ({
   checked,
   children = null,
   disabled = false,
@@ -34,7 +34,7 @@ export const SelectorButton = ({
   size = 'small',
   type = 'primary',
   ...rest
-}: SelectorButtonProps) => {
+}) => {
   const theme = useTheme();
 
   const checkedIcon =

--- a/src/shared-components/tabs/index.tsx
+++ b/src/shared-components/tabs/index.tsx
@@ -18,7 +18,7 @@ export interface TabsProps {
   }>;
 }
 
-export const Tabs = ({
+export const Tabs: React.FC<TabsProps> = ({
   initialActiveTabId = 1,
   onClick = () => undefined,
   tabItems,
@@ -54,6 +54,6 @@ Tabs.propTypes = {
     PropTypes.shape({
       id: PropTypes.number.isRequired,
       text: PropTypes.string.isRequired,
-    }),
+    }).isRequired,
   ).isRequired,
 };

--- a/src/shared-components/toggle/index.tsx
+++ b/src/shared-components/toggle/index.tsx
@@ -24,13 +24,14 @@ const toggleInputStyles = {
 };
 
 /**
- * The `<Toggle>` component is usually wrapped in a `container` element (with a fixed `width` style for example). The toggle and label are spread in the container (`space-between`) from edge to edge.
+ * The `<Toggle>` component is usually wrapped in a `container` element (with a fixed `width` style for example).
+ * The toggle and label are spread in the container (`space-between`) from edge to edge.
  */
-export const Toggle = ({
+export const Toggle: React.FC<ToggleProps> = ({
   checked = false,
   label = '',
   onChange,
-}: ToggleProps) => {
+}) => {
   const theme = useTheme();
 
   return (

--- a/src/shared-components/tooltip/index.tsx
+++ b/src/shared-components/tooltip/index.tsx
@@ -70,7 +70,7 @@ export interface TooltipProps {
  *
  * They can be triggered from an icon or another component (such as a navigation link)
  */
-export const Tooltip = ({
+export const Tooltip: React.FC<TooltipProps> = ({
   alignRightPercent = 0,
   alignTopPercent = 0,
   arrowAlign = 'middle',
@@ -85,7 +85,7 @@ export const Tooltip = ({
   nudgeRight = 0,
   nudgeTop = 0,
   position = 'top',
-}: TooltipProps) => {
+}) => {
   const theme = useTheme();
   const [clicked, setClicked] = useState(false);
   const [hovered, setHovered] = useState(false);

--- a/src/shared-components/transitions/index.tsx
+++ b/src/shared-components/transitions/index.tsx
@@ -15,11 +15,11 @@ export interface FadeInContainerProps {
   speed?: string;
 }
 
-export const FadeInContainer = ({
+export const FadeInContainer: React.FC<FadeInContainerProps> = ({
   children,
   slide = false,
   speed = '350ms',
-}: FadeInContainerProps) => (
+}) => (
   <Style.FadeInContainer withSlide={slide} animationSpeed={speed}>
     {children}
   </Style.FadeInContainer>

--- a/src/shared-components/verificationMessages/index.tsx
+++ b/src/shared-components/verificationMessages/index.tsx
@@ -30,11 +30,11 @@ export interface VerificationMessagesProps {
  *
  * While it can be used as a standalone component, it is intended for use within the Field component.
  */
-export const VerificationMessages = ({
+export const VerificationMessages: React.FC<VerificationMessagesProps> = ({
   centered = false,
   messages = {},
   type = 'error',
-}: VerificationMessagesProps) => {
+}) => {
   const messageKeys = Object.keys(messages);
   const showMessages = messageKeys.length > 0;
 
@@ -67,6 +67,13 @@ export const VerificationMessages = ({
 
 VerificationMessages.propTypes = {
   centered: PropTypes.bool,
-  messages: PropTypes.objectOf(PropTypes.node),
+  messages: PropTypes.objectOf(
+    PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string.isRequired),
+      PropTypes.arrayOf(PropTypes.element.isRequired),
+    ]).isRequired,
+  ),
   type: PropTypes.oneOf(['error', 'success']),
 };

--- a/stories/button/index.stories.tsx
+++ b/stories/button/index.stories.tsx
@@ -197,7 +197,13 @@ export const WithControls = () => {
         isLoading={boolean('isLoading', false)}
         disabled={boolean('disabled', false)}
         onClick={action('button clicked')}
-        textColor={text('textColor', '') as ThemeColors}
+        textColor={
+          text(
+            'textColor',
+            // @ts-expect-error -- Rely on component fallback
+            undefined,
+          ) as ThemeColors
+        }
       >
         {text('children', 'Click me!')}
       </Button>

--- a/stories/button/linkButton/index.stories.tsx
+++ b/stories/button/linkButton/index.stories.tsx
@@ -93,7 +93,13 @@ export const WithControls = () => {
         buttonColor={select('buttonColor', theme.COLORS, theme.COLORS.primary)}
         disabled={boolean('disabled', false)}
         onClick={action('You clicked a button')}
-        textColor={text('textColor', '') as ThemeColors}
+        textColor={
+          text(
+            'textColor',
+            // @ts-expect-error -- Rely on component fallback
+            undefined,
+          ) as ThemeColors
+        }
       >
         {text('children', 'Click it!')}
       </LinkButton>

--- a/stories/button/roundButton/index.stories.tsx
+++ b/stories/button/roundButton/index.stories.tsx
@@ -153,7 +153,13 @@ export const WithControls = () => {
         disabled={boolean('disabled', false)}
         onClick={action('button clicked')}
         icon={<CheckmarkIcon />}
-        textColor={text('textColor', '') as ThemeColors}
+        textColor={
+          text(
+            'textColor',
+            // @ts-expect-error -- Rely on component fallback
+            undefined,
+          ) as ThemeColors
+        }
       >
         {text('children', 'Click me!')}
       </RoundButton>

--- a/stories/constants/availableConstants.stories.tsx
+++ b/stories/constants/availableConstants.stories.tsx
@@ -12,6 +12,7 @@ const {
   primaryTheme: _primaryTheme,
   secondaryTheme: _secondaryTheme,
   REACT_PORTAL_SECTION_ID: _REACT_PORTAL_SECTION_ID,
+  BORDER_RADIUS_PROP_TYPES: _BORDER_RADIUS_PROP_TYPES,
   ...VALID_CONSTANTS
 } = CONSTANTS;
 

--- a/stories/field/index.stories.tsx
+++ b/stories/field/index.stories.tsx
@@ -163,7 +163,11 @@ export const TextareaWithASuccessMessageAndHiddenIcon = () => (
       messagesType="success"
       hideMessagesIcon
     >
-      <Field.Textarea id="textarea-id" value="some answer" />
+      <Field.Textarea
+        id="textarea-id"
+        value="some answer"
+        onChange={() => undefined}
+      />
     </Field>
   </FieldsContainer>
 );


### PR DESCRIPTION
### What & Why

Upgrading a consumer app from Emotion 10 to 11 surfaced a number of PropTypes type errors related to PropTypes definitions:
<img width="720" alt="Screen Shot 2021-05-24 at 11 14 17 AM" src="https://user-images.githubusercontent.com/13544620/119376131-3ae7b980-bc81-11eb-80c6-b617647ff5ff.png">

After looking into the issue, using `React.FC<Props>` type definitions on the Radiance components surfaced PropTypes issues where there were differences in specificity between the TypeScript definitions and the PropTypes definitions. Interestingly, I thought these checks were already occurring, but that does not seem to be the case. 

This PR adds `React.FC` to all appropriate components and upgrading the PropTypes definitions accordingly. 

### Other 

1. Export `RadianceIconComponent` type for use in consumer apps.