### PR TITLE
Adds close (X) icon to callout component.

### DIFF
--- a/src/shared-components/callout/__snapshots__/test.tsx.snap
+++ b/src/shared-components/callout/__snapshots__/test.tsx.snap
@@ -41,6 +41,84 @@ exports[`<Callout /> UI snapshots renders a simple callout 1`] = `
 </div>
 `;
 
+exports[`<Callout /> UI snapshots renders callout with close (X) icon 1`] = `
+.emotion-0 {
+  background-color: #EEEDF7;
+  padding: 1rem;
+  border-radius: 8px;
+  display: block;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-2 {
+  cursor: pointer;
+  float: right;
+  height: 16px;
+  margin-left: 1rem;
+  pointer-events: auto;
+  width: 16px;
+}
+
+.emotion-2:focus {
+  outline: none;
+}
+
+.emotion-4 {
+  display: block;
+  -webkit-transform: rotate(0deg);
+  -moz-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+  -webkit-transition: color 350ms,-webkit-transform 350ms;
+  transition: color 350ms,transform 350ms;
+}
+
+.emotion-5 {
+  color: #332E54;
+  font-size: 0.875rem;
+}
+
+<div
+  class="emotion-0 emotion-1"
+>
+  <div
+    aria-label="Close callout"
+    class="emotion-2 emotion-3"
+    role="button"
+    tabindex="0"
+  >
+    <svg
+      class="emotion-4"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m16.01.93-.89-.88-7.11 7.1L.91.05.02.93l7.11 7.11-7.11 7.11.89.88 7.1-7.11 7.11 7.11.89-.88L8.9 8.04 16.01.93Z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+  <div
+    class="emotion-5 emotion-6"
+  >
+    Callout text with text and close (X) icon
+  </div>
+</div>
+`;
+
 exports[`<Callout /> UI snapshots renders callout with icon 1`] = `
 .emotion-0 {
   background-color: #EEEDF7;

--- a/src/shared-components/callout/__snapshots__/test.tsx.snap
+++ b/src/shared-components/callout/__snapshots__/test.tsx.snap
@@ -61,15 +61,29 @@ exports[`<Callout /> UI snapshots renders callout with close (X) icon 1`] = `
 }
 
 .emotion-2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
   cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   float: right;
-  height: 16px;
-  margin-left: 1rem;
+  height: 40px;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  margin: -12px -12px 0 0;
   pointer-events: auto;
-  width: 16px;
+  width: 40px;
 }
 
 .emotion-2:focus {
+  border: #332e54 solid 2px;
   outline: none;
 }
 
@@ -91,11 +105,10 @@ exports[`<Callout /> UI snapshots renders callout with close (X) icon 1`] = `
 <div
   class="emotion-0 emotion-1"
 >
-  <div
+  <a
     aria-label="Close callout"
     class="emotion-2 emotion-3"
-    role="button"
-    tabindex="0"
+    href=""
   >
     <svg
       class="emotion-4"
@@ -110,7 +123,7 @@ exports[`<Callout /> UI snapshots renders callout with close (X) icon 1`] = `
         fill="currentColor"
       />
     </svg>
-  </div>
+  </a>
   <div
     class="emotion-5 emotion-6"
   >

