### PR TITLE
Adds an event argument to the AnchorLinkButton types

### DIFF
--- a/src/shared-components/button/components/anchorLinkButton/index.tsx
+++ b/src/shared-components/button/components/anchorLinkButton/index.tsx
@@ -12,7 +12,7 @@ export interface AnchorLinkButtonProps
    * Text to be displayed
    */
   children: string;
-  onClick: () => void;
+  onClick: (event: React.SyntheticEvent<HTMLButtonElement>) => void;
 }
 
 type ButtonRefType =


### PR DESCRIPTION
I'm trying to make some of our buttons-that-look-like-links ADA compliant, and getting type errors for the ones that use the event in their onClick handler.

- Adds an event argument to the onClick handler for AnchorLinkButton.

