### PR TITLE
Mark all node_modules as external

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,9 +5,6 @@ import { sizeSnapshot } from 'rollup-plugin-size-snapshot';
 import svgr from '@svgr/rollup';
 import path from 'path';
 
-// eslint-disable-next-line import/extensions
-import pkg from './package.json';
-
 const extensions = ['.js', '.ts', '.tsx'];
 
 const defaultConfig = {
@@ -30,12 +27,8 @@ const defaultConfig = {
     }),
     sizeSnapshot(),
   ],
-  /**
-   * @emotion/styled/base needs to be added explicitly because our
-   * @emotion/styled imports transpile specifically to @emotion/styled/base,
-   * which results in build errors if we do not include it.
-   */
-  external: [...Object.keys(pkg.dependencies), '@emotion/styled/base'],
+  // Note that this regex only works when using @rollup/plugin-node-resolve
+  external: /node_modules/,
 };
 
 export default [


### PR DESCRIPTION
This ensures that deep imports (not just the package name) are also marked as external.

Alternatively we could continue reading the `package.json` and convert each package name to a regex that also matches deep imports, but this seems faster and simpler.

See https://rollupjs.org/guide/en/#external
