### PR TITLE
meron/add border and update border-radius of OptionButton

### DIFF
--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -10,6 +10,7 @@ import PRIMARY_BORDER_RADIUS from '../../constants/borderRadius/primary';
 const DEFAULT_BORDER_RADIUS = 'small';
 
 export interface OptionButtonProps {
+  alt?: string;
   borderRadius?: keyof ThemeType['BORDER_RADIUS'];
   buttonType?: 'primary' | 'secondary';
   /**
@@ -46,6 +47,7 @@ export type OptionButtonContentProps = Pick<
   | 'image'
   | 'borderRadius'
   | 'textContainerHeight'
+  | 'alt'
 >;
 
 export type OptionButtonIconProps = Pick<
@@ -95,6 +97,7 @@ const OptionButtonContent: React.FC<OptionButtonContentProps> = ({
   image = '',
   borderRadius = DEFAULT_BORDER_RADIUS,
   textContainerHeight,
+  alt = '',
 }) => {
   /*
    * Hack for adjusting the border radius for the image. Since the image is smaller than its container,
@@ -116,7 +119,7 @@ const OptionButtonContent: React.FC<OptionButtonContentProps> = ({
             icon={icon}
             withImageBackground
           />
-          <Style.Image src={image} borderRadius={imageBorderRadius} />
+          <Style.Image src={image} borderRadius={imageBorderRadius} alt={alt} />
         </Style.ImageContainer>
       ) : (
         <OptionButtonIcon
@@ -158,6 +161,7 @@ export const OptionButton: OptionButton = ({
   text,
   image = '',
   textContainerHeight,
+  alt = '',
   ...rest
 }) => (
   <Style.ClickableContainer
@@ -181,6 +185,7 @@ export const OptionButton: OptionButton = ({
       image={image}
       borderRadius={borderRadius}
       textContainerHeight={textContainerHeight}
+      alt={alt}
     />
   </Style.ClickableContainer>
 );

--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -5,6 +5,7 @@ import Style from './style';
 import { CheckmarkIcon } from '../../icons';
 import { isDefined } from '../../utils/isDefined';
 import { BORDER_RADIUS_PROP_TYPES, ThemeType } from '../../constants';
+import PRIMARY_BORDER_RADIUS from '../../constants/borderRadius/primary';
 
 const DEFAULT_BORDER_RADIUS = 'small';
 
@@ -94,36 +95,44 @@ const OptionButtonContent: React.FC<OptionButtonContentProps> = ({
   image = '',
   borderRadius = DEFAULT_BORDER_RADIUS,
   textContainerHeight,
-}) => (
-  <Style.FlexContainer containsImage={!!image}>
-    {/**
-     * We sometimes use && conditionals such that we are passing in `false` as a value
-     */}
-    {image ? (
-      <Style.ImageContainer borderRadius={borderRadius}>
+}) => {
+  /*
+   * Hack for adjusting the border radius for the image. Since the image is smaller than its container,
+   * inheriting the border radius from its parent leaves a gap between the elements.
+   */
+  const imageBorderRadius =
+    parseInt(PRIMARY_BORDER_RADIUS[borderRadius], 10) - 1;
+  return (
+    <Style.FlexContainer containsImage={!!image}>
+      {/**
+       * We sometimes use && conditionals such that we are passing in `false` as a value
+       */}
+      {image ? (
+        <Style.ImageContainer borderRadius={borderRadius}>
+          <OptionButtonIcon
+            selected={selected}
+            optionType={optionType}
+            buttonType={buttonType}
+            icon={icon}
+            withImageBackground
+          />
+          <Style.Image src={image} borderRadius={imageBorderRadius} />
+        </Style.ImageContainer>
+      ) : (
         <OptionButtonIcon
           selected={selected}
           optionType={optionType}
           buttonType={buttonType}
           icon={icon}
-          withImageBackground
         />
-        <Style.Image src={image} />
-      </Style.ImageContainer>
-    ) : (
-      <OptionButtonIcon
-        selected={selected}
-        optionType={optionType}
-        buttonType={buttonType}
-        icon={icon}
-      />
-    )}
-    <Style.TextContainer containsImage={!!image} height={textContainerHeight}>
-      <Style.Text bold={!!image}>{text}</Style.Text>
-      {isDefined(subtext) && <Style.SubText>{subtext}</Style.SubText>}
-    </Style.TextContainer>
-  </Style.FlexContainer>
-);
+      )}
+      <Style.TextContainer containsImage={!!image} height={textContainerHeight}>
+        <Style.Text bold={!!image}>{text}</Style.Text>
+        {isDefined(subtext) && <Style.SubText>{subtext}</Style.SubText>}
+      </Style.TextContainer>
+    </Style.FlexContainer>
+  );
+};
 
 interface OptionButton extends React.FC<OptionButtonProps> {
   NotClickable: typeof OptionButtonNotClickable;

--- a/src/shared-components/optionButton/style.ts
+++ b/src/shared-components/optionButton/style.ts
@@ -50,12 +50,6 @@ const sharedContainerStyles = ({
 }: SharedContainerStylesProps) => `
   border-radius: ${theme.BORDER_RADIUS[borderRadius]};
   ${ContainerStyle.containerStyles(theme, containerType)}
-  ${
-    containsImage &&
-    `
-      border: none;
-    `
-  };
   padding: ${containsImage ? 'unset' : SPACER.large};
   margin-bottom: ${SPACER.medium};
   width: ${containsImage ? '151px' : '100%'};
@@ -196,9 +190,12 @@ const ImageContainer = styled.div<{
     theme.BORDER_RADIUS[borderRadius]};
 `;
 
-const Image = styled.img`
+const Image = styled.img<{
+  borderRadius: number;
+}>`
   width: inherit;
-  border-radius: inherit;
+  border-top-left-radius: ${({ borderRadius }) => borderRadius}px;
+  border-top-right-radius: ${({ borderRadius }) => borderRadius}px;
   height: 154px;
   object-fit: cover;
 `;

--- a/stories/optionButton/index.stories.tsx
+++ b/stories/optionButton/index.stories.tsx
@@ -265,6 +265,7 @@ export const WithImage = () => (
           image={personImg}
           borderRadius="small"
           textContainerHeight={150}
+          alt="Profile of person"
         />
         <OptionButton
           text="Helper text"
@@ -273,6 +274,7 @@ export const WithImage = () => (
           image={personImg}
           borderRadius="small"
           textContainerHeight={150}
+          alt="Profile of person"
         />
       </ExampleContainer>
     </OptionsContainer>


### PR DESCRIPTION
Discussed with Adam and we decided it best to add a border back to the `OptionButton` component for consistency reasons and Agency compatibility. Adding the border back in revealed `border-radius` discrepancies between `ImageContainer` and 'Image` so adjustments there are also added as part of this pr (before and after shown below). 
<img width="300" alt="Screen Shot 2022-09-26 at 12 59 17 PM" src="https://user-images.githubusercontent.com/8205569/192336819-a861703e-f9fa-4532-9294-f70dae42e9e8.png">
<img width="294" alt="Screen Shot 2022-09-26 at 12 59 46 PM" src="https://user-images.githubusercontent.com/8205569/192336891-dcfddbc0-b8aa-4e96-babe-fb73bb01caf2.png">
