### PR TITLE
meron/update OptionButton component border radius

### DIFF
--- a/src/shared-components/optionButton/index.tsx
+++ b/src/shared-components/optionButton/index.tsx
@@ -5,7 +5,6 @@ import Style from './style';
 import { CheckmarkIcon } from '../../icons';
 import { isDefined } from '../../utils/isDefined';
 import { BORDER_RADIUS_PROP_TYPES, ThemeType } from '../../constants';
-import PRIMARY_BORDER_RADIUS from '../../constants/borderRadius/primary';
 
 const DEFAULT_BORDER_RADIUS = 'small';
 
@@ -99,12 +98,6 @@ const OptionButtonContent: React.FC<OptionButtonContentProps> = ({
   textContainerHeight,
   alt = '',
 }) => {
-  /*
-   * Hack for adjusting the border radius for the image. Since the image is smaller than its container,
-   * inheriting the border radius from its parent leaves a gap between the elements.
-   */
-  const imageBorderRadius =
-    parseInt(PRIMARY_BORDER_RADIUS[borderRadius], 10) - 1;
   return (
     <Style.FlexContainer containsImage={!!image}>
       {/**
@@ -119,7 +112,7 @@ const OptionButtonContent: React.FC<OptionButtonContentProps> = ({
             icon={icon}
             withImageBackground
           />
-          <Style.Image src={image} borderRadius={imageBorderRadius} alt={alt} />
+          <Style.Image src={image} borderRadius={borderRadius} alt={alt} />
         </Style.ImageContainer>
       ) : (
         <OptionButtonIcon

--- a/src/shared-components/optionButton/style.ts
+++ b/src/shared-components/optionButton/style.ts
@@ -191,11 +191,27 @@ const ImageContainer = styled.div<{
 `;
 
 const Image = styled.img<{
-  borderRadius: number;
+  borderRadius: keyof ThemeType['BORDER_RADIUS'];
 }>`
   width: inherit;
-  border-top-left-radius: ${({ borderRadius }) => borderRadius}px;
-  border-top-right-radius: ${({ borderRadius }) => borderRadius}px;
+  ${({ theme, borderRadius }) => {
+    /*
+     * Hack for adjusting the border radius for the image. Since the image is smaller than its container,
+     * inheriting the border radius from its parent leaves a gap between the elements.
+     */
+    const convertedBorderRadius = parseInt(
+      theme.BORDER_RADIUS[borderRadius],
+      10,
+    );
+    const adjustedBorderRadius =
+      convertedBorderRadius > 0
+        ? convertedBorderRadius - 1
+        : convertedBorderRadius;
+    return `
+      border-top-left-radius: ${adjustedBorderRadius}px;
+      border-top-right-radius: ${adjustedBorderRadius}px;
+    `;
+  }}
   height: 154px;
   object-fit: cover;
 `;

--- a/stories/optionButton/index.stories.tsx
+++ b/stories/optionButton/index.stories.tsx
@@ -263,7 +263,6 @@ export const WithImage = () => (
           onClick={noop}
           optionType="radio"
           image={personImg}
-          borderRadius="small"
           textContainerHeight={150}
           alt="Profile of person"
         />
@@ -272,7 +271,6 @@ export const WithImage = () => (
           onClick={noop}
           optionType="radio"
           image={personImg}
-          borderRadius="small"
           textContainerHeight={150}
           alt="Profile of person"
         />


### PR DESCRIPTION
This pr updates the `border-radius` for the `Image` styled component on `OptionButton`.  Previously, the `border-radius` on the `Image` was being applied to Agency because we weren't using `Theme`