### PR TITLE
[a11y] Add screen reader indicator for invalid input

### DIFF
--- a/src/shared-components/field/__snapshots__/test.tsx.snap
+++ b/src/shared-components/field/__snapshots__/test.tsx.snap
@@ -264,6 +264,7 @@ exports[`<Field /> UI snapshots renders with errorMessage, hintMessage and hideM
     class="emotion-2 emotion-3"
   >
     <input
+      aria-invalid="true"
       class="emotion-4 emotion-5"
     />
     <div
@@ -279,10 +280,14 @@ exports[`<Field /> UI snapshots renders with errorMessage, hintMessage and hideM
         style="opacity: 1; max-height: 48px; transition-duration: 350ms; transition-property: max-height, opacity; transition-timing-function: ease-in-out;"
         type="error"
       >
-        <strong>
-          Uh Oh!
-        </strong>
-         Type again
+        <output
+          role="alert"
+        >
+          <strong>
+            Uh Oh!
+          </strong>
+           Type again
+        </output>
       </li>
     </ul>
   </div>

--- a/src/shared-components/field/index.tsx
+++ b/src/shared-components/field/index.tsx
@@ -79,6 +79,9 @@ export const Field: Field = ({
       />
     );
 
+  const { id } = inputChild.props as Record<'id', string | undefined>;
+  const isInvalid = showMessages && messagesType === 'error';
+
   return (
     <Style.FieldContainer>
       {!!label && (
@@ -95,11 +98,16 @@ export const Field: Field = ({
 
         {React.cloneElement(inputChild, {
           disabled,
+          'aria-invalid': isInvalid || undefined,
         })}
 
         {!!hintMessage && <Style.HintItem>{hintMessage}</Style.HintItem>}
 
-        <VerificationMessages messages={messages} type={messagesType} />
+        <VerificationMessages
+          messages={messages}
+          type={messagesType}
+          inputId={id}
+        />
       </Style.InputContainer>
     </Style.FieldContainer>
   );

--- a/src/shared-components/verificationMessages/__snapshots__/test.tsx.snap
+++ b/src/shared-components/verificationMessages/__snapshots__/test.tsx.snap
@@ -26,44 +26,60 @@ exports[`<VerificationMessages /> UI snapshot renders with default props and som
     style="opacity: 1; max-height: 48px; transition-duration: 350ms; transition-property: max-height, opacity; transition-timing-function: ease-in-out;"
     type="error"
   >
-    <strong>
-      Uh oh!
-    </strong>
-     This field is required
+    <output
+      role="alert"
+    >
+      <strong>
+        Uh oh!
+      </strong>
+       This field is required
+    </output>
   </li>
   <li
     class="emotion-2 emotion-3"
     style="opacity: 1; max-height: 48px; transition-duration: 350ms; transition-property: max-height, opacity; transition-timing-function: ease-in-out;"
     type="error"
   >
-    <strong>
-      Uh oh!
-    </strong>
-     Must be at least 3 characters
+    <output
+      role="alert"
+    >
+      <strong>
+        Uh oh!
+      </strong>
+       Must be at least 3 characters
+    </output>
   </li>
   <li
     class="emotion-2 emotion-3"
     style="opacity: 1; max-height: 48px; transition-duration: 350ms; transition-property: max-height, opacity; transition-timing-function: ease-in-out;"
     type="error"
   >
-    Must contain 1 number
-    , 
-    Must contain 1 symbol
+    <output
+      role="alert"
+    >
+      Must contain 1 number
+      , 
+      Must contain 1 symbol
+    </output>
   </li>
   <li
     class="emotion-2 emotion-3"
     style="opacity: 1; max-height: 48px; transition-duration: 350ms; transition-property: max-height, opacity; transition-timing-function: ease-in-out;"
     type="error"
   >
-    <strong>
-      1
-    </strong>
-     one
-    , 
-    <strong>
-      2
-    </strong>
-     two
+    <output
+      role="alert"
+    >
+      <strong>
+        1
+      </strong>
+       one
+      , 
+      <strong>
+        2
+      </strong>
+       two
+    </output>
   </li>
 </ul>
 `;
@@ -95,10 +111,14 @@ exports[`<VerificationMessages /> UI snapshot renders with non-default props 1`]
     style="opacity: 1; max-height: 48px; transition-duration: 350ms; transition-property: max-height, opacity; transition-timing-function: ease-in-out;"
     type="success"
   >
-    <strong>
-      Congrats!
-    </strong>
-     Your app was approved
+    <output
+      role="alert"
+    >
+      <strong>
+        Congrats!
+      </strong>
+       Your app was approved
+    </output>
   </li>
 </ul>
 `;

--- a/src/shared-components/verificationMessages/index.tsx
+++ b/src/shared-components/verificationMessages/index.tsx
@@ -14,6 +14,7 @@ export interface VerificationMessagesProps {
    * Centers the messages
    */
   centered?: boolean;
+  inputId?: string;
   /**
    * Object of key and React Node message pair. It also accepts an array of React Node as value
    */
@@ -32,6 +33,7 @@ export interface VerificationMessagesProps {
  */
 export const VerificationMessages: React.FC<VerificationMessagesProps> = ({
   centered = false,
+  inputId,
   messages = {},
   type = 'error',
 }) => {
@@ -54,7 +56,9 @@ export const VerificationMessages: React.FC<VerificationMessagesProps> = ({
           .map((key) => (
             <HelperTransition key={key}>
               <Style.MessageItem type={type}>
-                {formatMessage(messages[key])}
+                <output htmlFor={inputId} role="alert">
+                  {formatMessage(messages[key])}
+                </output>
               </Style.MessageItem>
             </HelperTransition>
           ))


### PR DESCRIPTION
### What & Why
The `Field` component does not currently indicate a failure/invalid state to screen-readers. This PR addresses this issue by adding an `output` element to `VerificationMessages` and adding an [aria-invalid](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-invalid) state to the input field.

---
<img width="1037" alt="Screen Shot 2022-06-16 at 9 54 35 AM" src="https://user-images.githubusercontent.com/83731749/174132063-2c27200c-1a48-4ace-a54a-da5b8f47acfb.png">

https://user-images.githubusercontent.com/83731749/174132070-79126982-ce24-47ca-a0fc-a7e15a979f9f.mov


