### PR TITLE
Add aria-label to dropdown component

### DIFF
--- a/src/shared-components/dropdown/desktopDropdown.tsx
+++ b/src/shared-components/dropdown/desktopDropdown.tsx
@@ -70,6 +70,7 @@ export const DesktopDropdown = <T extends OptionType>({
           aria-haspopup="menu"
           role="button"
           ref={initialFocus}
+          aria-label="dropdown"
         >
           <div
             css={Style.dropdownInputStyle({


### PR DESCRIPTION
This dropdown component was causing 'Accessibility check failed!' errors in my cypress tests. Below is a screenshot of the produced error. Simple fix was just to add an aria-label to the component. 
<img width="931" alt="Screen Shot 2021-08-06 at 9 41 32 AM" src="https://user-images.githubusercontent.com/8205569/128543752-12a321b7-7c91-492e-bb7b-f664b75896c4.png">
