### PR TITLE
[SegmentedControl] Refinements

### DIFF
--- a/src/shared-components/segmentedControl/__snapshots__/test.tsx.snap
+++ b/src/shared-components/segmentedControl/__snapshots__/test.tsx.snap
@@ -55,7 +55,6 @@ exports[`<SegmentedControl /> renders a regular segmented control 1`] = `
   -moz-transform: translate3d(0px, 0, 0);
   -ms-transform: translate3d(0px, 0, 0);
   transform: translate3d(0px, 0, 0);
-  box-shadow: 0px 2px 4px rgba(51, 46, 84, 0.05);
   border: 4px solid #EDEDF0;
 }
 
@@ -83,7 +82,7 @@ exports[`<SegmentedControl /> renders a regular segmented control 1`] = `
   top: 0;
   left: 0;
   bottom: 0;
-  border: 4px solid #EDEDF0;
+  padding: 0.25rem;
   color: #706D87;
   font-size: 0.875rem;
   line-height: 1.71;

--- a/src/shared-components/segmentedControl/__snapshots__/test.tsx.snap
+++ b/src/shared-components/segmentedControl/__snapshots__/test.tsx.snap
@@ -15,10 +15,9 @@ exports[`<SegmentedControl /> renders a regular segmented control 1`] = `
   -webkit-justify-content: space-between;
   justify-content: space-between;
   position: relative;
-  border-radius: 80px;
+  border-radius: 32px;
   background-color: #EDEDF0;
   padding: 0.25rem;
-  border: 4px solid #EDEDF0;
 }
 
 .emotion-2 {
@@ -39,14 +38,14 @@ exports[`<SegmentedControl /> renders a regular segmented control 1`] = `
   cursor: pointer;
   margin: 0;
   position: absolute;
-  border-radius: 80px;
+  border-radius: 32px;
   width: 33.333333333333336%;
   top: 0;
   left: 0;
   bottom: 0;
   background-color: white;
-  -webkit-transition: -webkit-transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
-  transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+  -webkit-transition: -webkit-transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+  transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
   color: #706D87;
   font-size: 0.875rem;
   line-height: 1.71;
@@ -57,7 +56,7 @@ exports[`<SegmentedControl /> renders a regular segmented control 1`] = `
   -ms-transform: translate3d(0px, 0, 0);
   transform: translate3d(0px, 0, 0);
   box-shadow: 0px 2px 4px rgba(51, 46, 84, 0.05);
-  border: none;
+  border: 4px solid #EDEDF0;
 }
 
 .emotion-2:focus {
@@ -84,12 +83,12 @@ exports[`<SegmentedControl /> renders a regular segmented control 1`] = `
   top: 0;
   left: 0;
   bottom: 0;
-  border: none;
+  border: 4px solid #EDEDF0;
   color: #706D87;
   font-size: 0.875rem;
   line-height: 1.71;
   color: #706D87;
-  border-radius: 80px;
+  border-radius: 32px;
   background-color: #EDEDF0;
   width: 33.333333333333336%;
 }

