### PR TITLE
Add .sr-only class for screen reader text

### DIFF
--- a/src/shared-components/globalStyles/style.ts
+++ b/src/shared-components/globalStyles/style.ts
@@ -265,4 +265,16 @@ export const brandStyles = (theme: ThemeType) => `
   .no-scroll {
     overflow: hidden;
   }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    white-space: nowrap;
+    border: 0;
+  }
 `;


### PR DESCRIPTION
Adds an `.sr-only` class to the global brand styles, taking inspiration from [Bootstrap's screen reader utility](https://getbootstrap.com/docs/4.5/utilities/screen-readers/).

If there is a better way to expose this styling globally via an emotion `css` function, I'd also be very open to that implementation. I suppose we could expose it as a styled component, but that seems much less ergonomic for the purposes of using these styles on various elements.