### PR TITLE
[Emotion] Prefer autoLabel: true for output

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,7 +14,15 @@ const getPresets = (modules) => [
   ],
   '@babel/react',
   '@babel/preset-typescript',
-  '@emotion/babel-preset-css-prop',
+  [
+    '@emotion/babel-preset-css-prop',
+    {
+      autoLabel: 'always',
+      labelFormat: '[local]',
+      useBuiltIns: false,
+      throwIfNamespace: true,
+    },
+  ],
 ];
 
 const plugins = [


### PR DESCRIPTION
We have an emotion 10 --> 11 branch ready for release but there's a bit of a size regression, ~+2.7% in bundle size. I've identified some change in `style.js` output as partially responsible:

Emotion 10:

```tsx
var Container = _styled("div", {
  target: "ei8l98n0",
  label: "Container"
})(...rest)
```

Emotion 11 (before this PR):

```tsx
var Container = _styled("div", process.env.NODE_ENV === "production" ? {
  target: "ei8l98n4"
} : {
  target: "ei8l98n4",
  label: "Container"
})(...rest)
```

Emotion 11 (with 5b34e62):

```tsx
var Container = _styled("div", {
  target: "ei8l98n4",
  label: "Container"
})(...rest)
```

Unless the `autoLabel` default value changed, which I didn't notice in the migration guide, I'm not sure why this behavior is different. In any case it helps shave down about 33% of the regression. (The bundlewatch for this PR reports +1.8% size regression instead of 2.7%.)