### PR TITLE
[a11y] Add aria-checked to OptionButton

### DIFF
--- a/src/shared-components/optionButton/__snapshots__/test.tsx.snap
+++ b/src/shared-components/optionButton/__snapshots__/test.tsx.snap
@@ -107,6 +107,7 @@ exports[`<OptionButton /> UI snapshots checkbox selected, without custom icon 1`
 }
 
 <button
+  aria-checked="true"
   class="emotion-0 emotion-1"
   role="checkbox"
   type="button"

--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -100,6 +100,7 @@ export const OptionButton: OptionButton = ({
     onClick={onClick}
     type="button"
     role={optionType}
+    aria-checked={selected}
     containerType="clickable"
     // eslint-disable-next-line react/jsx-props-no-spreading
     {...rest}


### PR DESCRIPTION
### What & Why
This PR adds `aria-checked` to the `optionButton` component. This allows screen-readers to indicate whether a checkbox or radio-button is checked/selected.

**Before**
<img width="720" alt="Screen Shot 2022-05-31 at 12 26 27 PM" src="https://user-images.githubusercontent.com/83731749/171269781-9cc54979-782f-4704-94ce-cbdf7f685f66.png">
<img width="731" alt="Screen Shot 2022-05-31 at 12 28 56 PM" src="https://user-images.githubusercontent.com/83731749/171269785-10e07710-b742-4be1-9f61-d3ff9e345c07.png">


**After**

<img width="742" alt="Screen Shot 2022-05-31 at 11 57 59 AM" src="https://user-images.githubusercontent.com/83731749/171267916-7d664a0f-855d-455c-8ef1-0aad802fac4e.png">
<img width="736" alt="Screen Shot 2022-05-31 at 11 58 30 AM" src="https://user-images.githubusercontent.com/83731749/171267919-6f37be90-0240-41bd-ab92-0eff9b7724d0.png">