--- a/src/shared-components/segmentedControl/__snapshots__/test.tsx.snap
+++ b/src/shared-components/segmentedControl/__snapshots__/test.tsx.snap
@@ -78,7 +78,7 @@ exports[`<SegmentedControl /> renders a regular segmented control 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  margin: 0;
+  margin: 0 0.125rem;
   top: 0;
   left: 0;
   bottom: 0;

--- a/src/shared-components/segmentedControl/__snapshots__/test.tsx.snap
+++ b/src/shared-components/segmentedControl/__snapshots__/test.tsx.snap
@@ -17,7 +17,7 @@ exports[`<SegmentedControl /> renders a regular segmented control 1`] = `
   position: relative;
   border-radius: 32px;
   background-color: #EDEDF0;
-  padding: 0.25rem;
+  padding: 0.25rem 0;
 }
 
 .emotion-2 {
@@ -105,26 +105,22 @@ exports[`<SegmentedControl /> renders a regular segmented control 1`] = `
   <button
     class="emotion-2 emotion-3"
     transform="translate3d(0px, 0, 0)"
-    width="33.333333333333336"
   >
     Tab 1
   </button>
   <button
     class="emotion-4 emotion-5"
     disabled=""
-    width="33.333333333333336"
   >
     Tab 1
   </button>
   <button
     class="emotion-4 emotion-5"
-    width="33.333333333333336"
   >
     Tab 2
   </button>
   <button
     class="emotion-4 emotion-5"
-    width="33.333333333333336"
   >
     Tab 3
   </button>

--- a/src/shared-components/segmentedControl/index.tsx
+++ b/src/shared-components/segmentedControl/index.tsx
@@ -4,7 +4,9 @@ import { SegmentsContainer, SegmentItem, Indicator } from './style';
 import { SegmentedControlProps, SegmentItemType } from './types';
 
 /**
- * The width of the top-level container is set to 100%, so it will expand to fill its parent container. Set a non-percentage `width` on the parent element during implementation to avoid stretched-out layout or animation effects.
+ * The width of the top-level container is set to 100%, so it will expand to fill its parent container.
+ *
+ * Set a non-percentage `width` on the parent element during implementation to avoid stretched-out layout or animation effects.
  */
 export const SegmentedControl: React.FC<SegmentedControlProps> = ({
   segmentItems,
@@ -24,9 +26,8 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
   const [activeSegmentText, setActiveSegmentText] = useState(() =>
     initialActiveItem ? initialActiveItem.text : segmentItems[0].text,
   );
-  const [activeSegmentIndex, setActiveSegmentIndex] = useState(
-    initialActiveIndex,
-  );
+  const [activeSegmentIndex, setActiveSegmentIndex] =
+    useState(initialActiveIndex);
   const targetRef = useRef<HTMLButtonElement>(null);
   const [transform, setTransform] = useState('');
   const [targetWidth, setTargetWidth] = useState(0);
@@ -47,7 +48,10 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
     setActiveSegmentText(segment.text);
     setActiveSegmentIndex(index);
     setTransform(`translate3d(${targetWidth * index}px, 0, 0)`);
-    return onClick ? onClick(segment) : null;
+
+    if (onClick) {
+      onClick(segment);
+    }
   };
 
   return (
@@ -60,7 +64,9 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
           width={segmentWidth}
           active={index === activeSegmentIndex}
           key={segment.id}
-          onClick={() => onSegmentClick(segment, index)}
+          onClick={() => {
+            onSegmentClick(segment, index);
+          }}
           disabled={index === activeSegmentIndex}
         >
           {segment.text}

--- a/src/shared-components/segmentedControl/index.tsx
+++ b/src/shared-components/segmentedControl/index.tsx
@@ -13,12 +13,16 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
   initialActiveId = 1,
   onClick,
 }) => {
-  if (segmentItems.length === 0) {
+  const itemsCount = segmentItems.length;
+
+  if (itemsCount === 0) {
     return null;
   }
+
   const initialActiveItem = segmentItems.find(
     (item: SegmentItemType) => item.id === initialActiveId,
   );
+
   const initialActiveIndex = initialActiveItem
     ? segmentItems.indexOf(initialActiveItem)
     : 0;
@@ -31,7 +35,7 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
   const targetRef = useRef<HTMLButtonElement>(null);
   const [transform, setTransform] = useState('');
   const [targetWidth, setTargetWidth] = useState(0);
-  const segmentWidth = 100 / segmentItems.length;
+  const segmentWidth = 100 / itemsCount;
 
   useEffect(() => {
     if (targetRef.current) {
@@ -53,15 +57,18 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
       onClick(segment);
     }
   };
-
   return (
     <SegmentsContainer>
-      <Indicator width={segmentWidth} transform={transform} ref={targetRef}>
+      <Indicator
+        segmentWidth={segmentWidth}
+        transform={transform}
+        ref={targetRef}
+      >
         {activeSegmentText}
       </Indicator>
       {segmentItems.map((segment, index) => (
         <SegmentItem
-          width={segmentWidth}
+          segmentWidth={segmentWidth}
           active={index === activeSegmentIndex}
           key={segment.id}
           onClick={() => {

--- a/src/shared-components/segmentedControl/style.ts
+++ b/src/shared-components/segmentedControl/style.ts
@@ -35,7 +35,7 @@ export const SegmentItem = styled.button<SegmentItemProps>`
   top: 0;
   left: 0;
   bottom: 0;
-  border: 4px solid ${({ theme }) => theme.COLORS.border};
+  padding: ${SPACER.xsmall};
   ${({ theme }) => TYPOGRAPHY_STYLE.caption(theme)};
   color: ${({ theme }) => theme.COLORS.primaryTint2};
   border-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
@@ -68,7 +68,6 @@ export const Indicator = styled.button<IndicatorProps>`
   color: ${({ theme }) => theme.COLORS.primary};
   font-weight: bold;
   transform: ${({ transform }) => transform};
-  box-shadow: 0px 2px 4px rgba(51, 46, 84, 0.05);
   border: 4px solid ${({ theme }) => theme.COLORS.border};
 
   &:focus {

--- a/src/shared-components/segmentedControl/style.ts
+++ b/src/shared-components/segmentedControl/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { buttonReset } from 'src/utils/styles/buttonReset';
 
-import { SPACER, ThemeType } from '../../constants';
+import { SPACER } from '../../constants';
 import { TYPOGRAPHY_STYLE } from '../typography';
 
 interface SegmentItemProps {
@@ -16,17 +16,13 @@ interface IndicatorProps {
   width: number;
 }
 
-// This border radius value is only used for the SegmentedControl component.
-const getSegmentedControlBorderRadius = (theme: ThemeType) =>
-  theme.__type === 'primary' ? '80px' : '0';
-
 export const SegmentsContainer = styled.div`
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
   position: relative;
-  border-radius: ${({ theme }) => getSegmentedControlBorderRadius(theme)};
+  border-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
   background-color: ${({ theme }) => theme.COLORS.border};
   padding: ${SPACER.xsmall};
   border: 4px solid ${({ theme }) => theme.COLORS.border};
@@ -44,9 +40,10 @@ export const SegmentItem = styled.button<SegmentItemProps>`
   border: none;
   ${({ theme }) => TYPOGRAPHY_STYLE.caption(theme)};
   color: ${({ theme }) => theme.COLORS.primaryTint2};
-  border-radius: ${({ theme }) => getSegmentedControlBorderRadius(theme)};
+  border-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
   background-color: ${({ theme }) => theme.COLORS.border};
   width: ${({ width }) => `${width}%`};
+
   &:focus {
     outline: none;
     box-shadow: 0px 0px 0px 2px ${({ theme }) => theme.COLORS.primary};
@@ -62,19 +59,20 @@ export const Indicator = styled.button<IndicatorProps>`
   cursor: pointer;
   margin: 0;
   position: absolute;
-  border-radius: ${({ theme }) => getSegmentedControlBorderRadius(theme)};
+  border-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
   width: ${({ width }) => `${width}%`};
   top: 0;
   left: 0;
   bottom: 0;
   background-color: white;
-  transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+  transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
   ${({ theme }) => TYPOGRAPHY_STYLE.caption(theme)};
   color: ${({ theme }) => theme.COLORS.primary};
   font-weight: bold;
   transform: ${({ transform }) => transform};
   box-shadow: 0px 2px 4px rgba(51, 46, 84, 0.05);
   border: none;
+
   &:focus {
     box-shadow: ${({ theme }) => theme.BOX_SHADOWS.focusInner};
     outline: none;

--- a/src/shared-components/segmentedControl/style.ts
+++ b/src/shared-components/segmentedControl/style.ts
@@ -31,7 +31,7 @@ export const SegmentItem = styled.button<SegmentItemProps>`
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 0;
+  margin: 0 ${SPACER.x2small};
   top: 0;
   left: 0;
   bottom: 0;

--- a/src/shared-components/segmentedControl/style.ts
+++ b/src/shared-components/segmentedControl/style.ts
@@ -7,12 +7,12 @@ import { TYPOGRAPHY_STYLE } from '../typography';
 interface SegmentItemProps {
   active: boolean;
   onClick: () => void;
-  width: number;
+  segmentWidth: number;
 }
 
 interface IndicatorProps {
+  segmentWidth: number;
   transform: string;
-  width: number;
 }
 
 export const SegmentsContainer = styled.div`
@@ -23,7 +23,7 @@ export const SegmentsContainer = styled.div`
   position: relative;
   border-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
   background-color: ${({ theme }) => theme.COLORS.border};
-  padding: ${SPACER.xsmall};
+  padding: ${SPACER.xsmall} 0;
 `;
 
 export const SegmentItem = styled.button<SegmentItemProps>`
@@ -40,7 +40,7 @@ export const SegmentItem = styled.button<SegmentItemProps>`
   color: ${({ theme }) => theme.COLORS.primaryTint2};
   border-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
   background-color: ${({ theme }) => theme.COLORS.border};
-  width: ${({ width }) => `${width}%`};
+  width: ${({ segmentWidth }) => `${segmentWidth}%;`};
 
   &:focus {
     outline: none;
@@ -58,7 +58,7 @@ export const Indicator = styled.button<IndicatorProps>`
   margin: 0;
   position: absolute;
   border-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
-  width: ${({ width }) => `${width}%`};
+  width: ${({ segmentWidth }) => `${segmentWidth}%`};
   top: 0;
   left: 0;
   bottom: 0;

--- a/src/shared-components/segmentedControl/style.ts
+++ b/src/shared-components/segmentedControl/style.ts
@@ -6,7 +6,6 @@ import { TYPOGRAPHY_STYLE } from '../typography';
 
 interface SegmentItemProps {
   active: boolean;
-  key: number;
   onClick: () => void;
   width: number;
 }
@@ -25,7 +24,6 @@ export const SegmentsContainer = styled.div`
   border-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
   background-color: ${({ theme }) => theme.COLORS.border};
   padding: ${SPACER.xsmall};
-  border: 4px solid ${({ theme }) => theme.COLORS.border};
 `;
 
 export const SegmentItem = styled.button<SegmentItemProps>`
@@ -37,7 +35,7 @@ export const SegmentItem = styled.button<SegmentItemProps>`
   top: 0;
   left: 0;
   bottom: 0;
-  border: none;
+  border: 4px solid ${({ theme }) => theme.COLORS.border};
   ${({ theme }) => TYPOGRAPHY_STYLE.caption(theme)};
   color: ${({ theme }) => theme.COLORS.primaryTint2};
   border-radius: ${({ theme }) => theme.BORDER_RADIUS.large};
@@ -71,7 +69,7 @@ export const Indicator = styled.button<IndicatorProps>`
   font-weight: bold;
   transform: ${({ transform }) => transform};
   box-shadow: 0px 2px 4px rgba(51, 46, 84, 0.05);
-  border: none;
+  border: 4px solid ${({ theme }) => theme.COLORS.border};
 
   &:focus {
     box-shadow: ${({ theme }) => theme.BOX_SHADOWS.focusInner};

--- a/src/shared-components/segmentedControl/test.tsx
+++ b/src/shared-components/segmentedControl/test.tsx
@@ -12,7 +12,7 @@ const testSegmentedControl = {
 };
 
 describe('<SegmentedControl />', () => {
-  test('renders a regular segmented control', () => {
+  it('renders a regular segmented control', () => {
     const { container } = render(
       <SegmentedControl {...testSegmentedControl} />,
     );
@@ -20,7 +20,7 @@ describe('<SegmentedControl />', () => {
     expect(container.firstElementChild).toMatchSnapshot();
   });
 
-  test('calls onClick when button is clicked', () => {
+  it('calls onClick when button is clicked', () => {
     const spy = jest.fn();
 
     const { getByRole } = render(

--- a/src/shared-components/segmentedControl/types.ts
+++ b/src/shared-components/segmentedControl/types.ts
@@ -1,16 +1,16 @@
-export type SegmentedControlProps = {
+export interface SegmentedControlProps {
   /**
    * Initial segment id to display as active
    */
   initialActiveId?: number;
-  segmentItems: SegmentItemType[];
   /**
    * Callback invoked on `segmentItem` click
    */
   onClick?: (segment: SegmentItemType) => void;
-};
+  segmentItems: SegmentItemType[];
+}
 
-export type SegmentItemType = {
+export interface SegmentItemType {
   id: number;
   text: string;
-};
+}

--- a/stories/field/index.stories.tsx
+++ b/stories/field/index.stories.tsx
@@ -189,7 +189,6 @@ export const WithControls = () => (
   <FieldsContainer>
     <Field
       disabled={boolean('disabled', false)}
-      // @ts-expect-error: select + Field['message'] type compat issue
       messages={select('messages', messagesOptions, {})}
       messagesType={
         select('messagesType', messagesTypeOptions, 'error') as

--- a/stories/segmentedControl/index.stories.tsx
+++ b/stories/segmentedControl/index.stories.tsx
@@ -11,6 +11,7 @@ import {
 } from '@storybook/addon-docs/blocks';
 import type { Meta } from '@storybook/react';
 import { SegmentItemType } from 'src/shared-components/segmentedControl/types';
+import { FocusScope, useFocusManager } from '@react-aria/focus';
 
 const SegmentedControlContainer = styled.div<{ segmentedWidth?: number }>`
   width: ${({ segmentedWidth = 500 }) => `${segmentedWidth}px`};
@@ -34,6 +35,48 @@ export const TwoItems = () => {
   );
 };
 
+interface SegmentedControlWithFocusScopeProps {
+  onClick: (segment: SegmentItemType) => void;
+  segmentItems: SegmentItemType[];
+}
+
+const SegmentedControlWithFocusScope: React.FC<SegmentedControlWithFocusScopeProps> =
+  ({ onClick, segmentItems }) => {
+    const focusManager = useFocusManager();
+
+    React.useEffect(() => {
+      focusManager.focusLast({ wrap: true });
+    }, []);
+
+    return <SegmentedControl onClick={onClick} segmentItems={segmentItems} />;
+  };
+
+/**
+ * TODO: Add regression test to currently-active tab focus state after figuring out why it does not
+ * work by default (z-index, disabled buttons, etc.)
+ */
+export const TwoItemsWithFocusOnLastItem = () => {
+  const twoItems = [
+    { id: 1, text: 'Option 1' },
+    { id: 2, text: 'Option 2' },
+  ];
+
+  const onClick = (segment: SegmentItemType) => {
+    console.log(segment);
+  };
+
+  return (
+    <SegmentedControlContainer segmentedWidth={344}>
+      <FocusScope autoFocus contain restoreFocus>
+        <SegmentedControlWithFocusScope
+          onClick={onClick}
+          segmentItems={twoItems}
+        />
+      </FocusScope>
+    </SegmentedControlContainer>
+  );
+};
+
 export const ThreeItems = () => {
   const threeItems = [
     { id: 1, text: 'Option 1' },
@@ -51,6 +94,30 @@ export const ThreeItems = () => {
     </SegmentedControlContainer>
   );
 };
+
+export const ThreeItemsWithFocusOnLastItem = () => {
+  const threeItems = [
+    { id: 1, text: 'Option 1' },
+    { id: 2, text: 'Option 2' },
+    { id: 3, text: 'Option 3' },
+  ];
+
+  const onClick = (segment: SegmentItemType) => {
+    console.log(segment);
+  };
+
+  return (
+    <SegmentedControlContainer segmentedWidth={349}>
+      <FocusScope autoFocus contain restoreFocus>
+        <SegmentedControlWithFocusScope
+          onClick={onClick}
+          segmentItems={threeItems}
+        />
+      </FocusScope>
+    </SegmentedControlContainer>
+  );
+};
+
 /* eslint-enable no-console */
 
 const THEME_STORIES: Meta = {

--- a/stories/segmentedControl/index.stories.tsx
+++ b/stories/segmentedControl/index.stories.tsx
@@ -12,8 +12,8 @@ import {
 import type { Meta } from '@storybook/react';
 import { SegmentItemType } from 'src/shared-components/segmentedControl/types';
 
-const SegmentedControlContainer = styled.div<{ width?: string }>`
-  width: ${({ width = '500px' }) => width};
+const SegmentedControlContainer = styled.div<{ segmentedWidth?: number }>`
+  width: ${({ segmentedWidth = 500 }) => `${segmentedWidth}px`};
 `;
 
 /* eslint-disable no-console */
@@ -28,7 +28,7 @@ export const TwoItems = () => {
   };
 
   return (
-    <SegmentedControlContainer width="300px">
+    <SegmentedControlContainer segmentedWidth={344}>
       <SegmentedControl onClick={onClick} segmentItems={twoItems} />
     </SegmentedControlContainer>
   );
@@ -46,7 +46,7 @@ export const ThreeItems = () => {
   };
 
   return (
-    <SegmentedControlContainer>
+    <SegmentedControlContainer segmentedWidth={349}>
       <SegmentedControl onClick={onClick} segmentItems={threeItems} />
     </SegmentedControlContainer>
   );


### PR DESCRIPTION
### CHANGELOG

1. Run `eslint --fix` to address new standards since branch was created.
1. Replace `80px` `border-radius` with `theme.BORDER_RADIUS.large`.
    - It is accurately `0` for the secondary theme, and it is `32px` for the primary theme, which is equal to `80px` (you can edit in your dev tools to examine this.)
1. Update `transition: transform 0.22s` to `transition: transform 0.3s` to match `300ms` specified in Figma spec: <img width="310" alt="Screen Shot 2021-09-24 at 12 24 01 AM" src="https://user-images.githubusercontent.com/13544620/134617962-875a2d46-dee8-405c-9827-70f3481c4ccd.png">
1. Move `border` style from item container to individual segment items to prevent issue of `Indicator` being presentationally different from the other segment items.
    - Before: <img width="520" alt="Screen Shot 2021-09-24 at 12 29 39 AM" src="https://user-images.githubusercontent.com/13544620/134618445-b5a2d9a1-48d5-4437-9e2a-f620191e2382.png">
         - The height of the `position: absolute` element was larger because the `border` on the parent was not affecting the height. 
    - After: <img width="518" alt="Screen Shot 2021-09-24 at 12 29 46 AM" src="https://user-images.githubusercontent.com/13544620/134618498-9c9ccc73-c36c-4f3d-bd52-54f391e88a82.png">
    
    **TODO:** There' still some refinement that could be made here: the absolutely positioned indicator is 172px width compared to 168px width for the non-indicator buttons, so they should be made more consistent, probably. 
1. Update the width handling--by removing the horizontal padding from `padding: 0.25rem`--such that the `position: absolute` Indicator element width matches the other elements. 
    - Before: 
    
    https://user-images.githubusercontent.com/13544620/134618026-81e8636e-56aa-4f63-b4cd-1de188d9fd1c.mov
    - After: 
    
    https://user-images.githubusercontent.com/13544620/134618040-3ecd3bb8-f0bf-4b4a-a1ce-47c14e694df8.mov
1. Add visual regression tests for un-selected focus state. 

### TODO for future PRs

The current functionality sits somewhere between a [RadioGroup](https://react-spectrum.adobe.com/react-aria/useRadioGroup.html) and a [TabList](https://react-spectrum.adobe.com/react-aria/useTabList.html). In both examples the keyboard controls use tabbing to focus the options, and then arrow keys to toggle between the options, where changing the selection is done automatically, without a button "click" event. 

If we decide to use neither of these paradigms, the biggest problem right now is that because the Indicator comes before the more appropriately interactive button elements, toggling through the options sometimes paradoxically goes backwards in order. This video shows normal tabbing behavior: the first selection is the indicator, and then it starts from the first available button, and then skips the button that matches the indicator selection and proceeds to the next focusable element:

https://user-images.githubusercontent.com/13544620/135016279-dce30f20-ad01-4d1a-8a08-74d7811647e7.mov

This needs to be fixed in a future PR, but for now we are maintaining this behavior to unblock UI development this week. 



