### PR TITLE
[Dropdown] Add optional id prop

### DIFF
--- a/src/shared-components/dropdown/desktopDropdown.tsx
+++ b/src/shared-components/dropdown/desktopDropdown.tsx
@@ -14,6 +14,7 @@ interface DesktopDropdownProps<T> {
   borderRadius: string;
   closeDropdown: () => void;
   currentOption?: T;
+  id?: string;
   isOpen: boolean;
   onDesktopSelectChange: (
     event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>,
@@ -29,6 +30,7 @@ export const DesktopDropdown = <T extends OptionType>({
   borderRadius,
   closeDropdown,
   currentOption,
+  id,
   isOpen,
   onDesktopSelectChange,
   options,
@@ -88,6 +90,7 @@ export const DesktopDropdown = <T extends OptionType>({
 
         <Style.DropdownOptionsContainer
           borderRadius={borderRadius}
+          id={id}
           isOpen={isOpen}
           optionsContainerMaxHeight={optionsContainerMaxHeight}
           role="menu"
@@ -102,15 +105,15 @@ export const DesktopDropdown = <T extends OptionType>({
               ...rest
             } = option;
 
-            const id = isDefined(optionValue)
+            const optionId = isDefined(optionValue)
               ? `${optionValue}`
               : `undefined-${index}`;
 
             return (
               <Style.DropdownOption
-                key={id}
+                key={optionId}
                 value={optionValue}
-                id={id}
+                id={optionId}
                 selected={value === optionValue}
                 disabled={disabled}
                 onClick={onDesktopSelectChange}

--- a/src/shared-components/dropdown/index.tsx
+++ b/src/shared-components/dropdown/index.tsx
@@ -27,6 +27,10 @@ export interface OptionType {
 interface DropdownProps<T> {
   borderRadius?: string;
   /**
+   * ID for label associated control
+   */
+  id?: string;
+  /**
    * The handler to be invoked on option change
    */
   onChange: (option: T) => void;
@@ -48,6 +52,7 @@ interface DropdownProps<T> {
  */
 export const Dropdown = <T extends OptionType>({
   borderRadius,
+  id,
   onChange,
   options,
   optionsContainerMaxHeight = '250px',
@@ -113,6 +118,7 @@ export const Dropdown = <T extends OptionType>({
     return (
       <MobileDropdown
         borderRadius={borderRadiusValue}
+        id={id}
         onMobileSelectChange={onMobileSelectChange}
         options={options}
         textAlign={textAlign}
@@ -128,6 +134,7 @@ export const Dropdown = <T extends OptionType>({
       borderRadius={borderRadiusValue}
       closeDropdown={closeDropdown}
       currentOption={currentOption}
+      id={id}
       isOpen={isOpen}
       onDesktopSelectChange={onDesktopSelectChange}
       options={options}
@@ -141,6 +148,7 @@ export const Dropdown = <T extends OptionType>({
 
 Dropdown.propTypes = {
   borderRadius: PropTypes.string,
+  id: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/shared-components/dropdown/mobileDropdown.tsx
+++ b/src/shared-components/dropdown/mobileDropdown.tsx
@@ -8,6 +8,7 @@ import { OptionType, OptionValue } from '.';
 
 interface MobileDropdownProps<T> {
   borderRadius: string;
+  id?: string;
   onMobileSelectChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
   options: T[];
   textAlign: 'left' | 'center';
@@ -21,6 +22,7 @@ interface MobileDropdownProps<T> {
  */
 export const MobileDropdown = <T extends OptionType>({
   borderRadius,
+  id,
   onMobileSelectChange,
   options,
   textAlign,
@@ -37,6 +39,7 @@ export const MobileDropdown = <T extends OptionType>({
           textAlign,
           theme,
         })}
+        id={id}
         value={value ?? ''}
         onChange={onMobileSelectChange}
       >


### PR DESCRIPTION
This PR continues the work of #1110 by adding an optional id prop so that we can associate `<label for="unique-field-identifier" />` with the Dropdown by passing the id to it, e.g. `<select id="unique-field-identifier" />`. We previously removed ID in #307 because it was not unique, but this ID is meant to be used in conjunction with our existing form components. 

Future PRs can look into more robust a11y handling via `react-aria` and consideration of orchestrating certain prop configurations as non-optional so as to raise type errors in accordance with a11y errors. 