### PR TITLE
Update Theming Conditions to include Tertiary Theme

### DIFF
--- a/src/shared-components/icon/index.tsx
+++ b/src/shared-components/icon/index.tsx
@@ -59,7 +59,7 @@ export const useIcon = (
 ) => {
   const theme = useTheme();
 
-  const ThemeIcon = theme.__type === 'primary' ? PrimaryIcon : SecondaryIcon;
+  const ThemeIcon = (theme.__type === 'primary' || theme.__type === 'tertiary') ? PrimaryIcon : SecondaryIcon;
 
   if (ThemeIcon === null) return null;
 

--- a/src/utils/themeStyles/index.ts
+++ b/src/utils/themeStyles/index.ts
@@ -4,7 +4,7 @@
 import type { ThemeColors, ThemeType } from '../../constants';
 
 export const primaryButtonFontColor = (theme: ThemeType) =>
-  theme.__type === 'primary' ? theme.COLORS.white : theme.COLORS.primary;
+  (theme.__type === 'primary' || theme.__type === 'tertiary') ? theme.COLORS.white : theme.COLORS.primary;
 
 export const primaryButtonBackgroundColor = (
   theme: ThemeType,
@@ -19,7 +19,7 @@ export const primaryButtonBackgroundColor = (
 };
 
 export const primaryButtonLoadingBackgroundColor = (theme: ThemeType) =>
-  theme.__type === 'primary' ? theme.COLORS.white : theme.COLORS.primary;
+  (theme.__type === 'primary' || theme.__type === 'tertiary') ? theme.COLORS.white : theme.COLORS.primary;
 
 /**
  * We use theme.FONTS.baseFont for all primary styles, but use a
@@ -29,7 +29,7 @@ export const setSecondaryHeadingFont = (theme: ThemeType) =>
   theme.__type === 'secondary' ? `font-family: ${theme.FONTS.headerFont};` : '';
 
 export const setButtonStyleFontWeight = (theme: ThemeType) =>
-  theme.__type === 'primary'
+  (theme.__type === 'primary' || theme.__type === 'tertiary')
     ? `font-weight: ${theme.TYPOGRAPHY.fontWeight.bold};`
     : '';
 
@@ -46,4 +46,4 @@ export const setThemeFontWeight = (theme: ThemeType) =>
 export const applyPrimaryThemeVerticalOffset = (
   theme: ThemeType,
   offset = '1',
-) => (theme.__type === 'primary' ? `transform: translateY(${offset}px);` : '');
+) => ((theme.__type === 'primary' || theme.__type === 'tertiary') ? `transform: translateY(${offset}px);` : '');


### PR DESCRIPTION
The Tertiary Theme is built specifically to cater to the Admin+Pharmacy Apps in PocketDerm. While this will be further extended in the future - the current scope of the theme is to establish Admin/Pharmacy-specific typography+fonts & inherit all remaining assets from the Primary Theme (following suit with current usage on Timeline).

This ticket is a minor fix for an oversight in conditional rendering for Icons and certain minor styles. With these condition updates - the Admin/Pharmacy Apps will be injected with the proper inheritance of Primary Theme assets.

Note - v26.4.0 has not yet been deployed to PocketDerm; current changes for this version are not yet visible on production. To be released with the merge of [MPO 921](https://github.com/curology/PocketDerm/pull/17146)