### PR TITLE
[AnchorLinkButton] Allow all valid HTMLButtonProps

### DIFF
--- a/src/shared-components/button/components/anchorLinkButton/index.tsx
+++ b/src/shared-components/button/components/anchorLinkButton/index.tsx
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 
 import Style from './style';
 
-export interface AnchorLinkButtonProps {
+export interface AnchorLinkButtonProps
+  extends React.DetailedHTMLProps<
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    HTMLButtonElement
+  > {
   /**
    * Text to be displayed
    */
@@ -28,10 +32,11 @@ type ButtonRefType =
 export const AnchorLinkButton: React.ForwardRefExoticComponent<
   AnchorLinkButtonProps & React.RefAttributes<HTMLButtonElement>
 > = React.forwardRef((props: AnchorLinkButtonProps, ref: ButtonRefType) => {
-  const { children, onClick } = props;
+  const { children, onClick, ...rest } = props;
 
   return (
     <button
+      {...rest}
       ref={ref}
       css={Style.anchorLinkButton}
       onClick={onClick}

--- a/src/shared-components/button/components/anchorLinkButton/test.tsx
+++ b/src/shared-components/button/components/anchorLinkButton/test.tsx
@@ -12,5 +12,18 @@ describe('<AnchorLinkButton/>', () => {
 
       expect(container.firstElementChild).toMatchSnapshot();
     });
+
+    it('passes down all valid button props to underlying button', () => {
+      const label = 'Click me for more information';
+
+      const { getByLabelText } = render(
+        <AnchorLinkButton onClick={() => undefined} aria-label={label}>
+          Click me
+        </AnchorLinkButton>,
+      );
+
+      const button = getByLabelText(label);
+      expect(button).toHaveTextContent('Click me');
+    });
   });
 });


### PR DESCRIPTION
We don't currently spread any props in AnchorLinkButton to keep the API constrained, but since it's ultimately an underlying `button` element we can allow any valid HTMLButtonProps to pass through.