### PR TITLE
[SEO-124] Update secondaryTint4 color

### DIFF
--- a/src/constants/colors/primary.ts
+++ b/src/constants/colors/primary.ts
@@ -10,7 +10,7 @@ const PRIMARY_COLORS = {
   secondaryTint1: '#B8B4E8',
   secondaryTint2: '#CAC7EE',
   secondaryTint3: '#EFEEF7',
-  secondaryTint4: '#EFEEF7',
+  secondaryTint4: '#F7F6FD',
   tertiary: '#F8F8FA',
   tertiaryTint1: '#F8F8FA',
   tertiaryTint2: '#F8F8FA',


### PR DESCRIPTION
Currently `secondaryTint3` & `secondaryTint4` are defined as the same color. This PR updates `secondaryTint4` to align with our radiance colors as defined in [Figma](https://www.figma.com/file/dE10QHEwFYEqb2cMLrHev0ce/Radiance-Colors?node-id=0%3A1).
<img width="254" alt="Screen Shot 2022-09-20 at 12 43 50 PM" src="https://user-images.githubusercontent.com/83731749/191352667-69f89f65-19fe-488a-b055-2fef1923123b.png">


**Before**
<img width="527" alt="Screen Shot 2022-09-20 at 12 58 51 PM" src="https://user-images.githubusercontent.com/83731749/191353238-5c3ab480-6e44-480c-bda1-8cfc438a0000.png">

**After** 
<img width="531" alt="Screen Shot 2022-09-20 at 12 45 36 PM" src="https://user-images.githubusercontent.com/83731749/191353252-a30bcaf0-f7ef-4320-aa9b-0ed2065b25ed.png">
