### PR TITLE
[Hotfix] Allow node 14 in package.json#engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": "16.x",
+    "node": "14.x || 16.x",
     "yarn": "1.x"
   },
   "scripts": {


### PR DESCRIPTION
I bumped node to 16 to resolve some Heroku build issues in #1283 but broke downstream v14 usage in our consumer apps. This PR will unbreak that behavior. 