### PR TITLE
Update default input color

### DIFF
--- a/src/shared-components/globalStyles/style.ts
+++ b/src/shared-components/globalStyles/style.ts
@@ -221,7 +221,7 @@ export const brandStyles = (theme: ThemeType) => `
     transition-timing-function: ease-in-out;
   }
 
-  input {
+  input:is([type="button"], [type="submit"], [type="reset"]), input[type="file"]::file-selector-button, button {
     color: ${theme.COLORS.primary};
   }
 

--- a/src/shared-components/globalStyles/style.ts
+++ b/src/shared-components/globalStyles/style.ts
@@ -221,6 +221,10 @@ export const brandStyles = (theme: ThemeType) => `
     transition-timing-function: ease-in-out;
   }
 
+  input {
+    color: ${theme.COLORS.primary};
+  }
+
   img {
     max-width: 100%;
   }


### PR DESCRIPTION
The color on inputs were showing up as blue on IOS 15 devices because Apple introduced a default color to all inputs. This sets our own default color so the inputs don't fallback to the IOS default.