### PR TITLE
Improve valid HTML for SelectorButton

### DIFF
--- a/src/shared-components/selectorButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/selectorButton/__snapshots__/test.tsx.snap
@@ -100,6 +100,10 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 }
 
 .emotion-9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
   margin-left: 1rem;
   margin-top: 0.25rem;
   min-width: 125px;
@@ -137,11 +141,11 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
       type="primary"
     />
   </div>
-  <p
+  <div
     class="emotion-9 emotion-10"
   >
     SelectorButton Text
-  </p>
+  </div>
 </div>
 `;
 
@@ -245,6 +249,10 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
 }
 
 .emotion-9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
   margin-left: 1rem;
   margin-top: 0.25rem;
   min-width: 125px;
@@ -286,11 +294,11 @@ exports[`<SelectorButton /> UI snapshots when Icon added displays check mark for
       type="primary"
     />
   </div>
-  <p
+  <div
     class="emotion-9 emotion-10"
   >
     SelectorButton Text
-  </p>
+  </div>
 </div>
 `;
 
@@ -394,6 +402,10 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
 }
 
 .emotion-9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
   margin-left: 1rem;
   margin-top: 0.25rem;
   min-width: 125px;
@@ -435,11 +447,11 @@ exports[`<SelectorButton /> UI snapshots when checked type is primary 1`] = `
       type="primary"
     />
   </div>
-  <p
+  <div
     class="emotion-9 emotion-10"
   >
     SelectorButton Text
-  </p>
+  </div>
 </div>
 `;
 
@@ -543,6 +555,10 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
 }
 
 .emotion-9 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
   margin-left: 1rem;
   margin-top: 0.25rem;
   min-width: 125px;
@@ -584,11 +600,11 @@ exports[`<SelectorButton /> UI snapshots when checked type is secondary 1`] = `
       type="secondary"
     />
   </div>
-  <p
+  <div
     class="emotion-9 emotion-10"
   >
     SelectorButton Text
-  </p>
+  </div>
 </div>
 `;
 
@@ -681,6 +697,10 @@ exports[`<SelectorButton /> UI snapshots when children is a node 1`] = `
 }
 
 .emotion-8 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
   margin-left: 1rem;
   margin-top: 0.25rem;
   min-width: 125px;
@@ -704,11 +724,11 @@ exports[`<SelectorButton /> UI snapshots when children is a node 1`] = `
       type="primary"
     />
   </div>
-  <p
+  <div
     class="emotion-8 emotion-9"
   >
     SelectorButton Text
-  </p>
+  </div>
 </div>
 `;
 
@@ -909,6 +929,10 @@ exports[`<SelectorButton /> UI snapshots when is checkbox 1`] = `
 }
 
 .emotion-8 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
   margin-left: 1rem;
   margin-top: 0.25rem;
   min-width: 125px;
@@ -932,10 +956,10 @@ exports[`<SelectorButton /> UI snapshots when is checkbox 1`] = `
       type="primary"
     />
   </div>
-  <p
+  <div
     class="emotion-8 emotion-9"
   >
     SelectorButton Text
-  </p>
+  </div>
 </div>
 `;

--- a/src/shared-components/selectorButton/style.ts
+++ b/src/shared-components/selectorButton/style.ts
@@ -104,7 +104,8 @@ const Selector = styled.div<{
   }
 `;
 
-const TextContainer = styled.p`
+const TextContainer = styled.div`
+  flex-grow: 1;
   margin-left: ${SPACER.medium};
   margin-top: ${SPACER.xsmall};
   min-width: 125px;


### PR DESCRIPTION
This change fixes `validateDOMNesting` console errors thrown by React in the PocketDerm repo.

Consumers of the `RadioButton` or `Checkbox` components may sometimes require more complicated DOM structures than plain text to describe the input choice. For example, in [our `SetCustomization` component](https://github.com/curology/PocketDerm/blob/master/resources/assets/jsx/components/patient/setCustomization/index.tsx), we have the following:

![Screen Shot 2021-06-02 at 2 39 58 PM](https://user-images.githubusercontent.com/6865979/120555897-9cf69c00-c3b0-11eb-8616-8d0351859559.png)

This structure currently employs usage of `div` elements to create a flexbox layout. It also uses the `Chip` component, which utilizes a `div`. My first instinct was to maintain the `<p>` usage and convert any children to [valid phrasing content](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content), but I think this change is more flexible for a variety of consumers (despite my constant urge to slash seemingly unnecessary `<div>`'s).