--- a/src/shared-components/callout/__snapshots__/test.tsx.snap
+++ b/src/shared-components/callout/__snapshots__/test.tsx.snap
@@ -65,6 +65,7 @@ exports[`<Callout /> UI snapshots renders callout with close (X) icon 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  border: 0;
   border-radius: 50%;
   cursor: pointer;
   display: -webkit-box;
@@ -105,10 +106,9 @@ exports[`<Callout /> UI snapshots renders callout with close (X) icon 1`] = `
 <div
   class="emotion-0 emotion-1"
 >
-  <a
+  <button
     aria-label="Close callout"
     class="emotion-2 emotion-3"
-    href=""
   >
     <svg
       class="emotion-4"
@@ -123,7 +123,7 @@ exports[`<Callout /> UI snapshots renders callout with close (X) icon 1`] = `
         fill="currentColor"
       />
     </svg>
-  </a>
+  </button>
   <div
     class="emotion-5 emotion-6"
   >

--- a/src/shared-components/callout/index.tsx
+++ b/src/shared-components/callout/index.tsx
@@ -71,7 +71,6 @@ export const Callout: Callout = ({ children, icon, onClose, type }) => {
       {!!onClose && (
         <Style.CrossIconContainer
           aria-label="Close callout"
-          href=""
           onClick={(evt) => {
             onClose();
             evt.preventDefault();

--- a/src/shared-components/callout/index.tsx
+++ b/src/shared-components/callout/index.tsx
@@ -69,13 +69,7 @@ export const Callout: Callout = ({ children, icon, onClose, type }) => {
       displayCloseIcon={!!onClose}
     >
       {!!onClose && (
-        <Style.CrossIconContainer
-          aria-label="Close callout"
-          onClick={(evt) => {
-            onClose();
-            evt.preventDefault();
-          }}
-        >
+        <Style.CrossIconContainer aria-label="Close callout" onClick={onClose}>
           <CrossIcon />
         </Style.CrossIconContainer>
       )}

--- a/src/shared-components/callout/index.tsx
+++ b/src/shared-components/callout/index.tsx
@@ -71,9 +71,11 @@ export const Callout: Callout = ({ children, icon, onClose, type }) => {
       {!!onClose && (
         <Style.CrossIconContainer
           aria-label="Close callout"
-          onClick={onClose}
-          role="button"
-          tabIndex={0}
+          href=""
+          onClick={(evt) => {
+            onClose();
+            evt.preventDefault();
+          }}
         >
           <CrossIcon />
         </Style.CrossIconContainer>

--- a/src/shared-components/callout/index.tsx
+++ b/src/shared-components/callout/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useTheme } from '@emotion/react';
 
+import { CrossIcon } from '../../icons';
 import Style from './style';
 import { isDefined } from '../../utils/isDefined';
 import type { ThemeColors, ThemeType } from '../../constants';
@@ -15,6 +16,10 @@ export interface CalloutProps {
    * Icon displayed inside the callout right aligned
    */
   icon?: React.ReactNode;
+  /**
+   * Callback used to display a close (X) icon for closing the callout as well as executing logic upon clicking the close icon
+   */
+  onClose?: () => void;
   /**
    * Custom prop to draw on preset Callout styles
    */
@@ -52,14 +57,27 @@ const getCalloutStyles = (theme: ThemeType, type?: CalloutProps['type']) => {
  *
  * `Callout` will cover the entirety of the container that holds it. You may optionally wrap it with `Callout.Container` which will set the `max-width` to `327px`.
  *
- * If you use a glyph as callout icon the recommended dimesions are 48x48 pixels (which is the default for Glyphs)
+ * If you use a glyph as callout icon the recommended dimesions are 48x48 pixels (which is the default for Glyphs).
  */
-export const Callout: Callout = ({ children, icon, type }) => {
+export const Callout: Callout = ({ children, icon, onClose, type }) => {
   const theme = useTheme();
   const { backgroundColor, textColor } = getCalloutStyles(theme, type);
 
   return (
-    <Style.CalloutContainer backgroundColor={backgroundColor}>
+    <Style.CalloutContainer
+      backgroundColor={backgroundColor}
+      displayCloseIcon={!!onClose}
+    >
+      {!!onClose && (
+        <Style.CrossIconContainer
+          aria-label="Close callout"
+          onClick={onClose}
+          role="button"
+          tabIndex={0}
+        >
+          <CrossIcon />
+        </Style.CrossIconContainer>
+      )}
       <Style.Text textColor={textColor}>{children}</Style.Text>
       {isDefined(icon) && icon !== false && (
         <Style.Icon iconColor={textColor}>{icon}</Style.Icon>
@@ -73,5 +91,6 @@ Callout.Container = Style.ParentContainer;
 Callout.propTypes = {
   children: PropTypes.node.isRequired,
   icon: PropTypes.node,
+  onClose: PropTypes.func,
   type: PropTypes.oneOf(['error', 'success']),
 };

--- a/src/shared-components/callout/style.ts
+++ b/src/shared-components/callout/style.ts
@@ -6,11 +6,14 @@ const ParentContainer = styled.div`
   max-width: 327px;
 `;
 
-const CalloutContainer = styled.div<{ backgroundColor: ThemeColors }>`
+const CalloutContainer = styled.div<{
+  backgroundColor: ThemeColors;
+  displayCloseIcon: boolean;
+}>`
   background-color: ${({ backgroundColor }) => backgroundColor};
   padding: ${SPACER.medium};
   border-radius: ${({ theme }) => theme.BORDER_RADIUS.medium};
-  display: flex;
+  display: ${({ displayCloseIcon }) => (displayCloseIcon ? 'block' : 'flex')};
   flex-flow: row nowrap;
   justify-content: space-between;
   align-items: center;
@@ -37,8 +40,22 @@ const Icon = styled.div<{
   }
 `;
 
+const CrossIconContainer = styled.div`
+  cursor: pointer;
+  float: right;
+  height: 16px;
+  margin-left: ${SPACER.medium};
+  pointer-events: auto;
+  width: 16px;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
 export default {
   CalloutContainer,
+  CrossIconContainer,
   Icon,
   ParentContainer,
   Text,

--- a/src/shared-components/callout/style.ts
+++ b/src/shared-components/callout/style.ts
@@ -40,15 +40,20 @@ const Icon = styled.div<{
   }
 `;
 
-const CrossIconContainer = styled.div`
+const CrossIconContainer = styled.a`
+  align-items: center;
+  border-radius: 50%;
   cursor: pointer;
+  display: flex;
   float: right;
-  height: 16px;
-  margin-left: ${SPACER.medium};
+  height: 40px;
+  justify-content: center;
+  margin: -12px -12px 0 0;
   pointer-events: auto;
-  width: 16px;
+  width: 40px;
 
   &:focus {
+    border: #332e54 solid 2px;
     outline: none;
   }
 `;

--- a/src/shared-components/callout/style.ts
+++ b/src/shared-components/callout/style.ts
@@ -40,8 +40,9 @@ const Icon = styled.div<{
   }
 `;
 
-const CrossIconContainer = styled.a`
+const CrossIconContainer = styled.button`
   align-items: center;
+  border: 0;
   border-radius: 50%;
   cursor: pointer;
   display: flex;

--- a/src/shared-components/callout/test.tsx
+++ b/src/shared-components/callout/test.tsx
@@ -25,5 +25,18 @@ describe('<Callout />', () => {
 
       expect(container.firstElementChild).toMatchSnapshot();
     });
+    it('renders callout with close (X) icon', () => {
+      const { container } = render(
+        <Callout
+          onClose={() => {
+            return null;
+          }}
+        >
+          Callout text with text and close (X) icon
+        </Callout>,
+      );
+
+      expect(container.firstElementChild).toMatchSnapshot();
+    });
   });
 });

