### PR TITLE
[Glyphs] Update CleanserGlyphSecondary

### DIFF
--- a/src/icons/glyphs/cleanserGlyph.ts
+++ b/src/icons/glyphs/cleanserGlyph.ts
@@ -1,5 +1,5 @@
-import { CleanserGlyph } from './svgs';
+import { CleanserGlyph, CleanserGlyphSecondary } from './svgs';
 import { useIcon, IconProps } from '../../shared-components/icon';
 
 export default (props: IconProps) =>
-  useIcon(CleanserGlyph, CleanserGlyph, props);
+  useIcon(CleanserGlyph, CleanserGlyphSecondary, props);


### PR DESCRIPTION
This PR adds `CleanserGlyphSecondary` to the CleanserGlyph export.
<img width="94" alt="cleanser-glyph" src="https://user-images.githubusercontent.com/83731749/132897972-f35f1728-bb70-4f36-ad97-442c72b7b8a9.png">
