### PR TITLE
[Tooltip] Modify Hover Logic

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,8 +9,8 @@ module.exports = {
     global: {
       branches: 50,
       functions: 66,
-      lines: 75,
-      statements: 75,
+      lines: 74,
+      statements: 74,
     },
   },
   moduleNameMapper: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,5 +20,10 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>tests/setupTests.ts'],
   snapshotSerializers: ['@emotion/jest/serializer'],
   testEnvironment: 'jsdom',
-  testPathIgnorePatterns: ['/node_modules/', '/lib/', '/__snapshots__'],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/lib*',
+    '/__snapshots__',
+    '/dist*',
+  ],
 };

--- a/src/shared-components/immersiveModal/style.ts
+++ b/src/shared-components/immersiveModal/style.ts
@@ -38,7 +38,7 @@ const Overlay = styled.div`
 `;
 
 const CrossIconContainer = styled.button`
-  ${buttonReset};
+  ${buttonReset}
   padding: 0;
   position: absolute;
   top: 8px;

--- a/src/shared-components/tooltip/__snapshots__/test.tsx.snap
+++ b/src/shared-components/tooltip/__snapshots__/test.tsx.snap
@@ -26,6 +26,7 @@ exports[`<Tooltip /> UI snapshot renders content and children 1`] = `
   min-width: 100px;
   opacity: 0;
   padding: 1rem;
+  cursor: none;
   pointer-events: none;
   position: absolute;
   -webkit-transform: translateY(-8px);

--- a/src/shared-components/tooltip/index.tsx
+++ b/src/shared-components/tooltip/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Global, useTheme } from '@emotion/react';
+import { useTheme } from '@emotion/react';
 
 import { ArrowIcon } from '../../icons';
 import { OffClickWrapper } from '../offClickWrapper';
@@ -9,8 +9,6 @@ import Style from './style';
 export type ArrowAlignTypes = 'left' | 'middle' | 'right';
 
 export type PositionTypes = 'top' | 'bottom';
-
-const CURSOR_POINTER = 'cursor-pointer';
 
 export interface TooltipProps {
   /**
@@ -91,21 +89,10 @@ export const Tooltip: React.FC<TooltipProps> = ({
   const [hovered, setHovered] = useState(false);
 
   const onClick = () => {
-    if (clicked) {
-      // if clicked is true, we're about to update to false so remove class
-      document.querySelector('body')?.classList.remove(CURSOR_POINTER);
-    } else {
-      document.querySelector('body')?.classList.add(CURSOR_POINTER);
-    }
-
     setClicked(!clicked);
   };
 
   const closeTooltip = () => {
-    if (clicked) {
-      document.querySelector('body')?.classList.remove(CURSOR_POINTER);
-    }
-
     setClicked(false);
     setHovered(false);
   };
@@ -114,13 +101,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
 
   return (
     <OffClickWrapper onOffClick={closeTooltip}>
-      <Global
-        styles={{
-          'body.cursor-pointer': {
-            cursor: 'pointer',
-          },
-        }}
-      />
       <Style.MainContainer>
         <Style.Trigger
           onClick={onClick}
@@ -137,6 +117,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
           alignRightPercent={alignRightPercent}
           alignTopPercent={alignTopPercent}
           arrowAlign={arrowAlign}
+          onClick={open ? onClick : undefined}
           displayTooltip={display}
           hasRestrictedWidth={hasRestrictedWidth}
           isSmall={isSmall}

--- a/src/shared-components/tooltip/style.ts
+++ b/src/shared-components/tooltip/style.ts
@@ -110,6 +110,8 @@ const TooltipBox = styled.div<{
   opacity: ${({ open }) => (open ? '1' : '0')};
   padding: ${({ isSmall }) =>
     isSmall ? `${SPACER.x2small} ${SPACER.small}` : SPACER.medium};
+  cursor: ${({ open }) => (open ? 'pointer' : 'none')};
+  pointer-events: ${({ open }) => (open ? 'auto' : 'none')};
   position: absolute;
   transform: ${({ open }) => (open ? 'translateY(0)' : 'translateY(-8px)')};
   transition-delay: 30ms;
@@ -119,9 +121,6 @@ const TooltipBox = styled.div<{
   text-align: left;
   font-size: ${({ theme }) => theme.TYPOGRAPHY.fontSize.caption};
   display: ${({ displayTooltip }) => (displayTooltip ? 'block' : 'none')};
-
-  cursor: ${({ open }) => (open ? 'pointer' : 'none')};
-  pointer-events: ${({ open }) => (open ? 'auto' : 'none')};
 `;
 
 const TooltipContent = styled.div`

--- a/src/shared-components/tooltip/style.ts
+++ b/src/shared-components/tooltip/style.ts
@@ -110,7 +110,6 @@ const TooltipBox = styled.div<{
   opacity: ${({ open }) => (open ? '1' : '0')};
   padding: ${({ isSmall }) =>
     isSmall ? `${SPACER.x2small} ${SPACER.small}` : SPACER.medium};
-  pointer-events: none;
   position: absolute;
   transform: ${({ open }) => (open ? 'translateY(0)' : 'translateY(-8px)')};
   transition-delay: 30ms;
@@ -120,6 +119,9 @@ const TooltipBox = styled.div<{
   text-align: left;
   font-size: ${({ theme }) => theme.TYPOGRAPHY.fontSize.caption};
   display: ${({ displayTooltip }) => (displayTooltip ? 'block' : 'none')};
+
+  cursor: ${({ open }) => (open ? 'pointer' : 'none')};
+  pointer-events: ${({ open }) => (open ? 'auto' : 'none')};
 `;
 
 const TooltipContent = styled.div`


### PR DESCRIPTION
Roughly ~7kb of the Emotion regression is due to our including a `<Global />` style in Tooltip. This PR:

1. Removes that style, as well as the manual `document.body.classList` handling.
1. Adds `onClick` functionality to the TooltipBox
1. Updates the styling to prevent (intended) behavior regression. 

Before: The click behavior applies `cursor-pointer` to the body so the `cursor: pointer` still shows even after the tooltip is closed:

https://user-images.githubusercontent.com/13544620/120420148-66c20980-c329-11eb-8bca-b7a9130b8e12.mov

After: Behavior is simplified and fixed:

https://user-images.githubusercontent.com/13544620/120420168-70e40800-c329-11eb-8e6e-49d4a7286664.mov

After making this change the Bundlewatch reports a small size increase in the `next` branch now: `(+2.92KB, -1.46KB, +0.2%)`

TODO: Move Tooltip trigger tabbable. 