### PR TITLE
Add onFocus prop to Dropdown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,26 @@ jobs:
       - store_test_results:
           path: test-results
 
+  test-tsc-stories:
+    <<: *defaults
+    docker:
+      - image: circleci/node:16-stretch
+
+    environment:
+      NODE_OPTIONS: --max_old_space_size=4096
+
+    steps:
+      - checkout
+      - <<: *prospective-merge
+      - attach_workspace:
+          at: *root
+      - <<: *prepare-environment
+      - run:
+          name: Run TypeScript type-checking on Storybook Stories
+          command: yarn run tsc -p stories/tsconfig.json
+      - store_test_results:
+          path: test-results
+
 workflows:
   version: 2
 

--- a/src/shared-components/dropdown/desktopDropdown.tsx
+++ b/src/shared-components/dropdown/desktopDropdown.tsx
@@ -19,6 +19,7 @@ interface DesktopDropdownProps<T> {
   onDesktopSelectChange: (
     event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>,
   ) => void;
+  onFocus: (event: React.FocusEvent<HTMLDivElement>) => void;
   options: T[];
   optionsContainerMaxHeight: string;
   textAlign: 'left' | 'center';
@@ -33,6 +34,7 @@ export const DesktopDropdown = <T extends OptionType>({
   id,
   isOpen,
   onDesktopSelectChange,
+  onFocus,
   options,
   optionsContainerMaxHeight,
   textAlign,
@@ -72,6 +74,7 @@ export const DesktopDropdown = <T extends OptionType>({
           aria-haspopup="menu"
           role="button"
           ref={initialFocus}
+          onFocus={onFocus}
         >
           <div
             css={Style.dropdownInputStyle({

--- a/src/shared-components/dropdown/desktopDropdown.tsx
+++ b/src/shared-components/dropdown/desktopDropdown.tsx
@@ -19,7 +19,7 @@ interface DesktopDropdownProps<T> {
   onDesktopSelectChange: (
     event: React.MouseEvent<HTMLLIElement> | React.KeyboardEvent<HTMLLIElement>,
   ) => void;
-  onFocus: (event: React.FocusEvent<HTMLDivElement>) => void;
+  onDropdownContainerFocus: (event: React.FocusEvent<HTMLDivElement>) => void;
   options: T[];
   optionsContainerMaxHeight: string;
   textAlign: 'left' | 'center';
@@ -34,7 +34,7 @@ export const DesktopDropdown = <T extends OptionType>({
   id,
   isOpen,
   onDesktopSelectChange,
-  onFocus,
+  onDropdownContainerFocus,
   options,
   optionsContainerMaxHeight,
   textAlign,
@@ -74,7 +74,7 @@ export const DesktopDropdown = <T extends OptionType>({
           aria-haspopup="menu"
           role="button"
           ref={initialFocus}
-          onFocus={onFocus}
+          onFocus={onDropdownContainerFocus}
         >
           <div
             css={Style.dropdownInputStyle({

--- a/src/shared-components/dropdown/index.tsx
+++ b/src/shared-components/dropdown/index.tsx
@@ -34,6 +34,10 @@ interface DropdownProps<T> {
    * The handler to be invoked on option change
    */
   onChange: (option: T) => void;
+  /**
+   * The handler to be invoked on focus
+   */
+  onFocus?: (event?: React.FocusEvent) => void;
   options: T[];
   /**
    * Specifies maximum height of the expanded dropdown
@@ -54,6 +58,7 @@ export const Dropdown = <T extends OptionType>({
   borderRadius,
   id,
   onChange,
+  onFocus,
   options,
   optionsContainerMaxHeight = '250px',
   textAlign = 'left',
@@ -114,12 +119,19 @@ export const Dropdown = <T extends OptionType>({
     closeDropdown();
   };
 
+  const handleOnFocus = (event: React.FocusEvent) => {
+    if (onFocus) {
+      onFocus(event);
+    }
+  };
+
   if (touchSupported) {
     return (
       <MobileDropdown
         borderRadius={borderRadiusValue}
         id={id}
         onMobileSelectChange={onMobileSelectChange}
+        onFocus={handleOnFocus}
         options={options}
         textAlign={textAlign}
         value={value}
@@ -137,6 +149,7 @@ export const Dropdown = <T extends OptionType>({
       id={id}
       isOpen={isOpen}
       onDesktopSelectChange={onDesktopSelectChange}
+      onFocus={handleOnFocus}
       options={options}
       optionsContainerMaxHeight={optionsContainerMaxHeight}
       textAlign={textAlign}

--- a/src/shared-components/dropdown/index.tsx
+++ b/src/shared-components/dropdown/index.tsx
@@ -37,7 +37,7 @@ interface DropdownProps<T> {
   /**
    * The handler to be invoked on focus
    */
-  onFocus?: (event?: React.FocusEvent) => void;
+  onDropdownContainerFocus?: (event?: React.FocusEvent) => void;
   options: T[];
   /**
    * Specifies maximum height of the expanded dropdown
@@ -58,7 +58,7 @@ export const Dropdown = <T extends OptionType>({
   borderRadius,
   id,
   onChange,
-  onFocus,
+  onDropdownContainerFocus,
   options,
   optionsContainerMaxHeight = '250px',
   textAlign = 'left',
@@ -119,9 +119,9 @@ export const Dropdown = <T extends OptionType>({
     closeDropdown();
   };
 
-  const handleOnFocus = (event: React.FocusEvent) => {
-    if (onFocus) {
-      onFocus(event);
+  const handleOnDropdownContainerFocus = (event: React.FocusEvent) => {
+    if (onDropdownContainerFocus) {
+      onDropdownContainerFocus(event);
     }
   };
 
@@ -131,7 +131,7 @@ export const Dropdown = <T extends OptionType>({
         borderRadius={borderRadiusValue}
         id={id}
         onMobileSelectChange={onMobileSelectChange}
-        onFocus={handleOnFocus}
+        onDropdownContainerFocus={handleOnDropdownContainerFocus}
         options={options}
         textAlign={textAlign}
         value={value}
@@ -149,7 +149,7 @@ export const Dropdown = <T extends OptionType>({
       id={id}
       isOpen={isOpen}
       onDesktopSelectChange={onDesktopSelectChange}
-      onFocus={handleOnFocus}
+      onDropdownContainerFocus={handleOnDropdownContainerFocus}
       options={options}
       optionsContainerMaxHeight={optionsContainerMaxHeight}
       textAlign={textAlign}

--- a/src/shared-components/dropdown/mobileDropdown.tsx
+++ b/src/shared-components/dropdown/mobileDropdown.tsx
@@ -9,6 +9,7 @@ import { OptionType, OptionValue } from '.';
 interface MobileDropdownProps<T> {
   borderRadius: string;
   id?: string;
+  onFocus: (event: React.FocusEvent<HTMLSelectElement>) => void;
   onMobileSelectChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
   options: T[];
   textAlign: 'left' | 'center';
@@ -24,6 +25,7 @@ export const MobileDropdown = <T extends OptionType>({
   borderRadius,
   id,
   onMobileSelectChange,
+  onFocus,
   options,
   textAlign,
   value,
@@ -42,6 +44,7 @@ export const MobileDropdown = <T extends OptionType>({
         id={id}
         value={value ?? ''}
         onChange={onMobileSelectChange}
+        onFocus={onFocus}
       >
         {options.map((option, index) => {
           let isDisabled = option.disabled;

--- a/src/shared-components/dropdown/mobileDropdown.tsx
+++ b/src/shared-components/dropdown/mobileDropdown.tsx
@@ -9,7 +9,9 @@ import { OptionType, OptionValue } from '.';
 interface MobileDropdownProps<T> {
   borderRadius: string;
   id?: string;
-  onFocus: (event: React.FocusEvent<HTMLSelectElement>) => void;
+  onDropdownContainerFocus: (
+    event: React.FocusEvent<HTMLSelectElement>,
+  ) => void;
   onMobileSelectChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
   options: T[];
   textAlign: 'left' | 'center';
@@ -25,7 +27,7 @@ export const MobileDropdown = <T extends OptionType>({
   borderRadius,
   id,
   onMobileSelectChange,
-  onFocus,
+  onDropdownContainerFocus,
   options,
   textAlign,
   value,
@@ -44,7 +46,7 @@ export const MobileDropdown = <T extends OptionType>({
         id={id}
         value={value ?? ''}
         onChange={onMobileSelectChange}
-        onFocus={onFocus}
+        onFocus={onDropdownContainerFocus}
       >
         {options.map((option, index) => {
           let isDisabled = option.disabled;

--- a/src/shared-components/dropdown/test.tsx
+++ b/src/shared-components/dropdown/test.tsx
@@ -46,6 +46,7 @@ describe('<MobileDropdown />', () => {
     it('renders correctly', () => {
       const { container } = render(
         <MobileDropdown
+          onFocus={() => undefined}
           onMobileSelectChange={() => undefined}
           borderRadius="4px"
           options={options}
@@ -63,6 +64,7 @@ describe('<MobileDropdown />', () => {
         <MobileDropdown
           borderRadius="4px"
           options={options}
+          onFocus={() => undefined}
           onMobileSelectChange={spy}
           value=""
           textAlign="left"
@@ -72,6 +74,25 @@ describe('<MobileDropdown />', () => {
       const select = getByRole('combobox');
       fireEvent.change(select, { value: 'test1' });
 
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('onFocus callback', () => {
+    it('should be invoked on focus', () => {
+      const spy = jest.fn();
+      const { getByRole } = render(
+        <MobileDropdown
+          borderRadius="4px"
+          options={options}
+          onFocus={spy}
+          onMobileSelectChange={() => undefined}
+          value=""
+          textAlign="left"
+        />,
+      );
+
+      userEvent.click(getByRole('combobox'));
       expect(spy).toHaveBeenCalled();
     });
   });
@@ -86,6 +107,7 @@ describe('<DesktopDropdown />', () => {
         currentOption={{ value: 'test1', label: 'Test1' }}
         isOpen={false}
         onDesktopSelectChange={() => undefined}
+        onFocus={() => undefined}
         options={options}
         optionsContainerMaxHeight="250px"
         textAlign="left"
@@ -108,6 +130,7 @@ describe('<DesktopDropdown />', () => {
           optionsContainerMaxHeight="250px"
           closeDropdown={() => undefined}
           onDesktopSelectChange={() => undefined}
+          onFocus={() => undefined}
           textAlign="left"
           isOpen={false}
         />,
@@ -127,6 +150,7 @@ describe('<DesktopDropdown />', () => {
           options={options}
           currentOption={{ value: 'test1', label: 'Test1' }}
           onDesktopSelectChange={spy}
+          onFocus={() => undefined}
           isOpen
           optionsContainerMaxHeight="250px"
           toggleDropdown={() => null}
@@ -138,6 +162,29 @@ describe('<DesktopDropdown />', () => {
       const listItems = getAllByRole('menuitemradio');
       // Arbitrarily select last item
       userEvent.click(listItems[listItems.length - 1]);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('onFocus callback', () => {
+    it('should be invoked on focus', () => {
+      const spy = jest.fn();
+      render(
+        <DesktopDropdown
+          borderRadius="4px"
+          options={options}
+          currentOption={{ value: 'test1', label: 'Test1' }}
+          onDesktopSelectChange={() => undefined}
+          onFocus={spy}
+          isOpen
+          optionsContainerMaxHeight="250px"
+          toggleDropdown={() => null}
+          closeDropdown={() => null}
+          textAlign="left"
+        />,
+      );
+
+      userEvent.tab();
       expect(spy).toHaveBeenCalled();
     });
   });

--- a/src/shared-components/dropdown/test.tsx
+++ b/src/shared-components/dropdown/test.tsx
@@ -46,7 +46,7 @@ describe('<MobileDropdown />', () => {
     it('renders correctly', () => {
       const { container } = render(
         <MobileDropdown
-          onFocus={() => undefined}
+          onDropdownContainerFocus={() => undefined}
           onMobileSelectChange={() => undefined}
           borderRadius="4px"
           options={options}
@@ -64,7 +64,7 @@ describe('<MobileDropdown />', () => {
         <MobileDropdown
           borderRadius="4px"
           options={options}
-          onFocus={() => undefined}
+          onDropdownContainerFocus={() => undefined}
           onMobileSelectChange={spy}
           value=""
           textAlign="left"
@@ -78,14 +78,14 @@ describe('<MobileDropdown />', () => {
     });
   });
 
-  describe('onFocus callback', () => {
+  describe('onDropdownContainerFocus callback', () => {
     it('should be invoked on focus', () => {
       const spy = jest.fn();
       const { getByRole } = render(
         <MobileDropdown
           borderRadius="4px"
           options={options}
-          onFocus={spy}
+          onDropdownContainerFocus={spy}
           onMobileSelectChange={() => undefined}
           value=""
           textAlign="left"
@@ -107,7 +107,7 @@ describe('<DesktopDropdown />', () => {
         currentOption={{ value: 'test1', label: 'Test1' }}
         isOpen={false}
         onDesktopSelectChange={() => undefined}
-        onFocus={() => undefined}
+        onDropdownContainerFocus={() => undefined}
         options={options}
         optionsContainerMaxHeight="250px"
         textAlign="left"
@@ -130,7 +130,7 @@ describe('<DesktopDropdown />', () => {
           optionsContainerMaxHeight="250px"
           closeDropdown={() => undefined}
           onDesktopSelectChange={() => undefined}
-          onFocus={() => undefined}
+          onDropdownContainerFocus={() => undefined}
           textAlign="left"
           isOpen={false}
         />,
@@ -150,7 +150,7 @@ describe('<DesktopDropdown />', () => {
           options={options}
           currentOption={{ value: 'test1', label: 'Test1' }}
           onDesktopSelectChange={spy}
-          onFocus={() => undefined}
+          onDropdownContainerFocus={() => undefined}
           isOpen
           optionsContainerMaxHeight="250px"
           toggleDropdown={() => null}
@@ -166,7 +166,7 @@ describe('<DesktopDropdown />', () => {
     });
   });
 
-  describe('onFocus callback', () => {
+  describe('onDropdownContainerFocus callback', () => {
     it('should be invoked on focus', () => {
       const spy = jest.fn();
       render(
@@ -175,7 +175,7 @@ describe('<DesktopDropdown />', () => {
           options={options}
           currentOption={{ value: 'test1', label: 'Test1' }}
           onDesktopSelectChange={() => undefined}
-          onFocus={spy}
+          onDropdownContainerFocus={spy}
           isOpen
           optionsContainerMaxHeight="250px"
           toggleDropdown={() => null}

--- a/stories/dropdown/index.stories.tsx
+++ b/stories/dropdown/index.stories.tsx
@@ -77,6 +77,7 @@ export const Mobile = () => {
           options={options}
           onMobileSelectChange={onChange}
           textAlign="left"
+          onFocus={() => undefined}
         />
       </label>
     </DropdownContainer>


### PR DESCRIPTION
This PR exposes the `onFocus` event from the underlying elements of the `Dropdown` component.

**Use case**
We would like to instrument an analytics event when a user focuses on the dropdown to observe interaction behavior. We can derive certain observations like "Users who at least focused the dropdown in this form were 50% less likely to bounce" or "30% of users focused on this dropdown, but only 50% of those who focused ultimately made a selection".