### PR TITLE
[og-387] [og-388] update radiance modal components to use react-aria

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "@babel/runtime": "^7.17.9",
     "@emotion/react": "11.9.0",
     "@emotion/styled": "11.8.1",
+    "@react-aria/dialog": "^3.3.0",
     "@react-aria/focus": "^3.0.2",
     "focus-visible": "^5.1.0",
     "lodash.round": "^4.0.4",

--- a/src/shared-components/dialogModal/__snapshots__/test.tsx.snap
+++ b/src/shared-components/dialogModal/__snapshots__/test.tsx.snap
@@ -103,10 +103,61 @@ exports[`<DialogModal /> UI snapshots renders dialog modal with custom color 1`]
 }
 
 .emotion-4 {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 2000;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #F8F8FA;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+@media (min-width: 768px) {
+  .emotion-4 {
+    top: 16px;
+    right: 16px;
+  }
+}
+
+.emotion-4:focus {
+  outline: none;
+  box-shadow: 0px 0px 0px 2px #FFFFFF,0px 0px 0px 4px #332E54;
+}
+
+.emotion-6 {
+  display: block;
+  -webkit-transform: rotate(0deg);
+  -moz-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+  -webkit-transition: color 350ms,-webkit-transform 350ms;
+  transition: color 350ms,transform 350ms;
+}
+
+.emotion-7 {
   margin-bottom: 1.5rem;
 }
 