--- a/stories/callout/index.stories.tsx
+++ b/stories/callout/index.stories.tsx
@@ -70,6 +70,31 @@ WithControls.parameters = {
   chromatic: { disable: true },
 };
 
+export const WithCloseIcon = () => (
+  <Callout
+    onClose={() => {
+      alert('onClose callback called.');
+    }}
+  >
+    <span role="img" aria-label="Heart">
+      ❤️
+    </span>{' '}
+    This callout has a close (X) icon that calls the <strong>onClose</strong>{' '}
+    callback when clicked. It also has a lot of text to demonstrate that the
+    text wraps around the close icon. Lorem ipsum dolor sit amet, consectetur
+    adipiscing elit. Vivamus vel sem scelerisque ex euismod laoreet non eu
+    nulla. Cras est lacus, faucibus id finibus id, blandit sit amet nunc. Nullam
+    sagittis odio non ante malesuada eleifend. Cras efficitur nulla non dui
+    euismod maximus. Donec euismod massa in ligula aliquet sollicitudin. In hac
+    habitasse platea dictumst. Quisque sollicitudin, massa vel ullamcorper
+    pharetra, tortor risus mollis nisi, et ultrices justo lectus lobortis lorem.
+    Pellentesque imperdiet turpis sed lobortis convallis. Aliquam sit amet
+    cursus nisl. Curabitur sed metus nec tellus tristique convallis vehicula ut
+    velit. Morbi egestas ultricies magna quis vulputate. Sed sollicitudin neque
+    et tortor finibus, nec vehicula tortor rutrum.
+  </Callout>
+);
+
 const CHROMATIC_OPTIONS = {
   chromatic: { viewports: [BREAKPOINTS.xs] },
 } as const;


### PR DESCRIPTION
This PR adds a close (X) icon to the top-right corner of the callout component. This can be done by adding the new `onClose` function prop to the callout component.

This is my first PR in this repo, so looking for any and all feedback. Thank you.