### PR TITLE
Add disableHover prop to Tooltip component

### DIFF
--- a/src/shared-components/tooltip/index.tsx
+++ b/src/shared-components/tooltip/index.tsx
@@ -32,6 +32,10 @@ export interface TooltipProps {
    */
   defaultOpen?: boolean;
   /**
+   * When true, the tooltip will open on click only and not on hover
+   */
+  disableHover?: boolean;
+  /**
    * Programatically control the tooltip to never show (false) or function as normal (true)
    */
   display?: boolean;
@@ -74,6 +78,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   children,
   content = '',
   defaultOpen = false,
+  disableHover = false,
   display = true,
   hasRestrictedWidth = false,
   isSmall = false,
@@ -96,6 +101,20 @@ export const Tooltip: React.FC<TooltipProps> = ({
     setHovered(false);
   };
 
+  const handleMouseEnter = () => {
+    if (disableHover) {
+      return;
+    }
+    setHovered(true);
+  };
+
+  const handleMouseLeave = () => {
+    if (disableHover) {
+      return;
+    }
+    setHovered(false);
+  };
+
   const open = defaultOpen || clicked || hovered;
 
   return (
@@ -103,12 +122,8 @@ export const Tooltip: React.FC<TooltipProps> = ({
       <Style.MainContainer>
         <Style.Trigger
           onClick={onClick}
-          onMouseEnter={() => {
-            setHovered(true);
-          }}
-          onMouseLeave={() => {
-            setHovered(false);
-          }}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
         >
           {children}
         </Style.Trigger>

--- a/src/shared-components/tooltip/index.tsx
+++ b/src/shared-components/tooltip/index.tsx
@@ -109,9 +109,6 @@ export const Tooltip: React.FC<TooltipProps> = ({
   };
 
   const handleMouseLeave = () => {
-    if (disableHover) {
-      return;
-    }
     setHovered(false);
   };
 

--- a/stories/tooltip/index.stories.tsx
+++ b/stories/tooltip/index.stories.tsx
@@ -122,6 +122,7 @@ export const WithControls = () => (
       }
       content={text('Content', 'This is the tooltip text')}
       defaultOpen={boolean('defaultOpen', true)}
+      disableHover={boolean('disableHover', false)}
       display={boolean('display', true)}
       hasRestrictedWidth={boolean('hasRestrictedWidth', false)}
       isSmall={boolean('isSmall', false)}


### PR DESCRIPTION
Currently, the tooltip will open either by clicking or hovering over the trigger when on desktop. On mobile, the tooltip opens only on click. This PR introduces the option to disable the hover behavior, such that the tooltip will only open on click for both mobile & desktop. 