-.emotion-4:last-of-type {
+.emotion-7:last-of-type {
   margin-bottom: 2rem;
 }
 
@@ -122,10 +173,32 @@ exports[`<DialogModal /> UI snapshots renders dialog modal with custom color 1`]
     />
     <div
       class="entering emotion-2 emotion-3"
+      role="alertdialog"
+      tabindex="-1"
     >
+      <div
+        aria-label="Close modal"
+        class="emotion-4 emotion-5"
+        role="button"
+        tabindex="0"
+      >
+        <svg
+          class="emotion-6"
+          fill="none"
+          height="16"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m16.01.93-.89-.88-7.11 7.1L.91.05.02.93l7.11 7.11-7.11 7.11.89.88 7.1-7.11 7.11 7.11.89-.88L8.9 8.04 16.01.93Z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
       <div>
         <p
-          class="emotion-4 emotion-5"
+          class="emotion-7 emotion-8"
         >
           Dialog Modal Children Content
         </p>

--- a/src/shared-components/dialogModal/__snapshots__/test.tsx.snap
+++ b/src/shared-components/dialogModal/__snapshots__/test.tsx.snap
@@ -103,6 +103,9 @@ exports[`<DialogModal /> UI snapshots renders dialog modal with custom color 1`]
 }
 
 .emotion-4 {
+  background: transparent;
+  border: none;
+  padding: 0;
   position: absolute;
   top: 8px;
   right: 12px;
@@ -176,10 +179,9 @@ exports[`<DialogModal /> UI snapshots renders dialog modal with custom color 1`]
       role="alertdialog"
       tabindex="-1"
     >
-      <div
+      <button
         aria-label="Close modal"
         class="emotion-4 emotion-5"
-        role="button"
         tabindex="0"
       >
         <svg
@@ -195,7 +197,7 @@ exports[`<DialogModal /> UI snapshots renders dialog modal with custom color 1`]
             fill="currentColor"
           />
         </svg>
-      </div>
+      </button>
       <div>
         <p
           class="emotion-7 emotion-8"

--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -3,12 +3,18 @@ import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { Transition } from 'react-transition-group';
 import { FocusScope } from '@react-aria/focus';
+import { useDialog } from '@react-aria/dialog';
 import { useTheme } from '@emotion/react';
 
 import { REACT_PORTAL_SECTION_ID } from '../../constants/portals';
 import { CrossIcon } from '../../icons';
 import Style from './style';
-import { Colors, primaryTheme, secondaryTheme, tertiaryTheme } from '../../constants';
+import {
+  Colors,
+  primaryTheme,
+  secondaryTheme,
+  tertiaryTheme,
+} from '../../constants';
 
 export interface DialogModalProps {
   /**
@@ -53,6 +59,14 @@ export const DialogModal: DialogModal = ({
   title = '',
   ...rest
 }) => {
+  const ref = React.useRef(null);
+  /**
+   * Exposes ARIA dialog role to assistive technology, i.e., announces to users with
+   * screen readers that they are in a dialog component, thereby making apparent
+   * additional accessibility functionality (e.g., exiting dialog with "Esc" key)
+   */
+  const { dialogProps, titleProps } = useDialog({ role: 'alertdialog' }, ref);
+
   const theme = useTheme();
   const backgroundColorWithTheme = backgroundColor ?? theme.COLORS.white;
   const [isClosing, setIsClosing] = useState(false);
@@ -103,6 +117,8 @@ export const DialogModal: DialogModal = ({
               backgroundColor={backgroundColorWithTheme}
               className={transitionState}
               onKeyDown={handleKeyDown}
+              ref={ref}
+              {...dialogProps}
             >
               {onCloseIconClick && (
                 <Style.CrossIconContainer
@@ -115,7 +131,9 @@ export const DialogModal: DialogModal = ({
                   <CrossIcon />
                 </Style.CrossIconContainer>
               )}
-              {!!title && <Style.ModalTitle>{title}</Style.ModalTitle>}
+              {!!title && (
+                <Style.ModalTitle {...titleProps}>{title}</Style.ModalTitle>
+              )}
               {children}
             </Style.ModalContainer>
           </FocusScope>

--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -27,10 +27,10 @@ export interface DialogModalProps {
    */
   children: React.ReactNode;
   /**
-   * If provided, DialogModal displays a Close Icon positioned top-right.
+   * DialogModal displays a Close Icon positioned top-right.
    * This function must contain the logic for closing the modal.
    */
-  onCloseIconClick?: (() => void) | null;
+  onClose: () => void;
   title?: string;
   [key: string]: unknown;
 }
@@ -55,7 +55,7 @@ const getDomNode = () =>
 export const DialogModal: DialogModal = ({
   backgroundColor,
   children,
-  onCloseIconClick,
+  onClose,
   title = '',
   ...rest
 }) => {
@@ -86,9 +86,9 @@ export const DialogModal: DialogModal = ({
   }, []);
 
   const handleCloseIntent = () => {
-    if (onCloseIconClick) {
+    if (onClose) {
       setIsClosing(true);
-      setTimeout(onCloseIconClick, 350);
+      setTimeout(onClose, 350);
     }
   };
 
@@ -120,17 +120,15 @@ export const DialogModal: DialogModal = ({
               ref={ref}
               {...dialogProps}
             >
-              {onCloseIconClick && (
-                <Style.CrossIconContainer
-                  backgroundColor={backgroundColorWithTheme}
-                  onClick={handleCloseIntent}
-                  role="button"
-                  tabIndex={0}
-                  aria-label="Close modal"
-                >
-                  <CrossIcon />
-                </Style.CrossIconContainer>
-              )}
+              <Style.CrossIconContainer
+                backgroundColor={backgroundColorWithTheme}
+                onClick={handleCloseIntent}
+                role="button"
+                tabIndex={0}
+                aria-label="Close modal"
+              >
+                <CrossIcon />
+              </Style.CrossIconContainer>
               {!!title && (
                 <Style.ModalTitle {...titleProps}>{title}</Style.ModalTitle>
               )}
@@ -153,6 +151,6 @@ DialogModal.propTypes = {
     tertiaryTheme.COLORS.background,
   ]),
   children: PropTypes.node.isRequired,
-  onCloseIconClick: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
   title: PropTypes.string,
 };

--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -121,7 +121,6 @@ export const DialogModal: DialogModal = ({
               <Style.CrossIconContainer
                 backgroundColor={backgroundColorWithTheme}
                 onClick={handleCloseIntent}
-                role="button"
                 tabIndex={0}
                 aria-label="Close modal"
               >

--- a/src/shared-components/dialogModal/index.tsx
+++ b/src/shared-components/dialogModal/index.tsx
@@ -86,10 +86,8 @@ export const DialogModal: DialogModal = ({
   }, []);
 
   const handleCloseIntent = () => {
-    if (onClose) {
-      setIsClosing(true);
-      setTimeout(onClose, 350);
-    }
+    setIsClosing(true);
+    setTimeout(onClose, 350);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent): void => {

--- a/src/shared-components/dialogModal/style.ts
+++ b/src/shared-components/dialogModal/style.ts
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import { buttonReset } from '../../utils/styles/buttonReset';
 import { Typography } from '../typography';
 import { Colors, MEDIA_QUERIES, SPACER, Z_SCALE } from '../../constants';
 
@@ -90,9 +91,11 @@ const ModalTitle = styled(Typography.Title)`
   margin-bottom: ${SPACER.small};
 `;
 
-const CrossIconContainer = styled.div<{
+const CrossIconContainer = styled.button<{
   backgroundColor: Colors['background'] | Colors['white'];
 }>`
+  ${buttonReset}
+  padding: 0;
   position: absolute;
   top: 8px;
   right: 12px;

--- a/src/shared-components/dialogModal/test.tsx
+++ b/src/shared-components/dialogModal/test.tsx
@@ -12,7 +12,7 @@ describe('<DialogModal />', () => {
   describe('UI snapshots', () => {
     it('renders dialog modal with custom color', () => {
       const { container, getByText } = render(
-        <DialogModal backgroundColor={primaryTheme.COLORS.background}>
+        <DialogModal backgroundColor={primaryTheme.COLORS.background} onClose={() => undefined}>
           <div>{modalBody}</div>
         </DialogModal>,
         { withPortalContainer: true },
@@ -26,7 +26,7 @@ describe('<DialogModal />', () => {
 
   it('render children content correctly', () => {
     const { getAllByText, getByText } = render(
-      <DialogModal title={modalTitle}>{modalBody}</DialogModal>,
+      <DialogModal title={modalTitle} onClose={() => undefined}>{modalBody}</DialogModal>,
       { withPortalContainer: true },
     );
 

--- a/src/shared-components/immersiveModal/index.tsx
+++ b/src/shared-components/immersiveModal/index.tsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import { Transition } from 'react-transition-group';
 import throttle from 'lodash.throttle';
 import { FocusScope, useFocusManager } from '@react-aria/focus';
+import { useDialog } from '@react-aria/dialog';
 
 import { REACT_PORTAL_SECTION_ID } from '../../constants/portals';
 import { OffClickWrapper } from '../offClickWrapper';
@@ -73,7 +74,14 @@ const ImmersiveModalContent = ({
   handleCloseIntent,
   children,
 }: ImmersiveModalContentProps) => {
+  const ref = React.useRef(null);
   const focusManager = useFocusManager();
+  /**
+   * Exposes ARIA dialog role to assistive technology, i.e., announces to users with
+   * screen readers that they are in a dialog component, thereby making apparent
+   * additional accessibility functionality (e.g., exiting dialog with "Esc" key)
+   */
+  const { dialogProps, titleProps } = useDialog({ role: 'dialog' }, ref);
 
   /**
    * It is not typical modal behavior to be able to scroll. Consequently, our
@@ -101,10 +109,15 @@ const ImmersiveModalContent = ({
     <Style.MainModalContentContainer
       id={MODAL_DESKTOP_SCROLLING_ID}
       hasHeaderImage={hasHeaderImage}
+      ref={ref}
+      {...dialogProps}
     >
       {!showMobileHeaderBar && (
         <React.Fragment>
-          <Style.DesktopHeaderBar showDesktopHeaderBar={showDesktopHeaderBar}>
+          <Style.DesktopHeaderBar
+            {...titleProps}
+            showDesktopHeaderBar={showDesktopHeaderBar}
+          >
             <span>{title}</span>
           </Style.DesktopHeaderBar>
           <Style.CrossIconButton

--- a/stories/dialogModal/index.stories.tsx
+++ b/stories/dialogModal/index.stories.tsx
@@ -31,7 +31,12 @@ export const Default = () => {
       </Button>
 
       {openModal && (
-        <DialogModal title="Heads up!">
+        <DialogModal
+          title="Heads up!"
+          onClose={() => {
+            setOpenModal(false);
+          }}
+        >
           <DialogModal.Paragraph>
             This will remove the cleanser and moisturizer from your free trial,
             too. Just the custom bottle will be sent your way!
@@ -80,7 +85,12 @@ export const DefaultOpened = () => {
       </Button>
 
       {openModal && (
-        <DialogModal title="Heads up!">
+        <DialogModal
+          title="Heads up!"
+          onClose={() => {
+            setOpenModal(false);
+          }}
+        >
           <DialogModal.Paragraph>
             This will remove the cleanser and moisturizer from your free trial,
             too. Just the custom bottle will be sent your way!
@@ -128,6 +138,9 @@ export const WithColor = () => {
         <DialogModal
           title="Heads up!"
           backgroundColor={theme.COLORS.background}
+          onClose={() => {
+            setWithColor(false);
+          }}
         >
           <DialogModal.Paragraph>
             This will remove the cleanser and moisturizer from your free trial,
@@ -181,6 +194,9 @@ export const WithColorOpened = () => {
         <DialogModal
           title="Heads up!"
           backgroundColor={theme.COLORS.background}
+          onClose={() => {
+            setWithColor(false);
+          }}
         >
           <DialogModal.Paragraph>
             This will remove the cleanser and moisturizer from your free trial,
@@ -232,7 +248,7 @@ export const WithCloseIcon = () => {
       {withCloseIcon && (
         <DialogModal
           title="Heads up!"
-          onCloseIconClick={() => {
+          onClose={() => {
             setWithCloseIcon(false);
           }}
         >
@@ -285,7 +301,7 @@ export const WithCloseIconOpened = () => {
       {withCloseIcon && (
         <DialogModal
           title="Heads up!"
-          onCloseIconClick={() => {
+          onClose={() => {
             setWithCloseIcon(false);
           }}
         >

--- a/stories/dialogModal/index.stories.tsx
+++ b/stories/dialogModal/index.stories.tsx
@@ -233,110 +233,6 @@ WithColorOpened.decorators = [modalStoryDecoratorForChromatic];
 DefaultOpened.storyName = 'Default (Opened)';
 DefaultOpened.decorators = [modalStoryDecoratorForChromatic];
 
-export const WithCloseIcon = () => {
-  const [withCloseIcon, setWithCloseIcon] = useState(false);
-
-  return (
-    <React.Fragment>
-      <Button
-        onClick={() => {
-          setWithCloseIcon(true);
-        }}
-      >
-        with close icon
-      </Button>
-      {withCloseIcon && (
-        <DialogModal
-          title="Heads up!"
-          onClose={() => {
-            setWithCloseIcon(false);
-          }}
-        >
-          <DialogModal.Paragraph>
-            This will remove the cleanser and moisturizer from your free trial,
-            too. Just the custom bottle will be sent your way!
-          </DialogModal.Paragraph>
-          <Button.Container>
-            <Button
-              isFullWidth
-              onClick={() => {
-                setWithCloseIcon(false);
-              }}
-            >
-              Yes, remove
-            </Button>
-            <Button
-              isFullWidth
-              onClick={() => {
-                setWithCloseIcon(false);
-              }}
-              buttonType="tertiary"
-            >
-              never mind
-            </Button>
-          </Button.Container>
-        </DialogModal>
-      )}
-    </React.Fragment>
-  );
-};
-
-WithCloseIcon.id = `${DIALOG_MODAL_STORY_ID_PREFIX}with-close-icon`;
-WithCloseIcon.parameters = {
-  chromatic: { disable: true },
-};
-
-export const WithCloseIconOpened = () => {
-  const [withCloseIcon, setWithCloseIcon] = useState(true);
-
-  return (
-    <React.Fragment>
-      <Button
-        onClick={() => {
-          setWithCloseIcon(true);
-        }}
-      >
-        with close icon
-      </Button>
-      {withCloseIcon && (
-        <DialogModal
-          title="Heads up!"
-          onClose={() => {
-            setWithCloseIcon(false);
-          }}
-        >
-          <DialogModal.Paragraph>
-            This will remove the cleanser and moisturizer from your free trial,
-            too. Just the custom bottle will be sent your way!
-          </DialogModal.Paragraph>
-          <Button.Container>
-            <Button
-              isFullWidth
-              onClick={() => {
-                setWithCloseIcon(false);
-              }}
-            >
-              Yes, remove
-            </Button>
-            <Button
-              isFullWidth
-              onClick={() => {
-                setWithCloseIcon(false);
-              }}
-              buttonType="tertiary"
-            >
-              never mind
-            </Button>
-          </Button.Container>
-        </DialogModal>
-      )}
-    </React.Fragment>
-  );
-};
-
-WithCloseIconOpened.storyName = 'With Close Icon (Opened)';
-WithCloseIconOpened.decorators = [modalStoryDecoratorForChromatic];
-
 const CHROMATIC_OPTIONS = {
   chromatic: { delay: parseInt(ANIMATION.defaultTiming, 10) * 25 },
 } as const;
@@ -378,11 +274,6 @@ const DIALOG_MODAL_STORIES: DialogModalStories = {
           <Anchor storyId={WithColor.id} />
           <Canvas>
             <Story id={WithColor.id} />
-          </Canvas>
-          <Anchor storyId={WithCloseIcon.id} />
-          <Heading>With Close Icon</Heading>
-          <Canvas>
-            <Story id={WithCloseIcon.id} />
           </Canvas>
         </React.Fragment>
       ),

--- a/stories/dialogModal/index.stories.tsx
+++ b/stories/dialogModal/index.stories.tsx
@@ -121,14 +121,14 @@ export const DefaultOpened = () => {
 };
 
 export const WithColor = () => {
-  const [withColor, setWithColor] = useState(false);
+  const [withColor, setOpenModalWithColor] = useState(false);
   const theme = useTheme();
 
   return (
     <React.Fragment>
       <Button
         onClick={() => {
-          setWithColor(true);
+          setOpenModalWithColor(true);
         }}
       >
         open dialog modal
@@ -139,7 +139,7 @@ export const WithColor = () => {
           title="Heads up!"
           backgroundColor={theme.COLORS.background}
           onClose={() => {
-            setWithColor(false);
+            setOpenModalWithColor(false);
           }}
         >
           <DialogModal.Paragraph>
@@ -150,7 +150,7 @@ export const WithColor = () => {
             <Button
               isFullWidth
               onClick={() => {
-                setWithColor(false);
+                setOpenModalWithColor(false);
               }}
             >
               Yes, remove
@@ -158,7 +158,7 @@ export const WithColor = () => {
             <Button
               isFullWidth
               onClick={() => {
-                setWithColor(false);
+                setOpenModalWithColor(false);
               }}
               buttonType="tertiary"
             >
@@ -177,14 +177,14 @@ WithColor.parameters = {
 };
 
 export const WithColorOpened = () => {
-  const [withColor, setWithColor] = useState(true);
+  const [withColor, setOpenModalWithColor] = useState(true);
   const theme = useTheme();
 
   return (
     <React.Fragment>
       <Button
         onClick={() => {
-          setWithColor(true);
+          setOpenModalWithColor(true);
         }}
       >
         open dialog modal
@@ -195,7 +195,7 @@ export const WithColorOpened = () => {
           title="Heads up!"
           backgroundColor={theme.COLORS.background}
           onClose={() => {
-            setWithColor(false);
+            setOpenModalWithColor(false);
           }}
         >
           <DialogModal.Paragraph>
@@ -206,7 +206,7 @@ export const WithColorOpened = () => {
             <Button
               isFullWidth
               onClick={() => {
-                setWithColor(false);
+                setOpenModalWithColor(false);
               }}
             >
               Yes, remove
@@ -214,7 +214,7 @@ export const WithColorOpened = () => {
             <Button
               isFullWidth
               onClick={() => {
-                setWithColor(false);
+                setOpenModalWithColor(false);
               }}
               buttonType="tertiary"
             >

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,6 +1776,18 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.1.tgz#7f554e7368c9ab679a11f4a042ca17149d70cf12"
   integrity sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA==
 
+"@react-aria/dialog@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/dialog/-/dialog-3.3.0.tgz#7e355f99343c061d4b4d85c4bba1408bc8b675e0"
+  integrity sha512-kzJLjIYIRpK+ASOpOSY56sE6l+rpmk4QvIqTjrqlynXdneGVgNVu3OxX37U73Zn53is7ivbT+TugCzHTgle0qg==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/focus" "^3.7.0"
+    "@react-aria/utils" "^3.13.2"
+    "@react-stately/overlays" "^3.4.0"
+    "@react-types/dialog" "^3.4.2"
+    "@react-types/shared" "^3.14.0"
+
 "@react-aria/focus@^3.0.2":
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.5.5.tgz#d5e3eb7af8612e8dafda214746084766e55c4b01"
@@ -1786,6 +1798,26 @@
     "@react-aria/utils" "^3.12.0"
     "@react-types/shared" "^3.12.0"
     clsx "^1.1.1"
+
+"@react-aria/focus@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/focus/-/focus-3.7.0.tgz#6a90dc99da64bd145e3eeacf3097a29a0342f709"
+  integrity sha512-LydZSLBLEUklakM0Ogdk17F3f/Uwaj5Nl1mfcK8HhrroGT8A8XH0KjA9D6gM6JGHgxZemx0ufOgxhQZeBGQMQw==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/interactions" "^3.10.0"
+    "@react-aria/utils" "^3.13.2"
+    "@react-types/shared" "^3.14.0"
+    clsx "^1.1.1"
+
+"@react-aria/interactions@^3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.10.0.tgz#d60cc42c3904c1578f9c356fba4bab7003102dee"
+  integrity sha512-Lp74VfF+EskT3IqK2MBMdJpJU48p60+YkMbgtoDF6LudNO8jw0nxcsvnimPriTSkZWINRpajG/9sIa0EIDcQKw==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/utils" "^3.13.2"
+    "@react-types/shared" "^3.14.0"
 
 "@react-aria/interactions@^3.8.4":
   version "3.8.4"
@@ -1803,6 +1835,13 @@
   dependencies:
     "@babel/runtime" "^7.6.2"
 
+"@react-aria/ssr@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.3.0.tgz#25e81daf0c7a270a4a891159d8d984578e4512d8"
+  integrity sha512-yNqUDuOVZIUGP81R87BJVi/ZUZp/nYOBXbPsRe7oltJOfErQZD+UezMpw4vM2KRz18cURffvmC8tJ6JTeyDtaQ==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
 "@react-aria/utils@^3.12.0":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.12.0.tgz#39d0f37525e050356c4de725c85d9b10e7a5c0d9"
@@ -1814,6 +1853,26 @@
     "@react-types/shared" "^3.12.0"
     clsx "^1.1.1"
 
+"@react-aria/utils@^3.13.2":
+  version "3.13.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.13.2.tgz#c28bc96e940a8a84c3e69a19f483c9f060584580"
+  integrity sha512-VTI8tv9m/BxE/lPTNCZN1fcHuY540xm+HT1vg2ZQCryudUWvzQkHi+h0z32DhiGHhvRFIGdH/enf3psip7ZLTQ==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/ssr" "^3.3.0"
+    "@react-stately/utils" "^3.5.1"
+    "@react-types/shared" "^3.14.0"
+    clsx "^1.1.1"
+
+"@react-stately/overlays@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@react-stately/overlays/-/overlays-3.4.0.tgz#4023d0c7cd48363fe046e5b6084d703ac461c907"
+  integrity sha512-jXVm1V91lWOKh73cFvE9W9JtAE8idSWEUtFlVrlBI/jh0ZOt148UlRVWgHrm7FhaUpyvOFNUyfidRmKMuB+hgw==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-stately/utils" "^3.5.1"
+    "@react-types/overlays" "^3.6.2"
+
 "@react-stately/utils@^3.4.1":
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.4.1.tgz#56f049aa1704d338968b5973c796ee606e9c0c62"
@@ -1821,10 +1880,37 @@
   dependencies:
     "@babel/runtime" "^7.6.2"
 
+"@react-stately/utils@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.5.1.tgz#502de762e5d33e892347c5f58053674e06d3bc92"
+  integrity sha512-INeQ5Er2Jm+db8Py4upKBtgfzp3UYgwXYmbU/XJn49Xw27ktuimH9e37qP3bgHaReb5L3g8IrGs38tJUpnGPHA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
+"@react-types/dialog@^3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@react-types/dialog/-/dialog-3.4.2.tgz#509ac6998b6d7bedd2b8150306054389fee7ce61"
+  integrity sha512-ub5KrXuN0VELqIKDKuj+ySalcliIneuVnwnX83XbW+xSs9/zFo5WwALU0YxP77rzwIyuu6ziQ8CUZ7rHhLa0hQ==
+  dependencies:
+    "@react-types/overlays" "^3.6.2"
+    "@react-types/shared" "^3.14.0"
+
+"@react-types/overlays@^3.6.2":
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/@react-types/overlays/-/overlays-3.6.2.tgz#f11f8abe5073ca7a80d3beada018b715af25859c"
+  integrity sha512-ag9UCIlcNCvMHBORRksdLnQK3ef+CEbrt+TydOxBAxAf+87fXJ/0H6hP/4QTebEA2ixA0qz8CFga81S8ZGnOsQ==
+  dependencies:
+    "@react-types/shared" "^3.14.0"
+
 "@react-types/shared@^3.12.0":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.12.0.tgz#31a53fcec5c3159fd0d5c67f7e3f3876c7d19908"
   integrity sha512-faGr9xOjtMlkQPfA1i36iUmWS/hpPPtxIwdAtBi6p7rCejmShMLFZ2YN4DxzbJUCVubF2S1+rMMIKuXG17DkEw==
+
+"@react-types/shared@^3.14.0":
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.14.0.tgz#240991d6672f32ecd2a172111e163be0fe0778f2"
+  integrity sha512-K069Bh/P0qV3zUG8kqabeO8beAUlFdyVPvpcNVPjRl+0Q9NDS9mfdQbmUa0LqdVo5e6jRPdos77Ylflkrz8wcw==
 
 "@rollup/plugin-babel@^5.2.1":
   version "5.3.1"


### PR DESCRIPTION
- Adds @react-aria/dialog package in order to use `useDialog` hook so that screen readers can announce that the user is in a modal
- Adds `useDialog` hook to both `ImmersiveModal` and `DialogModal`
- Renames `onCloseIconClick` to `onClick` in `DialogModal` and makes this property required
- Updates tests
- Updates the `DialogModal` in storybook (since props changed)
  - Removes duplicate documentation now that close icon is default