### PR TITLE
[Bugfix] ImmersiveModal and OffClickWrapper

### DIFF
--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -63,9 +63,11 @@ export const DialogModal: DialogModal = ({
   useEffect(() => {
     domNode.current = getDomNode();
     htmlNode.current = getHtmlNode();
-    htmlNode.current.classList.add('no-scroll');
+    const htmlNodeInstance = htmlNode.current;
+
+    htmlNodeInstance.classList.add('no-scroll');
     return () => {
-      htmlNode.current.classList.remove('no-scroll');
+      htmlNodeInstance.classList.remove('no-scroll');
     };
   }, []);
 

--- a/src/shared-components/immersiveModal/index.tsx
+++ b/src/shared-components/immersiveModal/index.tsx
@@ -205,34 +205,40 @@ export const ImmersiveModal: ImmersiveModal = ({
     modalMobileScrollingElement.current = getModalMobileScrollingElement();
     modalDesktopScrollingElement.current = getModalDesktopScrollingElement();
 
-    htmlNode.current.classList.add('no-scroll');
+    const htmlNodeInstance = htmlNode.current;
+    const modalMobileScrollingElementInstance =
+      modalMobileScrollingElement.current;
+    const modalDesktopScrollingElementInstance =
+      modalDesktopScrollingElement.current;
+
+    htmlNodeInstance.classList.add('no-scroll');
 
     if (
-      modalMobileScrollingElement.current &&
-      modalDesktopScrollingElement.current
+      modalMobileScrollingElementInstance &&
+      modalDesktopScrollingElementInstance
     ) {
-      modalMobileScrollingElement.current.addEventListener(
+      modalMobileScrollingElementInstance.addEventListener(
         'scroll',
         handleScroll,
       );
-      modalDesktopScrollingElement.current.addEventListener(
+      modalDesktopScrollingElementInstance.addEventListener(
         'scroll',
         handleScroll,
       );
     }
 
     return () => {
-      htmlNode.current.classList.remove('no-scroll');
+      htmlNodeInstance.classList.remove('no-scroll');
 
       if (
-        modalMobileScrollingElement.current &&
-        modalDesktopScrollingElement.current
+        modalMobileScrollingElementInstance &&
+        modalDesktopScrollingElementInstance
       ) {
-        modalMobileScrollingElement.current.removeEventListener(
+        modalMobileScrollingElementInstance.removeEventListener(
           'scroll',
           handleScroll,
         );
-        modalDesktopScrollingElement.current.removeEventListener(
+        modalDesktopScrollingElementInstance.removeEventListener(
           'scroll',
           handleScroll,
         );

--- a/src/shared-components/offClickWrapper/index.tsx
+++ b/src/shared-components/offClickWrapper/index.tsx
@@ -41,8 +41,8 @@ export const OffClickWrapper: React.FC<OffClickWrapperProps> = ({
   };
 
   useEffect(() => {
-    document.addEventListener('click', handleOffClick, false);
-    document.addEventListener('keydown', handleKeyPress, false);
+    document.addEventListener('click', handleOffClick, { capture: true });
+    document.addEventListener('keydown', handleKeyPress, { capture: true });
     return () => {
       document.removeEventListener('click', handleOffClick, false);
       document.removeEventListener('keydown', handleKeyPress, false);


### PR DESCRIPTION
React 17 changed some event propagation behavior: https://reactjs.org/blog/2020/08/10/react-v17-rc.html#fixing-potential-issues

This PR fixes the usage of `OffClickWrapper` in `ImmersiveModal`: right now, the behavior is that when the modal is initiated, the offClickWrapper click close event immediately fires, so we see no content. 

It also updates some `ref` handling in `useEffect` as outlined here: https://reactjs.org/blog/2020/08/10/react-v17-rc.html#potential-issues