### PR TITLE
Move built assets from dist to lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ typings/
 **/.DS_Store
 
 # build files
-dist/
+lib/
 .out
 .size-snapshot.json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# Unreleased
+
+- [Internal] Moved built files from `dist` to `lib`. This is neccessary for TypeScript to properly resolve paths like `radiance-ui/lib/constants`, because TypeScript is unable to parse conditional exports.
+
 # v23.0.0
 
 - [Components] Added new `ResetStyles` and `BrandStyles` components to inject global styles. These replace the `utils/injectGlobalStyles/style` exports that were used for the same purpose. ([#1051)](https://github.com/curology/radiance-ui/pull/1051))

--- a/bundlewatch.config.json
+++ b/bundlewatch.config.json
@@ -1,12 +1,12 @@
 {
   "files": [
     {
-      "path": "dist/shared-components/!(typography)/**/index.js",
+      "path": "lib/shared-components/!(typography)/**/index.js",
       "maxSize": "20kB",
       "compression": "none"
     },
     {
-      "path": "dist/shared-components/typography/index.js",
+      "path": "lib/shared-components/typography/index.js",
       "maxSize": "100kB",
       "compression": "none"
     }

--- a/package.json
+++ b/package.json
@@ -2,32 +2,32 @@
   "name": "radiance-ui",
   "version": "23.0.0",
   "description": "Curology's React based component library",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "lib/index.cjs",
+  "module": "lib/index.js",
   "files": [
-    "dist"
+    "lib"
   ],
-  "types": "./dist/index.d.ts",
+  "types": "./lib/index.d.ts",
   "exports": {
     ".": {
-      "browser": "./dist/index.js",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "browser": "./lib/index.js",
+      "import": "./lib/index.js",
+      "require": "./lib/index.cjs"
     },
     "./lib/constants": {
-      "browser": "./dist/constants/index.js",
-      "import": "./dist/constants/index.js",
-      "require": "./dist/constants/index.cjs"
+      "browser": "./lib/constants/index.js",
+      "import": "./lib/constants/index.js",
+      "require": "./lib/constants/index.cjs"
     },
     "./lib/icons": {
-      "browser": "./dist/icons/index.js",
-      "import": "./dist/icons/index.js",
-      "require": "./dist/icons/index.cjs"
+      "browser": "./lib/icons/index.js",
+      "import": "./lib/icons/index.js",
+      "require": "./lib/icons/index.cjs"
     },
     "./lib/utils": {
-      "browser": "./dist/utils/index.js",
-      "import": "./dist/utils/index.js",
-      "require": "./dist/utils/index.cjs"
+      "browser": "./lib/utils/index.js",
+      "import": "./lib/utils/index.js",
+      "require": "./lib/utils/index.cjs"
     },
     "./package.json": "./package.json"
   },
@@ -39,7 +39,7 @@
     "storybook": "run-s build:icons:index storybook:dev",
     "storybook:dev": "start-storybook --port 9001 --config-dir .storybook --static-dir ./public",
     "build-storybook": "build-storybook --config-dir .storybook --output-dir .out --static-dir ./public",
-    "clean": "rimraf dist src/icons/**/svgs",
+    "clean": "rimraf lib src/icons/**/svgs",
     "build": "run-s build:icons:all build:rollup bundlewatch",
     "build:icons:all": "run-s clean build:icons build:icons:index",
     "build:icons": "run-p build:icons:emojis build:icons:glyphs build:icons:icons build:icons:logos build:icons:navicons",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ import pkg from './package.json';
 const extensions = ['.js', '.ts', '.tsx'];
 
 const defaultOutputOptions = {
-  dir: 'dist',
+  dir: 'lib',
   exports: 'named',
 };
 

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -1,3 +1,3 @@
-We write test helpers in `src/tests` instead of the `tests` directory at the root because in order for our TypeScript declaration files to not be deeply nested (e.g. `dist/src/constants`, instead of `dist/constants`, which is where we output our non-declaration source), `src` must be the "The longest common path of all non-declaration input files".
+We write test helpers in `src/tests` instead of the `tests` directory at the root because in order for our TypeScript declaration files to not be deeply nested (e.g. `lib/src/constants`, instead of `lib/constants`, which is where we output our non-declaration source), `src` must be the "The longest common path of all non-declaration input files".
 
 See: https://www.typescriptlang.org/tsconfig#outDir and https://www.typescriptlang.org/tsconfig#rootDir

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -1,3 +1,3 @@
-We write global `types` in `src/types` instead of a `types` directory at the root because in order for our TypeScript declaration files to not be deeply nested (e.g. `dist/src/constants`, instead of `dist/constants`, which is where we output our non-declaration source), `src` must be the "The longest common path of all non-declaration input files".
+We write global `types` in `src/types` instead of a `types` directory at the root because in order for our TypeScript declaration files to not be deeply nested (e.g. `lib/src/constants`, instead of `lib/constants`, which is where we output our non-declaration source), `src` must be the "The longest common path of all non-declaration input files".
 
 See: https://www.typescriptlang.org/tsconfig#outDir and https://www.typescriptlang.org/tsconfig#rootDir

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "noEmitOnError": true,
-    "outDir": "dist",
+    "outDir": "lib",
     // The folder structure in outDir is based on "The longest common path of all non-declaration input files."
     // To match our babel output, we need to compile everything in `src` without also nesting it in a folder named `src`.
     // Setting the `rootDir` to `src` will guarantee this behavior, and raise compilation errors if violated.


### PR DESCRIPTION
My last release broke Type resolution 😢

TypeScript cannot parse conditional exports, so it's unable to resolve types for paths like `radiance-ui/lib/constants` if they're actually in `radiance-ui/dist/constants`. Using the same name for the built assets ensures TypeScript can resolve the path correctly without having to parse the conditional exports.

We _could_ build the types to `lib` and the bundles to `dist` but that seemed confusing.

See https://github.com/microsoft/TypeScript/issues/33079