### PR TITLE
[DialogModal] Type Refinement

### DIFF
--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -24,7 +24,7 @@ export interface DialogModalProps {
    * If provided, DialogModal displays a Close Icon positioned top-right.
    * This function must contain the logic for closing the modal.
    */
-  onCloseIconClick?: () => void;
+  onCloseIconClick?: (() => void) | null;
   title?: string;
   [key: string]: unknown;
 }


### PR DESCRIPTION
PropTypes are particular about distinguishing between `null` and `undefined`. This will prevent errors in consumer app usage when the function is not provided, updating the default value `undefined` to be `null`.