### PR TITLE
[AnchorLinkButton] Remove text-decoration-skip-ink style

### DIFF
--- a/src/shared-components/button/components/anchorLinkButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/button/components/anchorLinkButton/__snapshots__/test.tsx.snap
@@ -15,7 +15,6 @@ exports[`<AnchorLinkButton/> UI snapshots to double-check regressions renders wi
   padding: 0;
   -webkit-text-decoration: underline;
   text-decoration: underline;
-  text-decoration-skip-ink: none;
   font-size: 0.875rem;
   border-radius: 4px;
 }

--- a/src/shared-components/button/components/anchorLinkButton/style.ts
+++ b/src/shared-components/button/components/anchorLinkButton/style.ts
@@ -13,7 +13,6 @@ const anchorLinkButton = (theme: ThemeType) => css`
   border: none;
   padding: 0;
   text-decoration: underline;
-  text-decoration-skip-ink: none;
   font-size: ${theme.TYPOGRAPHY.fontSize.link};
   border-radius: ${theme.BORDER_RADIUS.small};
 `;


### PR DESCRIPTION
When I added this component I made a somewhat unilateral decision to apply a `text-decoration-skip-ink` style to the component. The Figma design library does not have any letters (like y, g, p, etc.) that indicate one way or the other whether we want to apply this style. However, the majority of our non-`AnchorLinkButton` usage allows the letters to take precedence over the underline, and so this change lets that component do that, too. 

Before:

<img width="139" alt="Screen Shot 2021-10-28 at 11 54 30 AM" src="https://user-images.githubusercontent.com/13544620/139317989-7688d6ce-6249-4a33-9497-99b96d356c58.png">

After (matching other usage):
<img width="145" alt="Screen Shot 2021-10-28 at 11 54 23 AM" src="https://user-images.githubusercontent.com/13544620/139318013-e58672d2-f9fc-4d63-b7e8-882803adda35.png">


