### PR TITLE
[CircleCI] [Heroku] Configure package.json#engines with more specificity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
   build-js:
     <<: *defaults
     docker:
-      - image: circleci/node:12-stretch
+      - image: circleci/node:16-stretch
 
     steps:
       - checkout
@@ -70,7 +70,7 @@ jobs:
   build:
     <<: *defaults
     docker:
-      - image: circleci/node:12-stretch
+      - image: circleci/node:16-stretch
 
     steps:
       - checkout
@@ -86,7 +86,7 @@ jobs:
   lint-js:
     <<: *defaults
     docker:
-      - image: circleci/node:12-stretch
+      - image: circleci/node:16-stretch
 
     steps:
       - checkout
@@ -103,7 +103,7 @@ jobs:
   test-js:
     <<: *defaults
     docker:
-      - image: circleci/node:12-stretch
+      - image: circleci/node:16-stretch
 
     steps:
       - checkout
@@ -122,7 +122,7 @@ jobs:
   test-tsc:
     <<: *defaults
     docker:
-      - image: circleci/node:12-stretch
+      - image: circleci/node:16-stretch
 
     environment:
       NODE_OPTIONS: --max_old_space_size=4096

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": ">=12.13.0"
+    "node": "16.x",
+    "yarn": "1.x"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Heroku review apps have been broken since mid-October (!). The culprit appears to be a our lax `engines.node` settings, which means Heroku has been running `node` v17 and appears to be incompatible with part of our toolchain. This PR sets it to 16, and updates CircleCI, to match what most folks are running locally. TODO: Make this more specific with something like NVM.

https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version

### Other

Sets `yarn` to v1 explicitly even though Heroku defaults to v1.