### PR TITLE
Access NODE_ENV with dot operator

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -36,4 +36,10 @@ declare global {
   // No built-in utility counterpart to keyof--this allows us
   // to use it without worrying about importing it everywhere
   type valueof<T> = T[keyof T];
+
+  namespace NodeJS {
+    interface ProcessEnv {
+      NODE_ENV?: string;
+    }
+  }
 }

--- a/src/utils/shouldShowForEnvironment/index.ts
+++ b/src/utils/shouldShowForEnvironment/index.ts
@@ -1,6 +1,6 @@
 const defaultAllowedEnvironments = ['test', 'development', 'dev'];
 
-const environment = process.env['NODE_ENV'];
+const environment = process.env.NODE_ENV;
 
 const shouldShowForEnvironment = (
   allowedEnvironments = defaultAllowedEnvironments,


### PR DESCRIPTION
Using the bracket syntax can cause issues with various tools that try to statically replace the environment variables like Next.JS and Vite. The dot syntax is easier to replace when the app is built.

The brackets were used to make TypeScript happy, so we can tell TypeScript that we expect the value to exist instead.

For more info:

https://vitejs.dev/guide/env-and-mode.html#production-replacement
https://nextjs.org/docs/basic-features/environment-variables#loading-environment-variables