### PR TITLE
AR-22: Add subtitle typography + secondaryRebrand chip/selector styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radiance-ui",
-  "version": "30.3.1",
+  "version": "30.3.2",
   "description": "Curology's React based component library",
   "main": "lib/index.cjs",
   "module": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/PocketDerm/radiance-ui.git"
+    "url": "git+https://github.com/curology/radiance-ui.git"
   },
   "keywords": [
     "curology",
@@ -97,9 +97,9 @@
   "author": "Curology <engineering@curology.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/PocketDerm/radiance-ui/issues"
+    "url": "https://github.com/curology/radiance-ui/issues"
   },
-  "homepage": "https://github.com/PocketDerm/radiance-ui#readme",
+  "homepage": "https://github.com/curology/radiance-ui#readme",
   "devDependencies": {
     "@babel/core": "^7.17.9",
     "@babel/plugin-proposal-class-properties": "^7.16.7",

--- a/src/constants/typography/primary.ts
+++ b/src/constants/typography/primary.ts
@@ -12,6 +12,10 @@ const fontSize = {
    */
   title: '1.25rem',
   /**
+   * 20px
+   */
+  subtitle: '1.25rem',
+  /**
    * 16px
    */
   body: '1rem',

--- a/src/constants/typography/secondary.ts
+++ b/src/constants/typography/secondary.ts
@@ -12,6 +12,10 @@ const fontSize = {
    */
   title: '1.25rem',
   /**
+   * 20px
+   */
+  subtitle: '1.25rem',
+  /**
    * 16px
    */
   body: '1rem',

--- a/src/constants/typography/secondaryRebrand.ts
+++ b/src/constants/typography/secondaryRebrand.ts
@@ -12,6 +12,10 @@ const fontSize = {
    */
   title: '1.5rem',
   /**
+   * 20px
+   */
+  subtitle: '1.25rem',
+  /**
    * 14px
    */
   body: '0.875rem',

--- a/src/constants/typography/tertiary.ts
+++ b/src/constants/typography/tertiary.ts
@@ -12,6 +12,10 @@ const fontSize = {
    */
   title: '1.25rem',
   /**
+   * 20px
+   */
+  subtitle: '1.25rem',
+  /**
    * 16px
    */
   body: '1rem',

--- a/src/icons/test.ts
+++ b/src/icons/test.ts
@@ -11,7 +11,9 @@ import fs from 'fs';
  * transformFileName("someIcon.ts") === "someicon"
  */
 const transformIconFileNames = (fileName: string) =>
-  fileName.toLowerCase().replace(/(-|.tsx$|.ts$|primary|secondary|rebrand)/g, '');
+  fileName
+    .toLowerCase()
+    .replace(/(-|.tsx$|.ts$|primary|secondary|rebrand)/g, '');
 
 const transformSvgFileNames = (fileName: string) =>
   fileName.toLowerCase().replace(/(-|.tsx$|.ts$|.svg$)/g, '');

--- a/src/icons/test.ts
+++ b/src/icons/test.ts
@@ -7,10 +7,11 @@ import fs from 'fs';
  * @example
  * transformFileName("SomeIconPrimary.tsx") === "someicon"
  * transformFileName("SomeIconSecondary.tsx") === "someicon"
+ * transformFileName("SomeIconSecondaryRebrand.tsx") === "someicon"
  * transformFileName("someIcon.ts") === "someicon"
  */
 const transformIconFileNames = (fileName: string) =>
-  fileName.toLowerCase().replace(/(-|.tsx$|.ts$|primary|secondary)/g, '');
+  fileName.toLowerCase().replace(/(-|.tsx$|.ts$|primary|secondary|rebrand)/g, '');
 
 const transformSvgFileNames = (fileName: string) =>
   fileName.toLowerCase().replace(/(-|.tsx$|.ts$|.svg$)/g, '');

--- a/src/shared-components/chip/style.ts
+++ b/src/shared-components/chip/style.ts
@@ -2,7 +2,11 @@ import styled from '@emotion/styled';
 
 import { TYPOGRAPHY_STYLE } from '../typography';
 import { SPACER, ThemeColors } from '../../constants';
-import { applyPrimaryThemeVerticalOffset } from '../../utils/themeStyles';
+import {
+  applyPrimaryThemeVerticalOffset,
+  setChipBackgroundColor,
+  setChipTextColor,
+} from '../../utils/themeStyles';
 
 const ChipText = styled.span`
   ${({ theme }) => TYPOGRAPHY_STYLE.label(theme)}
@@ -24,10 +28,11 @@ const ChipStyles = styled.div<ChipStylesProps>`
   justify-content: center;
   align-items: center;
   padding: 0 ${SPACER.small};
-  background-color: ${({ backgroundColor }) => backgroundColor};
+  background-color: ${({ theme, backgroundColor }) =>
+    setChipBackgroundColor(theme, backgroundColor)};
 
   ${ChipText} {
-    color: ${({ textColor }) => textColor};
+    color: ${({ theme, textColor }) => setChipTextColor(theme, textColor)};
   }
 `;
 

--- a/src/shared-components/selectorButton/style.ts
+++ b/src/shared-components/selectorButton/style.ts
@@ -45,7 +45,11 @@ const SelectorIcon = styled.div<{ disabled: boolean }>`
 
 const primarySelectorStyle = (checked: boolean, theme: ThemeType) => `
   background-color: ${checked ? theme.COLORS.primary : 'transparent'};
-  border-color: ${theme.COLORS.primary};
+  border-color: ${
+    theme.__type === 'secondaryRebrand'
+      ? theme.COLORS.border
+      : theme.COLORS.primary
+  };
 `;
 
 const secondarySelectorStyle = (checked: boolean, theme: ThemeType) => `

--- a/src/shared-components/typography/index.ts
+++ b/src/shared-components/typography/index.ts
@@ -35,6 +35,14 @@ const titleStyle = (theme: ThemeType) => `
   ${setSecondaryHeadingFont(theme)}
 `;
 
+const subtitleStyle = (theme: ThemeType) => `
+  color: ${setHeadingColor(theme)};
+  font-size: ${theme.TYPOGRAPHY.fontSize.subtitle};
+  line-height: ${setThemeLineHeight(theme, round(32 / 20, 2))};
+  font-weight: ${setThemeFontWeight(theme)};
+  ${setSecondaryHeadingFont(theme)}
+`;
+
 export const baseBodyStyles = (theme: ThemeType) => `
   color: ${theme.COLORS.primaryTint1};
   font-size: ${theme.TYPOGRAPHY.fontSize.body};
@@ -109,6 +117,7 @@ export const TYPOGRAPHY_STYLE = {
   display: displayStyle,
   heading: headingStyle,
   title: titleStyle,
+  subtitle: subtitleStyle,
   body: bodyStyle,
   bodyBold: bodyBoldStyle,
   caption: captionStyle,
@@ -144,6 +153,9 @@ const Label = styled.label`
 const Link = styled.a`
   ${({ theme }) => linkStyle(theme)}
 `;
+const Subtitle = styled.h4`
+  ${({ theme }) => subtitleStyle(theme)}
+`;
 const Success = styled.p`
   ${({ theme }) => successStyle(theme)}
 `;
@@ -160,6 +172,7 @@ export const Typography = {
   Heading,
   Label,
   Link,
+  Subtitle,
   Success,
   Title,
 } as const;

--- a/src/utils/themeStyles/index.ts
+++ b/src/utils/themeStyles/index.ts
@@ -68,6 +68,19 @@ export const setButtonBorderRadius = (theme: ThemeType) =>
   THEME_FAMILY[theme.__type] === 'secondaryRebrand'
     ? '360px'
     : theme.BORDER_RADIUS.small;
+
+export const setChipBackgroundColor = (
+  theme: ThemeType,
+  backgroundColor: ThemeColors,
+) =>
+  THEME_FAMILY[theme.__type] === 'secondaryRebrand'
+    ? theme.COLORS.defaultLight
+    : backgroundColor;
+
+export const setChipTextColor = (theme: ThemeType, textColor: ThemeColors) =>
+  THEME_FAMILY[theme.__type] === 'secondaryRebrand'
+    ? theme.COLORS.default
+    : textColor;
 /**
  * We use theme.FONTS.baseFont for all primary styles, but use a
  * different secondary font for Display, Heading, and Title styles

--- a/stories/constants/availableConstants.stories.tsx
+++ b/stories/constants/availableConstants.stories.tsx
@@ -13,6 +13,7 @@ const {
    */
   primaryTheme: _primaryTheme,
   secondaryTheme: _secondaryTheme,
+  secondaryRebrandTheme: _secondaryRebrandTheme,
   tertiaryTheme: _tertiaryTheme,
   REACT_PORTAL_SECTION_ID: _REACT_PORTAL_SECTION_ID,
   BORDER_RADIUS_PROP_TYPES: _BORDER_RADIUS_PROP_TYPES,


### PR DESCRIPTION
## Summary
Adds the radiance-ui pieces for the Agency rebrand "customize box" work: a new `subtitle` typography scale (+ a ready-made `Typography.Subtitle` component) and `secondaryRebrand`-specific styling for `Chip` and the checkbox/radio `SelectorButton`. Also includes a small icons-test fix required by the new logo variant, a repo-metadata cleanup, and a version bump for release. All feature changes are additive and scoped to `secondaryRebrand` (other themes are visually unaffected).

## Changes

### Typography
- **New `subtitle` font-size token** (`1.25rem` / 20px) added to all four theme typographies (`primary`, `secondary`, `tertiary`, `secondaryRebrand`) so it's a valid, type-safe key on `theme.TYPOGRAPHY.fontSize` across the theme union — and keeps the theme key-parity test passing.
- **`Typography.Subtitle`** — a ready-made `<h4>` component, plus `TYPOGRAPHY_STYLE.subtitle` and a `subtitleStyle` (mirrors `Title`: heading color/weight/secondary heading font, at the new `subtitle` size).

### Chip (`shared-components/chip`)
- For `secondaryRebrand` only, the chip renders **background `defaultLight`** and **text `default`**; all other themes keep their caller-supplied `backgroundColor`/`textColor`. Implemented via new centralized helpers `setChipBackgroundColor` / `setChipTextColor` in `utils/themeStyles`.

### SelectorButton (`shared-components/selectorButton`) — backs `Checkbox`/`RadioButton`
- For `secondaryRebrand`, the primary selector's **border-color uses `COLORS.border`** (instead of `COLORS.primary`); other themes unchanged.

### Utils
- New `themeStyles` helpers: `setChipBackgroundColor`, `setChipTextColor` (keeps all `__type` conditionals centralized, per convention).

### Tests
- `src/icons/test.ts`: `transformIconFileNames` now also strips `rebrand`, so the `LogoSecondaryRebrand` SVG variant correctly pairs with the `logo` wrapper (`LogoPrimary`/`LogoSecondary`/`LogoSecondaryRebrand` → `logo`). Fixes the "logos pairings, with complementary naming" test.

### Chore
- **Repo metadata cleanup** (`package.json`): `repository.url`, `bugs.url`, and `homepage` updated from the stale `PocketDerm/radiance-ui` to the current `curology/radiance-ui` (matching the git remote, README badge, and recent changelog).
- **Version bump** → `30.3.2` for release.

## Testing
- `tsc` — 0 errors.
- `jest` — full suite green (36 suites / 159 tests), incl. the theme key-parity and icons pairing tests.

## Notes for reviewers / consumers
- **Purely additive** for existing themes — no `primary`/`secondary`/`tertiary` visual changes; the new `subtitle` token defaults to `1.25rem` on every theme.
- Consumers (e.g. Pocketderm) get `Typography.Subtitle`, the `subtitle` token, and the rebrand Chip/Selector styling after this is **published and their dependency is bumped** to `30.3.2`.
- Follows the existing pattern of keeping theme-conditional (`__type`) logic in `utils/themeStyles`.

## Release
Publishes as `30.3.2` (`yarn run publish-package`). Consuming apps then bump `radiance-ui` to `^30.3.2`.
