### PR TITLE
Theme JSON (design tokens)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
       "import": "./dist/utils/index.js",
       "require": "./dist/utils/index.cjs"
     },
+    "./theme.json": "./dist/theme.json",
     "./package.json": "./package.json"
   },
   "engines": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import babel from '@rollup/plugin-babel';
 import typescript from '@rollup/plugin-typescript';
 import svgr from '@svgr/rollup';
 import { defineConfig } from 'rollup'
+import path from 'path';
 
 import pkg from './package.json';
 
@@ -10,6 +11,40 @@ const extensions = ['.js', '.ts', '.tsx'];
 const defaultOutputOptions = {
   dir: 'dist',
   exports: 'named',
+};
+
+/**
+ * A simple Rollup plugin to write our themes to a JSON file.
+ *
+ * @type {import('rollup').Plugin}
+ */
+const themeJson = {
+  name: 'theme-json',
+  generateBundle: async function (options, bundle) {
+    const { dir, format } = options;
+
+    if (format !== 'cjs') {
+      return;
+    }
+
+    const { 'constants/index.cjs': file } = bundle;
+
+    if (!dir || !file) {
+      throw new Error('Could not locate the constants entrypoint.');
+    }
+
+    const mod = await import(path.resolve(dir, file.fileName));
+
+    const { primaryTheme, secondaryTheme } = mod;
+
+    const json = JSON.stringify({ primaryTheme, secondaryTheme }, null, 2);
+
+    this.emitFile({
+      type: 'asset',
+      fileName: 'theme.json',
+      source: json,
+    })
+  },
 };
 
 export default defineConfig({
@@ -41,6 +76,7 @@ export default defineConfig({
       extensions,
       exclude: 'node_modules/**',
     }),
+    themeJson,
   ],
   external: Object.keys(pkg.dependencies).map((name) => new RegExp(`^${name}`)),
 });


### PR DESCRIPTION
This PR adds a Rollup plugin to convert our themes to JSON. We need to use the themes in environments that can't evaluate JavaScript. Generating the JSON files adds almost no time to the build and makes that a lot easier.

The JSON file looks [like this](https://gist.github.com/matt-allan/b05cbd140e902a2a0405f6e15192c362).

In the future we could probably build off of this idea and use a real [design token toolchain](https://github.com/sturobson/Awesome-Design-Tokens#tools).

Forked off of #1049 for now.