### PR TITLE
Add support for additional attribute passing to Dropdown component

### DIFF
--- a/src/shared-components/dropdown/__snapshots__/test.tsx.snap
+++ b/src/shared-components/dropdown/__snapshots__/test.tsx.snap
@@ -102,16 +102,19 @@ exports[`<Dropdown /> UI snapshots renders correctly 1`] = `
     class="emotion-2"
   >
     <option
+      label="Test1"
       value="test1"
     >
       Test1
     </option>
     <option
+      label="Test2"
       value="test2"
     >
       Test2
     </option>
     <option
+      label="Test3"
       value="test3"
     >
       Test3

--- a/src/shared-components/dropdown/index.tsx
+++ b/src/shared-components/dropdown/index.tsx
@@ -24,10 +24,6 @@ export interface OptionType {
 }
 
 interface DropdownProps<T> {
-  /**
-   * An optional prop to allow for the select to have an aria-label attribute added for applications where a standalone label isn't ideal.
-   */
-  ariaLabel?: string | undefined;
   borderRadius?: string;
   /**
    * ID for label associated control
@@ -47,6 +43,10 @@ interface DropdownProps<T> {
    * The currently selected option
    */
   value?: OptionValue;
+  /**
+   * Any other data we want to pass from options
+   */
+  [key: string]: unknown;
 }
 
 /**
@@ -61,7 +61,7 @@ export const Dropdown = <T extends OptionType>({
   options,
   textAlign = 'left',
   value,
-  ariaLabel,
+  ...rest
 }: DropdownProps<T>) => {
   const theme = useTheme();
   const touchSupported = 'ontouchstart' in document.documentElement;
@@ -92,13 +92,12 @@ export const Dropdown = <T extends OptionType>({
         })}
         id={id}
         value={value ?? ''}
-        aria-label={ariaLabel}
         onChange={onSelectChange}
         onFocus={handleOnDropdownContainerFocus}
+        {...rest}
       >
         {options.map((option, index) => {
           let isDisabled = option.disabled;
-
           /*
            * We use touchSupported to prevent setting the default value to disabled
            */
@@ -111,6 +110,7 @@ export const Dropdown = <T extends OptionType>({
               key={option.value ?? `undefined-${index}`}
               value={option.value}
               disabled={isDisabled}
+              {...option} // additional spread attributes
             >
               {option.label}
             </option>
@@ -125,7 +125,6 @@ export const Dropdown = <T extends OptionType>({
 };
 
 Dropdown.propTypes = {
-  ariaLabel: PropTypes.string,
   borderRadius: PropTypes.string,
   id: PropTypes.string,
   onChange: PropTypes.func.isRequired,

--- a/src/shared-components/dropdown/index.tsx
+++ b/src/shared-components/dropdown/index.tsx
@@ -97,7 +97,8 @@ export const Dropdown = <T extends OptionType>({
         {...rest}
       >
         {options.map((option, index) => {
-          let isDisabled = option.disabled;
+          const { value: optionValue, disabled, ...optionsRest } = option;
+          let isDisabled = disabled;
           /*
            * We use touchSupported to prevent setting the default value to disabled
            */
@@ -107,10 +108,10 @@ export const Dropdown = <T extends OptionType>({
 
           return (
             <option
-              key={option.value ?? `undefined-${index}`}
-              value={option.value}
+              key={optionValue ?? `undefined-${index}`}
+              value={optionValue}
               disabled={isDisabled}
-              {...option} // additional spread attributes
+              {...optionsRest} // additional spread attributes
             >
               {option.label}
             </option>

--- a/src/shared-components/dropdown/test.tsx
+++ b/src/shared-components/dropdown/test.tsx
@@ -10,7 +10,12 @@ const options = [
 ];
 const optionsWithDisabledFirstOption = [
   { value: 'test1', label: 'Test1', disabled: true },
-  { value: 'test2', label: 'Test2' },
+  {
+    value: 'test2',
+    label: 'Test2',
+    disabled: false,
+    'data-test-id': 'additionalIDtest',
+  },
   { value: 'test3', label: 'Test3' },
 ];
 
@@ -37,9 +42,10 @@ describe('<Dropdown />', () => {
       const { getByRole } = render(
         <Dropdown
           value="test1"
-          ariaLabel="TEST"
           options={options}
           onChange={() => undefined}
+          aria-label="example of additional ...rest attribute"
+          data-test-id="additionalTestingID"
         />,
       );
       expect(getByRole('combobox')).toHaveAttribute('aria-label');

--- a/stories/dropdown/index.stories.tsx
+++ b/stories/dropdown/index.stories.tsx
@@ -24,7 +24,11 @@ const DesktopContainer = styled(DropdownContainer)`
 const options = [
   { value: -1, label: 'Please select an option', disabled: true },
   { value: 1, label: 'First option' },
-  { value: 2, label: 'Second option' },
+  {
+    value: '2',
+    label: 'Second Option',
+    'data-test-id': 'additionalIDtest',
+  },
   { value: '3', label: 'Third option' },
   { value: '4', label: 'Fourth option' },
   { value: '5', label: 'Fifth option' },
@@ -48,6 +52,8 @@ export const Default = () => {
           value={selectedOption}
           options={options}
           onChange={onChange}
+          aria-label="example of additional ...rest attribute"
+          data-test-id="additionalTestingID"
         />
       </label>
     </DesktopContainer>


### PR DESCRIPTION
Updating the dropdown component to allow for more flexible use in the consuming library. Basically I am removing the explicit option for `aria-label` and replacing it with support for optional `...rest` attributes. Had to update the docs and snapshot to go along with these changes. 